### PR TITLE
use matched tokenInterval when available

### DIFF
--- a/src/main/scala/edu/arizona/sista/odin/Mention.scala
+++ b/src/main/scala/edu/arizona/sista/odin/Mention.scala
@@ -188,6 +188,7 @@ class TextBoundMention(
 // this is allowed because it is useful for coreference
 class EventMention(
     val labels: Seq[String],
+    val tokenInterval: Interval,
     val trigger: TextBoundMention,
     val arguments: Map[String, Seq[Mention]],
     val paths: Map[String, Map[Mention, SynPath]],
@@ -198,15 +199,15 @@ class EventMention(
 ) extends Mention {
 
   def this(
-    label: String,
-    trigger: TextBoundMention,
-    arguments: Map[String, Seq[Mention]],
-    paths: Map[String, Map[Mention, SynPath]],
-    sentence: Int,
-    document: Document,
-    keep: Boolean,
-    foundBy: String
-  ) = this(Seq(label), trigger, arguments, paths, sentence, document, keep, foundBy)
+      label: String,
+      trigger: TextBoundMention,
+      arguments: Map[String, Seq[Mention]],
+      paths: Map[String, Map[Mention, SynPath]],
+      sentence: Int,
+      document: Document,
+      keep: Boolean,
+      foundBy: String
+  ) = this(Seq(label), mkTokenInterval(trigger, arguments), trigger, arguments, paths, sentence, document, keep, foundBy)
 
   def this(
       label: String,
@@ -216,7 +217,7 @@ class EventMention(
       document: Document,
       keep: Boolean,
       foundBy: String
-  ) = this(Seq(label), trigger, arguments, Map.empty[String, Map[Mention, SynPath]], sentence, document, keep, foundBy)
+  ) = this(Seq(label), mkTokenInterval(trigger, arguments), trigger, arguments, Map.empty[String, Map[Mention, SynPath]], sentence, document, keep, foundBy)
 
   def this(
       labels: Seq[String],
@@ -226,14 +227,7 @@ class EventMention(
       document: Document,
       keep: Boolean,
       foundBy: String
-  ) = this(labels, trigger, arguments, Map.empty[String, Map[Mention, SynPath]], sentence, document, keep, foundBy)
-
-  // token interval that contains trigger and all matched arguments
-  override def tokenInterval: Interval = {
-    val allStarts = trigger.start +: arguments.values.flatMap(_.map(_.start)).toSeq
-    val allEnds = trigger.end +: arguments.values.flatMap(_.map(_.end)).toSeq
-    Interval(allStarts.min, allEnds.max)
-  }
+  ) = this(labels, mkTokenInterval(trigger, arguments), trigger, arguments, Map.empty[String, Map[Mention, SynPath]], sentence, document, keep, foundBy)
 
   override def isValid: Boolean = {
     // get token interval for trigger
@@ -267,6 +261,7 @@ class EventMention(
   // Copy constructor for EventMention
   def copy(
       labels: Seq[String] = this.labels,
+      tokenInterval: Interval = this.tokenInterval,
       trigger: TextBoundMention = this.trigger,
       arguments: Map[String, Seq[Mention]] = this.arguments,
       paths: Map[String, Map[Mention, SynPath]] = this.paths,
@@ -274,12 +269,13 @@ class EventMention(
       document: Document = this.document,
       keep: Boolean = this.keep,
       foundBy: String = this.foundBy
-  ): EventMention = new EventMention(labels, trigger, arguments, paths, sentence, document, keep, foundBy)
+  ): EventMention = new EventMention(labels, tokenInterval, trigger, arguments, paths, sentence, document, keep, foundBy)
 
   // Convert an EventMention to a RelationMention by deleting the trigger
   def toRelationMention: RelationMention = {
     new RelationMention(
       this.labels,
+      this.tokenInterval,
       this.arguments,
       this.paths,
       this.sentence,
@@ -315,6 +311,7 @@ class EventMention(
 
 class RelationMention(
     val labels: Seq[String],
+    val tokenInterval: Interval,
     val arguments: Map[String, Seq[Mention]],
     val paths: Map[String, Map[Mention, SynPath]],
     val sentence: Int,
@@ -333,7 +330,7 @@ class RelationMention(
       document: Document,
       keep: Boolean,
       foundBy: String
-  ) = this(Seq(label), arguments, paths, sentence, document, keep, foundBy)
+  ) = this(Seq(label), mkTokenInterval(arguments), arguments, paths, sentence, document, keep, foundBy)
 
   def this(
       label: String,
@@ -342,7 +339,7 @@ class RelationMention(
       document: Document,
       keep: Boolean,
       foundBy: String
-  ) = this(Seq(label), arguments, Map.empty[String, Map[Mention, SynPath]], sentence, document, keep, foundBy)
+  ) = this(Seq(label), mkTokenInterval(arguments), arguments, Map.empty[String, Map[Mention, SynPath]], sentence, document, keep, foundBy)
 
   def this(
       labels: Seq[String],
@@ -351,14 +348,7 @@ class RelationMention(
       document: Document,
       keep: Boolean,
       foundBy: String
-  ) = this(labels, arguments, Map.empty[String, Map[Mention, SynPath]], sentence, document, keep, foundBy)
-
-  // token interval that contains all matched arguments
-  override def tokenInterval: Interval = {
-    val allStarts = arguments.values.flatMap(_.map(_.start))
-    val allEnds = arguments.values.flatMap(_.map(_.end))
-    Interval(allStarts.min, allEnds.max)
-  }
+  ) = this(labels, mkTokenInterval(arguments), arguments, Map.empty[String, Map[Mention, SynPath]], sentence, document, keep, foundBy)
 
   def jsonAST: JValue = {
     val args = arguments.map {
@@ -374,13 +364,14 @@ class RelationMention(
   // Copy constructor for RelationMention
   def copy(
       labels: Seq[String] = this.labels,
+      tokenInterval: Interval = this.tokenInterval,
       arguments: Map[String, Seq[Mention]] = this.arguments,
       paths: Map[String, Map[Mention, SynPath]] = this.paths,
       sentence: Int = this.sentence,
       document: Document = this.document,
       keep: Boolean = this.keep,
       foundBy: String = this.foundBy
-  ): RelationMention = new RelationMention(labels, arguments, paths, sentence, document, keep, foundBy)
+  ): RelationMention = new RelationMention(labels, tokenInterval, arguments, paths, sentence, document, keep, foundBy)
 
   // Convert a RelationMention to an EventMention by specifying a trigger
   def toEventMention(trigger: TextBoundMention): EventMention = {
@@ -390,6 +381,7 @@ class RelationMention(
 
     new EventMention(
       this.labels,
+      mkTokenInterval(trigger, this.arguments), // make new tokenInterval
       trigger,
       this.arguments,
       this.paths,

--- a/src/main/scala/edu/arizona/sista/odin/impl/DependencyPattern.scala
+++ b/src/main/scala/edu/arizona/sista/odin/impl/DependencyPattern.scala
@@ -86,7 +86,7 @@ class TriggerPatternDependencyPattern(
     r <- trigger.findAllIn(sent, doc, state)
     trig = new TextBoundMention(labels, Interval(r.start, r.end), sent, doc, keep, ruleName)
     (args, paths) <- extractArguments(trig.tokenInterval, sent, doc, state)
-  } yield new EventMention(labels, trig, args, paths, sent, doc, keep, ruleName)
+  } yield new EventMention(labels, mkTokenInterval(trig, args), trig, args, paths, sent, doc, keep, ruleName)
 }
 
 // creates an EventMention by matching trigger mentions
@@ -107,7 +107,7 @@ class TriggerMentionDependencyPattern(
     if mention.isInstanceOf[TextBoundMention]
     trig = mention.asInstanceOf[TextBoundMention]
     (args, paths) <- extractArguments(trig.tokenInterval, sent, doc, state)
-  } yield new EventMention(labels, trig, args, paths, sent, doc, keep, ruleName)
+  } yield new EventMention(labels, mkTokenInterval(trig, args), trig, args, paths, sent, doc, keep, ruleName)
 }
 
 // creates a RelationMention by matching mentions
@@ -129,5 +129,5 @@ class RelationDependencyPattern(
     (args, paths) <- extractArguments(mention.tokenInterval, sent, doc, state)
     relationArgs = args + (anchorName -> Seq(mention))
     relationPaths = paths + (anchorName -> Map(mention -> Nil))
-  } yield new RelationMention(labels, relationArgs, relationPaths, sent, doc, keep, ruleName)
+  } yield new RelationMention(labels, mkTokenInterval(relationArgs), relationArgs, relationPaths, sent, doc, keep, ruleName)
 }

--- a/src/main/scala/edu/arizona/sista/odin/impl/Extractor.scala
+++ b/src/main/scala/edu/arizona/sista/odin/impl/Extractor.scala
@@ -46,14 +46,14 @@ class TokenExtractor(
           intervals.map(i => new TextBoundMention(labels, i, sent, doc, keep, name))
         }
         val args = mergeArgs(groups, r.mentions)
-        new EventMention(labels, trigger, args, sent, doc, keep, name)
+        new EventMention(labels, r.interval, trigger, args, Map.empty, sent, doc, keep, name)
       case None if r.groups.nonEmpty || r.mentions.nonEmpty =>
         // result has arguments and no trigger, create a RelationMention
         val groups = r.groups transform { (argName, intervals) =>
           intervals.map(i => new TextBoundMention(labels, i, sent, doc, keep, name))
         }
         val args = mergeArgs(groups, r.mentions)
-        new RelationMention(labels, args, sent, doc, keep, name)
+        new RelationMention(labels, r.interval, args, Map.empty, sent, doc, keep, name)
       case None =>
         // result has no arguments, create a TextBoundMention
         new TextBoundMention(labels, r.interval, sent, doc, keep, name)

--- a/src/main/scala/edu/arizona/sista/odin/package.scala
+++ b/src/main/scala/edu/arizona/sista/odin/package.scala
@@ -1,6 +1,9 @@
 package edu.arizona.sista
 
+import edu.arizona.sista.struct.Interval
+
 package object odin {
+
   type Action = (Seq[Mention], State) => Seq[Mention]
   type SentenceToken = (Int, Int)
   type MentionLUT = Map[SentenceToken, Seq[Mention]]
@@ -8,4 +11,20 @@ package object odin {
   type SynPath = Seq[(Int, Int, String)] // governor, dependent, label
 
   def identityAction(mentions: Seq[Mention], state: State): Seq[Mention] = mentions
+
+
+  // token interval that contains trigger and all matched arguments
+  def mkTokenInterval(trigger: TextBoundMention, arguments: Map[String, Seq[Mention]]): Interval = {
+    val allStarts = trigger.start +: arguments.values.flatMap(_.map(_.start)).toSeq
+    val allEnds = trigger.end +: arguments.values.flatMap(_.map(_.end)).toSeq
+    Interval(allStarts.min, allEnds.max)
+  }
+
+  // token interval that contains all matched arguments
+  def mkTokenInterval(arguments: Map[String, Seq[Mention]]): Interval = {
+    val allStarts = arguments.values.flatMap(_.map(_.start))
+    val allEnds = arguments.values.flatMap(_.map(_.end))
+    Interval(allStarts.min, allEnds.max)
+  }
+
 }

--- a/src/test/scala/edu/arizona/sista/odin/TestTokenPattern.scala
+++ b/src/test/scala/edu/arizona/sista/odin/TestTokenPattern.scala
@@ -162,6 +162,37 @@ class TestTokenPattern extends FlatSpec with Matchers {
 
   // a b c d e f g h i c
 
+  it should "keep complete match interval when capturing a RelationMention" in {
+    val rule = """
+      |- name: testrule
+      |  priority: 1
+      |  type: token
+      |  label: TestCapture
+      |  pattern: |
+      |    b c (?<args>d e) f (?<args>g h) i
+      |""".stripMargin
+    val ee = ExtractorEngine(rule)
+    val results = ee.extractFrom(doc)
+    results should have size (1)
+    val r = results.head
+    r shouldBe a [RelationMention]
+    r.arguments should contain key ("args")
+    r.arguments("args") should have size (2)
+    val Seq(a1, a2) = r.arguments("args").sorted
+    a1.tokenInterval should have (
+      'start (3),
+      'end (5)
+    )
+    a2.tokenInterval should have (
+      'start (6),
+      'end (8)
+    )
+    r.tokenInterval should have (
+      'start (1),
+      'end (9)
+    )
+  }
+
   it should "match with variable length lookbehind" in {
     val p = TokenPattern.compile("(?<=a []+) e")
     val results = p.findAllIn(0, doc)


### PR DESCRIPTION
This pull request changes the behavior of `TokenExtractor` so that the matched `tokenInterval`
is used even when the result is an `EventMention` or `RelationMention`.

This is more intuitive behavior than the current, in which only the span of the captured arguments is considered.