### PR TITLE
use DependencyUtils.findHeadsStrict

### DIFF
--- a/src/main/scala/edu/arizona/sista/odin/Mention.scala
+++ b/src/main/scala/edu/arizona/sista/odin/Mention.scala
@@ -99,10 +99,7 @@ trait Mention extends Equals with Ordered[Mention] with Serializable {
       // we don't need dependencies, a single token is its own head
       tokenInterval
     } else {
-      sentenceObj.dependencies match {
-        case Some(deps) => DependencyUtils.findHeads(tokenInterval, deps)
-        case None => Nil
-      }
+      DependencyUtils.findHeadsStrict(tokenInterval, sentenceObj)
     }
   }
 


### PR DESCRIPTION
This pull request fixes a bug in Mention.synHead* methods so that a preposition is not considered a head