### PR TITLE
findHeads() handles graph cycles

### DIFF
--- a/src/main/scala/edu/arizona/sista/utils/DependencyUtils.scala
+++ b/src/main/scala/edu/arizona/sista/utils/DependencyUtils.scala
@@ -85,21 +85,19 @@ object DependencyUtils {
       case (tok, dist) :: rest if seen contains tok =>
         // we already explored this token, skip
         countSteps(rest, seen)
+      case (tok, dist) :: rest if graph.roots contains tok =>
+        // found a root
+        // it is the closest one because we are searching breath-first
+        // return distance
+        dist
       case (tok, dist) :: rest =>
         // explore
         val incoming = followIncoming(tok, graph)
         if (incoming.isEmpty) {
-          if (graph.roots contains tok) {
-            // found a root
-            // it is the closest one because we are searching breath-first
-            // return distance
-            dist
-          } else {
-            // this token has no incomings, but it is not a root
-            // it looks like a collapsed dependency graph
-            // (it couldn't be farther from the root)
-            Double.PositiveInfinity
-          }
+          // this token has no incomings, but it is not a root
+          // it looks like a collapsed dependency graph
+          // (it couldn't be farther from the root)
+          Double.PositiveInfinity
         } else {
           // keep looking, breadth-first
           val nextStep = incoming.map(i => (i, dist + 1)).toList

--- a/src/main/scala/edu/arizona/sista/utils/DependencyUtils.scala
+++ b/src/main/scala/edu/arizona/sista/utils/DependencyUtils.scala
@@ -1,7 +1,7 @@
 package edu.arizona.sista.utils
 
 import edu.arizona.sista.processors.Sentence
-import edu.arizona.sista.struct.{DirectedGraph, Interval}
+import edu.arizona.sista.struct.{ DirectedGraph, Interval }
 
 /**
  * Utility functions for use with directed (dependency) graphs
@@ -10,7 +10,17 @@ import edu.arizona.sista.struct.{DirectedGraph, Interval}
  */
 object DependencyUtils {
 
-  val defaultPolicy: (Seq[Int]) => Int = _.last
+  // a dependency graph is a directed graph with strings as edges
+  type DependencyGraph = DirectedGraph[String]
+
+  // a policy is a function that chooses an int from a sequence
+  type Policy = Seq[Int] => Int
+
+  // get all the governors of the given token according to the dependency graph
+  def followIncoming(tok: Int, graph: DependencyGraph): Array[Int] = graph.incomingEdges.lift(tok).getOrElse(Array.empty).map(_._1)
+
+  // by default we choose the last element of the sequence
+  val defaultPolicy: Policy = _.last
 
   /**
    * Given an Interval, finds the minimal span covering all of the Interval's nodes' children (recursively).
@@ -53,7 +63,7 @@ object DependencyUtils {
    * @param chooseWhich a function deciding which of multiple heads is returned; the rightmost head selected by default
    * @return the single node which is closest to the root among those in span
    */
-  def findHead(span: Interval, graph: DirectedGraph[String], chooseWhich:(Seq[Int]) => Int = defaultPolicy): Int = {
+  def findHead(span: Interval, graph: DependencyGraph, chooseWhich: Policy = defaultPolicy): Int = {
     chooseWhich(findHeads(span, graph))
   }
 
@@ -65,36 +75,51 @@ object DependencyUtils {
    * @param graph a directed graph containing the nodes in span
    * @return the single node which is closest to the root among those in span
    */
-  def findHeads(span: Interval, graph: DirectedGraph[String]): Seq[Int] = {
-
-    def getIncoming(i: Int) = graph.incomingEdges.lift(i).getOrElse(Array.empty).map(_._1)
-
-    def followTrail (i: Int, heads:Seq[Int]): Seq[Int] = {
-
-      // dependents
-      val incoming = getIncoming(i)
-
-      incoming match {
-        case valid if valid.isEmpty | valid.contains(i) => Seq(i)
-        case found if found.min < span.start | found.max > (span.end - 1) => followTrailOut(found.head, heads ++ Seq(i), i)
-        case _ => followTrail(incoming.head, heads ++ Seq(i))
-      }
+  def findHeads(span: Interval, graph: DependencyGraph): Seq[Int] = {
+    @annotation.tailrec
+    def countSteps(toksWithDist: List[(Int, Double)], seen: Set[Int]): Double = toksWithDist match {
+      case Nil =>
+        // we couldn't find a root in the graph
+        // maybe it is not a valid dependency graph?
+        sys.error("can't find a root")
+      case (tok, dist) :: rest if seen contains tok =>
+        // we already explored this token, skip
+        countSteps(rest, seen)
+      case (tok, dist) :: rest =>
+        // explore
+        val incoming = followIncoming(tok, graph)
+        if (incoming.isEmpty) {
+          if (graph.roots contains tok) {
+            // found a root
+            // it is the closest one because we are searching breath-first
+            // return distance
+            dist
+          } else {
+            // this token has no incomings, but it is not a root
+            // it looks like a collapsed dependency graph
+            // (it couldn't be farther from the root)
+            Double.PositiveInfinity
+          }
+        } else {
+          // keep looking, breadth-first
+          val nextStep = incoming.map(i => (i, dist + 1)).toList
+          countSteps(rest ::: nextStep, seen + tok)
+        }
     }
 
-    def followTrailOut (i: Int, heads:Seq[Int], highest: Int): Seq[Int] = {
+    // returns the distance to the closest root for a given token
+    def distToRoot(token: Int): Double = countSteps(List((token, 0)), Set.empty)
 
-      val incoming = getIncoming(i)
-
-      incoming match {
-        case valid if valid.isEmpty | valid.contains(i) => Seq(highest)
-        case outgoing if outgoing.min < span.start | outgoing.max > (span.end - 1) => followTrailOut (incoming.head, heads ++ Seq(i), highest)
-        case _ => followTrail (incoming.head, heads ++ Seq(i))
-      }
+    // get the distance to root for each token in span
+    val toksWithDist = span.map(t => (t, distToRoot(t)))
+    val dists = toksWithDist.map(_._2)
+    if (dists.isEmpty) {
+      Nil
+    } else {
+      // return all tokens with minimum distance
+      val minDist = dists.min
+      for ((t, d) <- toksWithDist if d == minDist) yield t
     }
-
-    val heads = for (i <- span.start until span.end) yield followTrail(i, Nil)
-
-    heads.flatten.distinct.sorted
   }
 
   /**
@@ -105,11 +130,11 @@ object DependencyUtils {
    * @param chooseWhich the function to adjudicate which is highest when there's a tie
    * @return Option containing the highest node index, or None if no such node is found
    */
-  def findHeadStrict(span: Interval, sent: Sentence, chooseWhich:(Seq[Int]) => Int = defaultPolicy): Option[Int] = {
+  def findHeadStrict(span: Interval, sent: Sentence, chooseWhich: Policy = defaultPolicy): Option[Int] = {
     val hds = findHeadsStrict(span, sent)
-    hds match{
-      case valid if valid.nonEmpty => Some(chooseWhich(valid))
-      case _ => None
+    hds match {
+      case Nil => None
+      case heads => Some(chooseWhich(heads))
     }
   }
 
@@ -120,41 +145,12 @@ object DependencyUtils {
    * @param sent the Sentence within which to look
    * @return Option containing a sequence of highest node indices, or None if no such node is found
    */
-  def findHeadsStrict(span: Interval, sent: Sentence): Seq[Int] = {
-
-    if (sent.dependencies.isEmpty) return Nil
-
-    val stopTags = "(.|,|\\(|\\)|:|''|``|#|$|CC|TO|IN)"
-
-    def getIncoming(i: Int) = sent.dependencies.get.incomingEdges.lift(i).getOrElse(Array.empty).map(_._1)
-
-    def followTrail (i: Int, heads:Seq[Int]): Seq[Int] = {
-
-      // dependents
-      val incoming = getIncoming(i)
-
-      incoming match {
-        case valid if valid.isEmpty | valid.contains(i) =>  Seq(i)
-        case found if found.min < span.start | found.max > (span.end - 1) => followTrailOut(found.head, heads ++ Seq(i), i)
-        case _ => followTrail(incoming.head, heads ++ Seq(i))
-      }
-    }
-
-    def followTrailOut (i: Int, heads:Seq[Int], highest: Int): Seq[Int] = {
-
-      val incoming = getIncoming(i)
-
-      incoming match {
-        case valid if valid.isEmpty | valid.contains(i) => Seq(highest)
-        case outgoing if outgoing.min < span.start | outgoing.max > (span.end - 1) => followTrailOut (incoming.head, heads ++ Seq(i), highest)
-        case _ => followTrail (incoming.head, heads ++ Seq(i))
-      }
-    }
-
-    val heads = for (i <- span.start until span.end) yield followTrail(i, Nil)
-
-    val filtered = heads.flatten.distinct.filter(x => !(sent.tags.get(x) matches stopTags)).sorted
-    filtered
+  def findHeadsStrict(span: Interval, sent: Sentence): Seq[Int] = sent.dependencies match {
+    case None => Nil
+    case Some(graph) =>
+      val stopTags = "(.|,|\\(|\\)|:|''|``|#|$|CC|TO|IN)"
+      val heads = findHeads(span, graph)
+      heads.filter(x => !(sent.tags.get(x) matches stopTags))
   }
 
 
@@ -170,7 +166,7 @@ object DependencyUtils {
    * @param chooseWhich a function deciding which of multiple heads is returned; the rightmost head selected by default
    * @return the single node which is closest to the root among those in span
    */
-  def findHeadLocal(span: Interval, graph: DirectedGraph[String], chooseWhich:(Seq[Int]) => Int = defaultPolicy): Int = {
+  def findHeadLocal(span: Interval, graph: DependencyGraph, chooseWhich: Policy = defaultPolicy): Int = {
     chooseWhich(findHeadsLocal(span, graph))
   }
 
@@ -185,7 +181,7 @@ object DependencyUtils {
    * @param graph a directed graph containing the nodes in span
    * @return the single node which is closest to the root among those in span
    */
-  def findHeadsLocal(span: Interval, graph: DirectedGraph[String]): Seq[Int] = {
+  def findHeadsLocal(span: Interval, graph: DependencyGraph): Seq[Int] = {
 
     def followTrail (i: Int, heads:Seq[Int]): Seq[Int] = {
 

--- a/src/test/scala/edu/arizona/sista/utils/TestDependencyUtils.scala
+++ b/src/test/scala/edu/arizona/sista/utils/TestDependencyUtils.scala
@@ -82,4 +82,16 @@ class TestDependencyUtils extends FlatSpec with Matchers {
     noException shouldBe thrownBy (DependencyUtils.findHeads(tokenInterval, depGraph))
   }
 
+  it should "handle roots with incoming dependencies" in {
+    val edges = List(
+      (7, 1, "advmod"), (7, 2, "nsubj"), (7, 3, "cop"), (7, 4, "det"), (7, 5, "amod"),
+      (7, 6, "nn"), (7, 9, "rcmod"), (9, 7, "nsubj"), (9, 10, "dobj"), (10, 13, "prep_for"),
+      (10, 15, "prep_for"), (13, 12, "det"), (13, 15, "conj_and"), (13, 18, "prep_of"),
+      (18, 17, "det")
+    )
+    val graph = new DirectedGraph(edges, Set(7))
+    val interval = Interval(4, 8)
+    noException shouldBe thrownBy (DependencyUtils.findHeads(interval, graph))
+  }
+
 }

--- a/src/test/scala/edu/arizona/sista/utils/TestDependencyUtils.scala
+++ b/src/test/scala/edu/arizona/sista/utils/TestDependencyUtils.scala
@@ -17,10 +17,14 @@ class TestDependencyUtils extends FlatSpec with Matchers {
   val doc1 = proc.annotate(text1, keepText = true)
   val sent1 = doc1.sentences.head
   text1 should "produce 'substrates' as the head of 'the substrates of Shp2'" in {
-    findHeadStrict(Interval(1, 5), sent1).get should be (2)
+    val result = findHeadStrict(Interval(1, 5), sent1)
+    result shouldBe defined
+    result.get should be (2)
   }
   it should "produce 'are' as the head of 'the substrates of Shp2 are'" in {
-    findHeadStrict(Interval(1, 6), sent1).get should be (5)
+    val result = findHeadStrict(Interval(1, 6), sent1)
+    result shouldBe defined
+    result.get should be (5)
   }
   it should "produce None for an empty Interval" in {
     findHeadStrict(Interval(0, 0), sent1) should be (None)
@@ -69,7 +73,7 @@ class TestDependencyUtils extends FlatSpec with Matchers {
     findHeadsStrict(Interval(0, 1), sent3) should have size (0)
   }
 
-  "dependencyUtils" should "handle cycles in the dependencyGraph correctly" in {
+  "DependencyUtils" should "handle cycles in the dependencyGraph correctly" in {
     val edges = List((1, 0, "det"),(1,3,"rcmod"),(3,1,"nsubj"),(3,6,"prep_at"),(6,5,"nn"),
       (8,1,"nsubj"),(8,7,"advmod"),(8,12,"dobj"),(8,20,"prep_in"),(12,9,"det"),(12,10,"nn"),
       (12,11,"nn"),(12,13,"partmod"),(13,16,"prep_for"),(16,15,"nn"),(20,19,"amod"))

--- a/src/test/scala/edu/arizona/sista/utils/TestDependencyUtils.scala
+++ b/src/test/scala/edu/arizona/sista/utils/TestDependencyUtils.scala
@@ -2,7 +2,7 @@ package edu.arizona.sista.utils
 
 import edu.arizona.sista.processors.bionlp.BioNLPProcessor
 import edu.arizona.sista.utils.DependencyUtils._
-import edu.arizona.sista.struct.Interval
+import edu.arizona.sista.struct.{DirectedGraph, Interval}
 import org.scalatest._
 
 /**
@@ -68,4 +68,14 @@ class TestDependencyUtils extends FlatSpec with Matchers {
   text3 should "produce no heads using findHeadsStrict" in {
     findHeadsStrict(Interval(0, 1), sent3) should have size (0)
   }
+
+  "dependencyUtils" should "handle cycles in the dependencyGraph correctly" in {
+    val edges = List((1, 0, "det"),(1,3,"rcmod"),(3,1,"nsubj"),(3,6,"prep_at"),(6,5,"nn"),
+      (8,1,"nsubj"),(8,7,"advmod"),(8,12,"dobj"),(8,20,"prep_in"),(12,9,"det"),(12,10,"nn"),
+      (12,11,"nn"),(12,13,"partmod"),(13,16,"prep_for"),(16,15,"nn"),(20,19,"amod"))
+    val depGraph = new DirectedGraph[String](edges, Set(8))
+    val tokenInterval = Interval(0, 2)
+    noException shouldBe thrownBy (DependencyUtils.findHeads(tokenInterval, depGraph))
+  }
+
 }


### PR DESCRIPTION
This pull request reimplements `DependencyUtils.findHeads()` to handle cycles in the dependency graph.

It also reimplements `DependencyUtils.findHeadsStrict()` to call `findHeads()` instead of reimplementing graph traversal.

Fixes #43 