### PR TITLE
throw exception when dependency parse when root is unreachable

### DIFF
--- a/src/main/scala/edu/arizona/sista/utils/DependencyUtils.scala
+++ b/src/main/scala/edu/arizona/sista/utils/DependencyUtils.scala
@@ -81,7 +81,7 @@ object DependencyUtils {
       case Nil =>
         // we couldn't find a root in the graph
         // maybe it is not a valid dependency graph?
-        sys.error("can't find a root")
+        throw new DependencyUtilsException("can't find a root")
       case (tok, dist) :: rest if seen contains tok =>
         // we already explored this token, skip
         countSteps(rest, seen)
@@ -219,3 +219,7 @@ object DependencyUtils {
     else false
   }
 }
+
+/** Exception thrown by errors in DependencyUtils */
+class DependencyUtilsException(message: String = null, cause: Throwable = null)
+extends RuntimeException(message, cause)

--- a/src/test/scala/edu/arizona/sista/utils/TestDependencyUtils.scala
+++ b/src/test/scala/edu/arizona/sista/utils/TestDependencyUtils.scala
@@ -94,4 +94,20 @@ class TestDependencyUtils extends FlatSpec with Matchers {
     noException shouldBe thrownBy (DependencyUtils.findHeads(interval, graph))
   }
 
+  // this test comes from sentence 23556 in file /data/nlp/corpora/agiga/data/xml/afp_eng_199405.xml.gz
+  // the dependency parse has an erroneous loop in token 11 that makes it impossible to reach the root from the given interval
+  it should "throw a DependencyUtilsException if the dependency parse is malformed" in {
+    val edges = List(
+      (3, 0, "det"), (3, 1, "nn"), (3, 2, "nn"), (5, 3, "nsubj"), (5, 4, "dep"), (5, 10, "ccomp"),
+      (8, 7, "det"), (10, 6, "tmod"), (10, 8, "nsubj"), (10, 9, "dep"), (10, 14, "prep_with"), (10, 27, "neg"),
+      (10, 30, "prep_in"), (10, 32, "prepc_about"),
+      (11, 11, "conj_and"), // note this loop in the graph
+      (11, 22, "prep_about"), (11, 26, "prep_with"), (14, 13, "det"), (14, 16, "prep_of"), (16, 19, "prep_in"),
+      (19, 18, "det"), (22, 21, "amod"), (26, 25, "det"), (30, 29, "det"), (32, 34, "dobj"), (34, 33, "amod")
+    )
+    val graph = new DirectedGraph(edges, Set(5))
+    val interval = Interval(21, 23)
+    a [DependencyUtilsException] shouldBe thrownBy (DependencyUtils.findHeads(interval, graph))
+  }
+
 }


### PR DESCRIPTION
We found a sentence in the agiga corpus that has a messed up dependency parse.
The issue is that there is a loop (a node pointing to itself) that makes the root unreachable.

This pull request introduces a `DependencyUtilsException` that is thrown when that happens.
