### PR TITLE
Add tissue type, reprioritize protein/families

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 # Changes
++ **5.8.4** - Updated to bioresources 1.1.6. Add and load TissueType KB. Synch the KBLoader with NER configuration in Bioresources.
 + **5.8.3** - Updated to bioresources 1.1.4. The BioNLPProcessor POS tagger now correctly tags verbs for biochemical interactions as verbs. 
 + **5.8.2** - Implemented unrestricted lookbehind for Odin's surface patterns. Updated to bioresources 1.1.1. Added support for unbalanced data to LibLinearClassifier. Incremental improvements to the SRL system.
 + **5.8.1** - Improved Odin's variables compatibility with YAML. Switched BioNLPProcessor to using bioresources rather than the local resources. Bug fix: RuleNER was not producing the longest possible match all the time.

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "processors"
 
-version := "5.8.3"
+version := "5.8.4"
 
 organization := "org.clulab"
 

--- a/build.sbt
+++ b/build.sbt
@@ -87,7 +87,7 @@ libraryDependencies ++= Seq(
   "org.scala-lang" % "scala-reflect" % scalaVersion.value,
   "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.3",
   "org.scalatest" %% "scalatest" % "2.2.4" % "test",
-  "org.clulab" % "bioresources" % "1.1.4",
+  "org.clulab" % "bioresources" % "1.1.6",
   "com.io7m.xom" % "xom" % "1.2.10",
   "org.json4s" %% "json4s-native" % "3.2.11",
   "edu.stanford.nlp" % "stanford-corenlp" % "3.5.1",

--- a/models/build.sbt
+++ b/models/build.sbt
@@ -1,6 +1,6 @@
 name := "models"
 
-version := "5.8.3"
+version := "5.8.4"
 
 organization := "org.clulab"
 

--- a/src/main/scala/edu/arizona/sista/processors/bionlp/BioNLPProcessor.scala
+++ b/src/main/scala/edu/arizona/sista/processors/bionlp/BioNLPProcessor.scala
@@ -181,7 +181,7 @@ class BioNLPProcessor (internStrings:Boolean = false,
   }
 
   def beginsContext(label:String):Boolean = {
-    if(label == "B-Species" || label == "B-Organ" || label == "B-CellType" || label == "B-CellLine") true
+    if(label == "B-Species" || label == "B-Organ" || label == "B-CellType" || label == "B-CellLine" || label == "B-TissueType") true
     else false
   }
 

--- a/src/main/scala/edu/arizona/sista/processors/bionlp/ner/KBLoader.scala
+++ b/src/main/scala/edu/arizona/sista/processors/bionlp/ner/KBLoader.scala
@@ -13,23 +13,24 @@ import scala.collection.mutable.ArrayBuffer
 /**
   * Loads the KBs from bioresources under org/clulab/reach/kb/ner
   * These must be generated offline by KBGenerator; see bioresources/ner_kb.sh
-  * User: mihais
-  * Date: 2/7/16
+  * User: mihais. 2/7/16.
+  * Last Modified: Update KB load order to match ner_kb.conf, add tissue type file.
   */
 object KBLoader {
   val logger = LoggerFactory.getLogger(classOf[BioNLPProcessor])
 
   val RULE_NER_KBS = List( // knowledge for the rule-based NER; order is important: it indicates priority!
-    "org/clulab/reach/kb/ner/Gene_or_gene_product.tsv.gz",
     "org/clulab/reach/kb/ner/Family.tsv.gz",
-    "org/clulab/reach/kb/ner/Site.tsv.gz",
+    "org/clulab/reach/kb/ner/Gene_or_gene_product.tsv.gz",
     "org/clulab/reach/kb/ner/Cellular_component.tsv.gz",
     "org/clulab/reach/kb/ner/Simple_chemical.tsv.gz",
-    "org/clulab/reach/kb/ner/Organ.tsv.gz",
-    "org/clulab/reach/kb/ner/CellType.tsv.gz",
-    "org/clulab/reach/kb/ner/CellLine.tsv.gz",
+    "org/clulab/reach/kb/ner/Site.tsv.gz",
+    "org/clulab/reach/kb/ner/BioProcess.tsv.gz",
     "org/clulab/reach/kb/ner/Species.tsv.gz",
-    "org/clulab/reach/kb/ner/BioProcess.tsv.gz"
+    "org/clulab/reach/kb/ner/CellLine.tsv.gz",
+    "org/clulab/reach/kb/ner/TissueType.tsv.gz",
+    "org/clulab/reach/kb/ner/CellType.tsv.gz",
+    "org/clulab/reach/kb/ner/Organ.tsv.gz"
   )
 
   def loadAll:RuleNER = {

--- a/src/main/scala/edu/arizona/sista/processors/bionlp/ner/KBLoader.scala
+++ b/src/main/scala/edu/arizona/sista/processors/bionlp/ner/KBLoader.scala
@@ -14,14 +14,14 @@ import scala.collection.mutable.ArrayBuffer
   * Loads the KBs from bioresources under org/clulab/reach/kb/ner
   * These must be generated offline by KBGenerator; see bioresources/ner_kb.sh
   * User: mihais. 2/7/16.
-  * Last Modified: Update KB load order to match ner_kb.conf, add tissue type file.
+  * Last Modified: Revert KB load order to prioritize proteins over families.
   */
 object KBLoader {
   val logger = LoggerFactory.getLogger(classOf[BioNLPProcessor])
 
   val RULE_NER_KBS = List( // knowledge for the rule-based NER; order is important: it indicates priority!
-    "org/clulab/reach/kb/ner/Family.tsv.gz",
     "org/clulab/reach/kb/ner/Gene_or_gene_product.tsv.gz",
+    "org/clulab/reach/kb/ner/Family.tsv.gz",
     "org/clulab/reach/kb/ner/Cellular_component.tsv.gz",
     "org/clulab/reach/kb/ner/Simple_chemical.tsv.gz",
     "org/clulab/reach/kb/ner/Site.tsv.gz",


### PR DESCRIPTION
Part of Reach issue #170: Activate tissue type KB.
This branch depends on Bioresources version 1.1.6.
This branch increments the Processors version to 5.8.4.