### PR TITLE
json serialization

### DIFF
--- a/src/main/scala/org/clulab/discourse/rstparser/RelationFeatureExtractor.scala
+++ b/src/main/scala/org/clulab/discourse/rstparser/RelationFeatureExtractor.scala
@@ -1,8 +1,7 @@
 package org.clulab.discourse.rstparser
 
-import org.clulab.processors.{CorefMention, Document}
-import org.clulab.struct.Counter
-import org.clulab.struct.Tree
+import org.clulab.processors.Document
+import org.clulab.struct.{CorefMention, Counter, Tree}
 import Utils._
 
 /**

--- a/src/main/scala/org/clulab/odin/Mention.scala
+++ b/src/main/scala/org/clulab/odin/Mention.scala
@@ -6,9 +6,7 @@ import org.clulab.struct.Interval
 import org.clulab.processors.Document
 import org.clulab.utils.DependencyUtils
 import org.clulab.odin.impl.StringMatcher
-import org.json4s._
-import org.json4s.JsonDSL._
-import org.json4s.native._
+
 
 @SerialVersionUID(1L)
 trait Mention extends Equals with Ordered[Mention] with Serializable {
@@ -135,12 +133,6 @@ trait Mention extends Equals with Ordered[Mention] with Serializable {
       bits.mkString
   }
 
-  def jsonAST: JValue
-
-  def json(pretty: Boolean = false): String =
-    if (pretty) prettyJson(renderJValue(jsonAST))
-    else compactJson(renderJValue(jsonAST))
-
   override def canEqual(a: Any) = a.isInstanceOf[Mention]
 
   override def equals(that: Any): Boolean = that match {
@@ -180,12 +172,12 @@ trait Mention extends Equals with Ordered[Mention] with Serializable {
 }
 
 class TextBoundMention(
-    val labels: Seq[String],
-    val tokenInterval: Interval,
-    val sentence: Int,
-    val document: Document,
-    val keep: Boolean,
-    val foundBy: String
+  val labels: Seq[String],
+  val tokenInterval: Interval,
+  val sentence: Int,
+  val document: Document,
+  val keep: Boolean,
+  val foundBy: String
 ) extends Mention {
 
   def this(
@@ -200,15 +192,6 @@ class TextBoundMention(
   // TextBoundMentions don't have arguments
   val arguments: Map[String, Seq[Mention]] = Map.empty
   val paths: Map[String, Map[Mention, SynPath]] = Map.empty
-
-  def jsonAST: JValue = {
-    ("type" -> "TextBound") ~
-    ("tokenInterval" -> List(start, end)) ~
-    ("characterOffsets" -> List(startOffset, endOffset)) ~
-    ("labels" -> labels) ~
-    ("sentence" -> sentence) ~
-    ("foundBy" -> foundBy)
-  }
 
   // Copy constructor for TextBoundMention
   def copy(
@@ -225,15 +208,15 @@ class TextBoundMention(
 // NOTE that event mentions *may* have no arguments
 // this is allowed because it is useful for coreference
 class EventMention(
-    val labels: Seq[String],
-    val tokenInterval: Interval,
-    val trigger: TextBoundMention,
-    val arguments: Map[String, Seq[Mention]],
-    val paths: Map[String, Map[Mention, SynPath]],
-    val sentence: Int,
-    val document: Document,
-    val keep: Boolean,
-    val foundBy: String
+  val labels: Seq[String],
+  val tokenInterval: Interval,
+  val trigger: TextBoundMention,
+  val arguments: Map[String, Seq[Mention]],
+  val paths: Map[String, Map[Mention, SynPath]],
+  val sentence: Int,
+  val document: Document,
+  val keep: Boolean,
+  val foundBy: String
 ) extends Mention {
 
   def this(
@@ -284,18 +267,6 @@ class EventMention(
     finalizeHash(h2, 2)
   }
 
-  def jsonAST: JValue = {
-    val args = arguments.map {
-      case (name, mentions) => (name -> JArray(mentions.map(_.jsonAST).toList))
-    }
-    ("type" -> "Event") ~
-    ("labels" -> labels) ~
-    ("sentence" -> sentence) ~
-    ("foundBy" -> foundBy) ~
-    ("trigger" -> trigger.jsonAST) ~
-    ("arguments" -> JObject(args.toList))
-  }
-
   // Copy constructor for EventMention
   def copy(
       labels: Seq[String] = this.labels,
@@ -321,7 +292,6 @@ class EventMention(
       this.keep,
       s"${this.foundBy} + toRelationMention"
     )
-
   }
 
   // scatters the args named `argName` into N mentions each with `size` args named `argName`
@@ -387,17 +357,6 @@ class RelationMention(
       keep: Boolean,
       foundBy: String
   ) = this(labels, mkTokenInterval(arguments), arguments, Map.empty[String, Map[Mention, SynPath]], sentence, document, keep, foundBy)
-
-  def jsonAST: JValue = {
-    val args = arguments.map {
-      case (name, mentions) => (name -> JArray(mentions.map(_.jsonAST).toList))
-    }
-    ("type" -> "Relation") ~
-    ("labels" -> labels) ~
-    ("sentence" -> sentence) ~
-    ("foundBy" -> foundBy) ~
-    ("arguments" -> JObject(args.toList))
-  }
 
   // Copy constructor for RelationMention
   def copy(

--- a/src/main/scala/org/clulab/processors/BioNLPProcessorFile.scala
+++ b/src/main/scala/org/clulab/processors/BioNLPProcessorFile.scala
@@ -3,6 +3,7 @@ package org.clulab.processors
 import java.io.PrintWriter
 
 import org.clulab.processors.bionlp.BioNLPProcessor
+import org.clulab.serialization.DocumentSerializer
 
 /**
  * Runs BioNLPProcessor on a single text file. The output is serialized in a .ser output file.

--- a/src/main/scala/org/clulab/processors/BioNLPProcessorFilesByLine.scala
+++ b/src/main/scala/org/clulab/processors/BioNLPProcessorFilesByLine.scala
@@ -1,8 +1,9 @@
 package org.clulab.processors
 
-import java.io.{PrintWriter, File}
+import java.io.{File, PrintWriter}
 
 import org.clulab.processors.bionlp.BioNLPProcessor
+import org.clulab.serialization.DocumentSerializer
 import org.clulab.utils.Files
 
 import scala.collection.mutable.ListBuffer

--- a/src/main/scala/org/clulab/processors/Document.scala
+++ b/src/main/scala/org/clulab/processors/Document.scala
@@ -1,9 +1,7 @@
 package org.clulab.processors
 
 import org.clulab.discourse.rstparser.DiscourseTree
-import org.clulab.struct.{Tree, DirectedGraph, DependencyMap, CorefChains}
-import org.clulab.struct.DependencyMap._
-import collection.mutable
+import org.clulab.struct.CorefChains
 
 
 /**
@@ -27,39 +25,6 @@ class Document( var id:Option[String],
 
   /** Clears any internal state potentially constructed by the annotators */
   def clear() { }
-}
-
-/** Stores the annotations for a single sentence */
-class Sentence(
-  /** Actual tokens in this sentence */
-  val words:Array[String],
-  /** Start character offsets for the words; start at 0 */
-  val startOffsets:Array[Int],
-  /** End character offsets for the words; start at 0 */
-  val endOffsets:Array[Int],
-  /** POS tags for words */
-  var tags:Option[Array[String]],
-  /** Lemmas */
-  var lemmas:Option[Array[String]],
-  /** NE labels */
-  var entities:Option[Array[String]],
-  /** Normalized values of named/numeric entities, such as dates */
-  var norms:Option[Array[String]],
-  /** Shallow parsing labels */
-  var chunks:Option[Array[String]],
-  /** Constituent tree of this sentence; includes head words */
-  var syntacticTree:Option[Tree],
-  /** DAG of syntactic and semantic dependencies; word offsets start at 0 */
-  var dependenciesByType:DependencyMap) extends Serializable {
-
-  def this(
-    words:Array[String],
-    startOffsets:Array[Int],
-    endOffsets:Array[Int]) =
-    this(words, startOffsets, endOffsets,
-      None, None, None, None, None, None, new DependencyMap)
-
-  def size:Int = words.length
 
   /**
     * Default dependencies: first Stanford collapsed, then Stanford basic, then None

--- a/src/main/scala/org/clulab/processors/Document.scala
+++ b/src/main/scala/org/clulab/processors/Document.scala
@@ -6,22 +6,14 @@ import org.clulab.struct.CorefChains
 
 /**
   * Stores all annotations for one document
-  * User: mihais
-  * Date: 3/1/13
   */
-class Document( var id:Option[String],
-  val sentences:Array[Sentence],
-  var coreferenceChains:Option[CorefChains],
-  var discourseTree:Option[DiscourseTree],
-  var text:Option[String]) extends Serializable {
+class Document(val sentences: Array[Sentence]) extends Serializable {
 
-  def this(sa:Array[Sentence], cc:Option[CorefChains], dt:Option[DiscourseTree]) {
-    this(None, sa, cc, dt, None)
-  }
-
-  def this(sa: Array[Sentence]) {
-    this(None, sa, None, None, None)
-  }
+  var id: Option[String] = None
+  // FIXME: are coreferenceChains needed? Seems like a CoreNLP-specific thing...
+  var coreferenceChains: Option[CorefChains] = None
+  var discourseTree: Option[DiscourseTree] = None
+  var text: Option[String] = None
 
   /** Clears any internal state potentially constructed by the annotators */
   def clear() { }
@@ -64,30 +56,15 @@ class Document( var id:Option[String],
     dependenciesByType += (depType -> deps)
   }
 
-  /**
-    * Recreates the text of the sentence, preserving the original number of white spaces between tokens
-    * @return the text of the sentence
-    */
-  def getSentenceText():String =  getSentenceFragmentText(0, words.length)
+object Document {
 
-  def getSentenceFragmentText(start:Int, end:Int):String = {
-    // optimize the single token case
-    if(end - start == 1) words(start)
-
-    val text = new mutable.StringBuilder()
-    for(i <- start until end) {
-      if(i > start) {
-        // add as many white spaces as recorded between tokens
-        // sometimes this space is negative: in BioNLPProcessor we replace "/" with "and"
-        //   in these cases, let's make sure we print 1 space, otherwise the text is hard to read
-        val numberOfSpaces = math.max(1, startOffsets(i) - endOffsets(i - 1))
-        for (j <- 0 until numberOfSpaces) {
-          text.append(" ")
-        }
-      }
-      text.append(words(i))
-    }
-    text.toString()
+  def apply(sentences: Array[Sentence]): Document = new Document(sentences)
+  def apply(id: Option[String], sentences: Array[Sentence], coref: Option[CorefChains], dtree: Option[DiscourseTree], text: Option[String]): Document = {
+    val d = Document(sentences)
+    d.id = id
+    d.coreferenceChains = coref
+    d.discourseTree = dtree
+    d.text = text
+    d
   }
-
 }

--- a/src/main/scala/org/clulab/processors/ProcessorShell.scala
+++ b/src/main/scala/org/clulab/processors/ProcessorShell.scala
@@ -7,6 +7,7 @@ import org.clulab.processors.fastnlp.FastNLPProcessor
 import java.io.File
 import jline.console.ConsoleReader
 import jline.console.history.FileHistory
+import org.clulab.processors.examples.ProcessorExample
 
 /**
  * A simple interactive shell

--- a/src/main/scala/org/clulab/processors/Sentence.scala
+++ b/src/main/scala/org/clulab/processors/Sentence.scala
@@ -1,33 +1,10 @@
 package org.clulab.processors
 
-import org.clulab.discourse.rstparser.DiscourseTree
-import org.clulab.struct.{Tree, DirectedGraph, DependencyMap, CorefChains}
-import org.clulab.struct.DependencyMap._
-import collection.mutable
+import org.clulab.struct.{DependencyMap, DirectedGraph, Tree}
+import org.clulab.struct.GraphMap._
 
+import scala.collection.mutable
 
-/**
-  * Stores all annotations for one document
-  * User: mihais
-  * Date: 3/1/13
-  */
-class Document( var id:Option[String],
-  val sentences:Array[Sentence],
-  var coreferenceChains:Option[CorefChains],
-  var discourseTree:Option[DiscourseTree],
-  var text:Option[String]) extends Serializable {
-
-  def this(sa:Array[Sentence], cc:Option[CorefChains], dt:Option[DiscourseTree]) {
-    this(None, sa, cc, dt, None)
-  }
-
-  def this(sa: Array[Sentence]) {
-    this(None, sa, None, None, None)
-  }
-
-  /** Clears any internal state potentially constructed by the annotators */
-  def clear() { }
-}
 
 /** Stores the annotations for a single sentence */
 class Sentence(

--- a/src/main/scala/org/clulab/processors/Sentence.scala
+++ b/src/main/scala/org/clulab/processors/Sentence.scala
@@ -1,8 +1,7 @@
 package org.clulab.processors
 
-import org.clulab.struct.{DependencyMap, DirectedGraph, Tree}
+import org.clulab.struct.{DirectedGraph, GraphMap, Tree}
 import org.clulab.struct.GraphMap._
-
 import scala.collection.mutable
 
 
@@ -42,39 +41,21 @@ class Sentence(
     * Default dependencies: first Stanford collapsed, then Stanford basic, then None
     * @return A directed graph of dependencies if any exist, otherwise None
     */
-  def dependencies:Option[DirectedGraph[String]] = {
-    if(dependenciesByType == null) return None
-
-    if(dependenciesByType.contains(STANFORD_COLLAPSED))
-      dependenciesByType.get(STANFORD_COLLAPSED)
-    else if(dependenciesByType.contains(STANFORD_BASIC))
-      dependenciesByType.get(STANFORD_BASIC)
-    else
-      None
+  def dependencies:Option[DirectedGraph[String]] = dependenciesByType match {
+    case collapsed if collapsed.contains(STANFORD_COLLAPSED) => collapsed.get(STANFORD_COLLAPSED)
+    case basic if basic.contains(STANFORD_BASIC) => basic.get(STANFORD_BASIC)
+    case _ => None
   }
 
   /** Fetches the Stanford basic dependencies */
-  def stanfordBasicDependencies:Option[DirectedGraph[String]] = {
-    if(dependenciesByType == null) return None
-    dependenciesByType.get(STANFORD_BASIC)
-  }
+  def stanfordBasicDependencies:Option[DirectedGraph[String]] = dependenciesByType.get(STANFORD_BASIC)
 
   /** Fetches the Stanford collapsed dependencies */
-  def stanfordCollapsedDependencies:Option[DirectedGraph[String]] = {
-    if(dependenciesByType == null) return None
-    dependenciesByType.get(STANFORD_COLLAPSED)
-  }
+  def stanfordCollapsedDependencies:Option[DirectedGraph[String]] = dependenciesByType.get(STANFORD_COLLAPSED)
 
-  def semanticRoles:Option[DirectedGraph[String]] = {
-    if(dependenciesByType == null) return None
-    dependenciesByType.get(SEMANTIC_ROLES)
-  }
+  def semanticRoles:Option[DirectedGraph[String]] = dependenciesByType.get(SEMANTIC_ROLES)
 
-  def setDependencies(depType:Int, deps:DirectedGraph[String]): Unit = {
-    if(dependenciesByType == null)
-      dependenciesByType = new DependencyMap
-    dependenciesByType += (depType -> deps)
-  }
+  def setDependencies(depType: String, deps: DirectedGraph[String]): Unit = dependenciesByType += (depType -> deps)
 
   /**
     * Recreates the text of the sentence, preserving the original number of white spaces between tokens

--- a/src/main/scala/org/clulab/processors/Sentence.scala
+++ b/src/main/scala/org/clulab/processors/Sentence.scala
@@ -8,37 +8,33 @@ import scala.collection.mutable
 /** Stores the annotations for a single sentence */
 class Sentence(
   /** Actual tokens in this sentence */
-  val words:Array[String],
+  val words: Array[String],
   /** Start character offsets for the words; start at 0 */
-  val startOffsets:Array[Int],
+  val startOffsets: Array[Int],
   /** End character offsets for the words; start at 0 */
-  val endOffsets:Array[Int],
-  /** POS tags for words */
-  var tags:Option[Array[String]],
-  /** Lemmas */
-  var lemmas:Option[Array[String]],
-  /** NE labels */
-  var entities:Option[Array[String]],
-  /** Normalized values of named/numeric entities, such as dates */
-  var norms:Option[Array[String]],
-  /** Shallow parsing labels */
-  var chunks:Option[Array[String]],
-  /** Constituent tree of this sentence; includes head words */
-  var syntacticTree:Option[Tree],
-  /** DAG of syntactic and semantic dependencies; word offsets start at 0 */
-  var dependenciesByType:DependencyMap) extends Serializable {
+  val endOffsets: Array[Int]
+) extends Serializable {
 
-  def this(
-    words:Array[String],
-    startOffsets:Array[Int],
-    endOffsets:Array[Int]) =
-    this(words, startOffsets, endOffsets,
-      None, None, None, None, None, None, new DependencyMap)
+  /** POS tags for words */
+  var tags: Option[Array[String]] = None
+  /** Lemmas */
+  var lemmas: Option[Array[String]] = None
+  /** NE labels */
+  var entities: Option[Array[String]] = None
+  /** Normalized values of named/numeric entities, such as dates */
+  var norms: Option[Array[String]] = None
+  /** Shallow parsing labels */
+  var chunks: Option[Array[String]] = None
+  /** Constituent tree of this sentence; includes head words */
+  var syntacticTree: Option[Tree] = None
+  /** DAG of syntactic and semantic dependencies; word offsets start at 0 */
+  var dependenciesByType: GraphMap = new GraphMap
 
   def size:Int = words.length
 
   /**
     * Default dependencies: first Stanford collapsed, then Stanford basic, then None
+    *
     * @return A directed graph of dependencies if any exist, otherwise None
     */
   def dependencies:Option[DirectedGraph[String]] = dependenciesByType match {
@@ -59,6 +55,7 @@ class Sentence(
 
   /**
     * Recreates the text of the sentence, preserving the original number of white spaces between tokens
+    *
     * @return the text of the sentence
     */
   def getSentenceText():String =  getSentenceFragmentText(0, words.length)
@@ -83,4 +80,36 @@ class Sentence(
     text.toString()
   }
 
+}
+
+object Sentence {
+
+  def apply(
+    words: Array[String],
+    startOffsets: Array[Int],
+    endOffsets: Array[Int]
+  ): Sentence = new Sentence(words, startOffsets, endOffsets)
+  def apply(
+    words: Array[String],
+    startOffsets: Array[Int],
+    endOffsets: Array[Int],
+    tags: Option[Array[String]],
+    lemmas: Option[Array[String]],
+    entities: Option[Array[String]],
+    norms: Option[Array[String]],
+    chunks: Option[Array[String]],
+    tree: Option[Tree],
+    deps: GraphMap
+  ): Sentence = {
+    val s = Sentence(words, startOffsets, endOffsets)
+    // update annotations
+    s.tags = tags
+    s.lemmas = lemmas
+    s.entities = entities
+    s.norms = norms
+    s.chunks = chunks
+    s.syntacticTree = tree
+    s.dependenciesByType = deps
+    s
+  }
 }

--- a/src/main/scala/org/clulab/processors/corenlp/CoreNLPDocument.scala
+++ b/src/main/scala/org/clulab/processors/corenlp/CoreNLPDocument.scala
@@ -11,25 +11,38 @@ import org.clulab.struct.CorefChains
  * User: mihais
  * Date: 3/2/13
  */
-class CoreNLPDocument(
-  id:Option[String],
-  sentences:Array[Sentence],
-  coref:Option[CorefChains],
-  dtree:Option[DiscourseTree],
-  text:Option[String],
-  var annotation:Option[Annotation]) extends Document(id, sentences, coref, dtree, text) {
+class CoreNLPDocument(sentences: Array[Sentence]) extends Document(sentences) {
 
-  def this(sentences:Array[Sentence],
-           coref:Option[CorefChains],
-           dtree:Option[DiscourseTree],
-           annotation:Option[Annotation]) =
-    this(None, sentences, coref, dtree, None, annotation)
-
-  def this(sentences:Array[Sentence], annotation:Option[Annotation]) =
-    this(sentences, None, None, annotation)
+  var annotation:Option[Annotation] = None
 
   override def clear() {
     //println("Clearing state from document.")
     annotation = None
+  }
+}
+
+object CoreNLPDocument {
+
+  def apply(sentences: Array[Sentence]) = new CoreNLPDocument(sentences)
+  def apply(
+    sentences: Array[Sentence],
+    coref: Option[CorefChains],
+    dtree: Option[DiscourseTree],
+    annotation: Option[Annotation]
+  ): CoreNLPDocument = {
+    val coreDoc = new CoreNLPDocument(sentences)
+    coreDoc.coreferenceChains = coref
+    coreDoc.discourseTree = dtree
+    coreDoc.annotation = annotation
+    coreDoc
+  }
+
+  def apply(
+    sentences: Array[Sentence],
+    annotation: Annotation
+  ): CoreNLPDocument = {
+    val coreDoc = new CoreNLPDocument(sentences)
+    coreDoc.annotation = Some(annotation)
+    coreDoc
   }
 }

--- a/src/main/scala/org/clulab/processors/corenlp/CoreNLPDocument.scala
+++ b/src/main/scala/org/clulab/processors/corenlp/CoreNLPDocument.scala
@@ -1,8 +1,9 @@
 package org.clulab.processors.corenlp
 
 import org.clulab.discourse.rstparser.DiscourseTree
-import org.clulab.processors.{CorefChains, Sentence, Document}
+import org.clulab.processors.{Document, Sentence}
 import edu.stanford.nlp.pipeline.Annotation
+import org.clulab.struct.CorefChains
 
 
 /**

--- a/src/main/scala/org/clulab/processors/corenlp/CoreNLPProcessor.scala
+++ b/src/main/scala/org/clulab/processors/corenlp/CoreNLPProcessor.scala
@@ -82,8 +82,8 @@ class CoreNLPProcessor(
         // save syntactic dependencies
         val basicDeps = sa.get(classOf[SemanticGraphCoreAnnotations.BasicDependenciesAnnotation])
         val collapsedDeps = sa.get(classOf[SemanticGraphCoreAnnotations.CollapsedCCProcessedDependenciesAnnotation])
-        doc.sentences(offset).setDependencies(DependencyMap.STANFORD_BASIC, CoreNLPUtils.toDirectedGraph(basicDeps, in))
-        doc.sentences(offset).setDependencies(DependencyMap.STANFORD_COLLAPSED, CoreNLPUtils.toDirectedGraph(collapsedDeps, in))
+        doc.sentences(offset).setDependencies(GraphMap.STANFORD_BASIC, CoreNLPUtils.toDirectedGraph(basicDeps, in))
+        doc.sentences(offset).setDependencies(GraphMap.STANFORD_COLLAPSED, CoreNLPUtils.toDirectedGraph(collapsedDeps, in))
       } else {
         doc.sentences(offset).syntacticTree = None
       }

--- a/src/main/scala/org/clulab/processors/corenlp/CoreNLPUtils.scala
+++ b/src/main/scala/org/clulab/processors/corenlp/CoreNLPUtils.scala
@@ -45,14 +45,14 @@ object CoreNLPUtils {
   }
 
   def toDirectedGraph(sg:SemanticGraph, interning: (String) => String):DirectedGraph[String] = {
-    val edgeBuffer = new ListBuffer[(Int, Int, String)]
+    val edgeBuffer = new ListBuffer[Edge[String]]
     for (edge <- sg.edgeIterable()) {
       val head:Int = edge.getGovernor.get(classOf[IndexAnnotation])
       val modifier:Int = edge.getDependent.get(classOf[IndexAnnotation])
       var label = edge.getRelation.getShortName
       val spec = edge.getRelation.getSpecific
       if (spec != null) label = label + "_" + spec
-      edgeBuffer.add((head - 1, modifier - 1, interning(label)))
+      edgeBuffer.add(Edge(head - 1, modifier - 1, interning(label)))
     }
 
     val roots = new mutable.HashSet[Int]

--- a/src/main/scala/org/clulab/processors/examples/DocumentSerializerExample.scala
+++ b/src/main/scala/org/clulab/processors/examples/DocumentSerializerExample.scala
@@ -1,6 +1,8 @@
-package org.clulab.processors
+package org.clulab.processors.examples
 
-import java.io.{FileReader, BufferedReader}
+import java.io.{BufferedReader, FileReader}
+
+import org.clulab.serialization.DocumentSerializer
 
 /**
  *

--- a/src/main/scala/org/clulab/processors/examples/ProcessorExample.scala
+++ b/src/main/scala/org/clulab/processors/examples/ProcessorExample.scala
@@ -1,6 +1,8 @@
-package org.clulab.processors
+package org.clulab.processors.examples
 
-import corenlp.CoreNLPProcessor
+import org.clulab.processors.corenlp.CoreNLPProcessor
+import org.clulab.serialization.DocumentSerializer
+import org.clulab.processors.{Document, Processor}
 import org.clulab.struct.DirectedGraphEdgeIterator
 
 /**

--- a/src/main/scala/org/clulab/processors/examples/ProcessorFileExample.scala
+++ b/src/main/scala/org/clulab/processors/examples/ProcessorFileExample.scala
@@ -1,6 +1,7 @@
-package org.clulab.processors
+package org.clulab.processors.examples
 
 import org.clulab.processors.fastnlp.FastNLPProcessor
+
 import scala.io.Source
 
 /**

--- a/src/main/scala/org/clulab/processors/sentiment/SentimentAnalyzer.scala
+++ b/src/main/scala/org/clulab/processors/sentiment/SentimentAnalyzer.scala
@@ -1,4 +1,6 @@
-package org.clulab.processors
+package org.clulab.processors.sentiment
+
+import org.clulab.processors.{Document, Sentence}
 
 /**
  * skeleton for sentiment analysis

--- a/src/main/scala/org/clulab/processors/shallownlp/ShallowNLPProcessor.scala
+++ b/src/main/scala/org/clulab/processors/shallownlp/ShallowNLPProcessor.scala
@@ -117,7 +117,7 @@ class ShallowNLPProcessor(val internStrings:Boolean = true) extends Processor {
       sa.set(classOf[TokenEndAnnotation], new Integer(tokenOffset))
     }
 
-    val doc = new CoreNLPDocument(sentences, Some(annotation))
+    val doc = CoreNLPDocument(sentences, annotation)
     if(keepText) doc.text = Some(text)
 
     doc
@@ -136,10 +136,11 @@ class ShallowNLPProcessor(val internStrings:Boolean = true) extends Processor {
       endOffsetBuffer += ta.endPosition()
     }
 
-    new Sentence(
+    Sentence(
       wordBuffer.toArray,
       startOffsetBuffer.toArray,
-      endOffsetBuffer.toArray)
+      endOffsetBuffer.toArray
+    )
   }
 
   def in(s:String):String = {
@@ -193,7 +194,7 @@ class ShallowNLPProcessor(val internStrings:Boolean = true) extends Processor {
       sentOffset += 1
     }
 
-    val doc = new CoreNLPDocument(docSents, Some(docAnnotation))
+    val doc = CoreNLPDocument(docSents, docAnnotation)
     if(keepText) doc.text = Some(origText)
 
     doc
@@ -250,7 +251,7 @@ class ShallowNLPProcessor(val internStrings:Boolean = true) extends Processor {
       sentOffset += 1
     }
 
-    val doc = new CoreNLPDocument(docSents, Some(docAnnotation))
+    val doc = CoreNLPDocument(docSents, docAnnotation)
     if(keepText) doc.text = Some(origText)
 
     doc

--- a/src/main/scala/org/clulab/serialization/DocumentSerializer.scala
+++ b/src/main/scala/org/clulab/serialization/DocumentSerializer.scala
@@ -1,11 +1,13 @@
-package org.clulab.processors
+package org.clulab.serialization
 
 import java.io._
-import org.clulab.discourse.rstparser.{TreeKind, TokenOffset, RelationDirection, DiscourseTree}
-import org.clulab.processors.DocumentSerializer._
+
+import org.clulab.discourse.rstparser.{DiscourseTree, RelationDirection, TokenOffset, TreeKind}
+import org.clulab.processors.{Document, Sentence}
 import org.clulab.struct._
-import collection.mutable.{ListBuffer, ArrayBuffer}
-import collection.mutable
+
+import scala.collection.mutable
+import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 import scala.reflect.ClassTag
 
 /**

--- a/src/main/scala/org/clulab/serialization/DocumentSerializer.scala
+++ b/src/main/scala/org/clulab/serialization/DocumentSerializer.scala
@@ -1,14 +1,13 @@
 package org.clulab.serialization
 
 import java.io._
-
 import org.clulab.discourse.rstparser.{DiscourseTree, RelationDirection, TokenOffset, TreeKind}
 import org.clulab.processors.{Document, Sentence}
 import org.clulab.struct._
-
 import scala.collection.mutable
 import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 import scala.reflect.ClassTag
+
 
 /**
  * Saves/loads a Document to/from a stream
@@ -18,6 +17,8 @@ import scala.reflect.ClassTag
  * Date: 3/5/13
  */
 class DocumentSerializer {
+
+  import DocumentSerializer._
 
   /**
    * This is deprecated! Please use load(r:BufferedReader) instead!
@@ -60,7 +61,10 @@ class DocumentSerializer {
       assert(bits(0) == END_OF_DOCUMENT)
     }
 
-    new Document(sents.toArray, coref, discourse)
+    val doc = Document(sents.toArray)
+    doc.coreferenceChains = coref
+    doc.discourseTree = discourse
+    doc
   }
 
   private def read(r:BufferedReader, howManyTokens:Int = 0): Array[String] = {
@@ -130,12 +134,12 @@ class DocumentSerializer {
     assert(normBuffer.isEmpty || normBuffer.size == tokenCount)
     assert(chunkBuffer.isEmpty || chunkBuffer.size == tokenCount)
 
-    var deps = new DependencyMap
+    var deps = new GraphMap
     var tree:Option[Tree] = None
     do {
       bits = read(r)
       if (bits(0) == START_DEPENDENCIES) {
-        val dt = bits(1).toInt
+        val dt = bits(1)
         val sz = bits(2).toInt
         val d = loadDependencies(r, sz)
         deps += (dt -> d)
@@ -146,7 +150,7 @@ class DocumentSerializer {
       }
     } while(bits(0) != END_OF_SENTENCE)
 
-    new Sentence(
+    Sentence(
       wordBuffer.toArray,
       startOffsetBuffer.toArray,
       endOffsetBuffer.toArray,
@@ -160,7 +164,7 @@ class DocumentSerializer {
   }
 
   private def loadDependencies(r:BufferedReader, sz:Int):DirectedGraph[String] = {
-    val edges = new ListBuffer[(Int, Int, String)]
+    val edges = new ListBuffer[Edge[String]]
     val roots = new mutable.HashSet[Int]()
     var bits = read(r)
     var offset = 0
@@ -171,7 +175,7 @@ class DocumentSerializer {
     do {
       bits = read(r)
       if (bits(0) != END_OF_DEPENDENCIES) {
-        val edge = new Tuple3(bits(0).toInt, bits(1).toInt, bits(2))
+        val edge = Edge(source = bits(0).toInt, destination = bits(1).toInt, relation = bits(2))
         //println("adding edge: " + edge)
         edges += edge
       }
@@ -302,7 +306,7 @@ class DocumentSerializer {
     os.println()
   }
 
-  private def saveDependencies(dg:DirectedGraph[String], dependencyType:Int, os:PrintWriter) {
+  private def saveDependencies(dg: DirectedGraph[String], dependencyType: String, os: PrintWriter) {
     os.println(START_DEPENDENCIES + SEP + dependencyType + SEP + dg.size)
     os.println(dg.roots.mkString(sep = SEP))
     val it = new DirectedGraphEdgeIterator[String](dg)

--- a/src/main/scala/org/clulab/serialization/json/JSONSerializer.scala
+++ b/src/main/scala/org/clulab/serialization/json/JSONSerializer.scala
@@ -1,0 +1,146 @@
+package org.clulab.serialization.json
+
+import java.io.File
+import org.clulab.odin._
+import org.clulab.processors.{Document, Sentence}
+import org.clulab.struct.{DirectedGraph, GraphMap, Interval}
+import org.json4s.JsonDSL._
+import org.json4s._
+import org.json4s.native.JsonMethods._
+
+
+/** JSON serialization utilities */
+object JSONSerializer {
+
+  implicit val formats = DefaultFormats
+
+  def jsonAST(mentions: Seq[Mention]): JValue = {
+    val docsMap = mentions.map(m => m.document.equivalenceHash.toString -> m.document.jsonAST).toMap
+    val mentionList = JArray(mentions.map(_.jsonAST).toList)
+
+    ("documents" -> docsMap) ~
+    ("mentions" -> mentionList)
+  }
+
+  def jsonAST(f: File): JValue = parse(scala.io.Source.fromFile(f).getLines.mkString)
+
+  /** Produce a sequence of mentions from json */
+  def mkMentions(json: JValue): Seq[Mention] = {
+
+    require(json \ "documents" != JNothing, "\"documents\" key missing from json")
+    require(json \ "mentions" != JNothing, "\"mentions\" key missing from json")
+
+    val djson = json \ "documents"
+    val mmjson = (json \ "mentions").asInstanceOf[JArray]
+
+    mmjson.arr.map(mjson => toMention(mjson, djson))
+  }
+  /** Produce a sequence of mentions from a json file */
+  def toMentions(file: File): Seq[Mention] = mkMentions(jsonAST(file))
+
+  /** Build mention from json of mention and corresponding json map of documents <br>
+    * Since a single Document can be quite large and may be shared by multiple mentions,
+    * only a reference to the document json is contained within each mention.
+    * A map from doc reference to document json is used to avoid redundancies and reduce file size during serialization.
+    * */
+  def toMention(mjson: JValue, djson: JValue): Mention = {
+
+    val tokInterval = Interval(
+      (mjson \ "tokenInterval" \ "start").extract[Int],
+      (mjson \ "tokenInterval" \ "end").extract[Int]
+    )
+    // elements shared by all Mention types
+    val labels = (mjson \ "labels").extract[List[String]]
+    val sentence = (mjson \ "sentence").extract[Int]
+    val docHash = (mjson \ "document").extract[String]
+    val document = toDocument(docHash, djson)
+    val keep = (mjson \ "keep").extract[Boolean]
+    val foundBy = (mjson \ "foundBy").extract[String]
+
+    def mkArgumentsFromJsonAST(json: JValue): Map[String, Seq[Mention]] = try {
+      val args = json.extract[Map[String, JArray]]
+      val argPairs = for {
+        (k: String, v: JValue) <- args
+        mns: Seq[Mention] = v.arr.map(m => toMention(m, djson))
+      } yield (k, mns)
+      argPairs
+    } catch {
+      case e: org.json4s.MappingException => Map.empty[String, Seq[Mention]]
+    }
+
+    // build Mention
+    mjson \ "type" match {
+      case JString("EventMention") =>
+        new EventMention(
+          labels,
+          // trigger must be TextBoundMention
+          toMention(mjson \ "trigger", djson).asInstanceOf[TextBoundMention],
+          mkArgumentsFromJsonAST(mjson \ "arguments"),
+          sentence,
+          document,
+          keep,
+          foundBy
+        )
+      case JString("RelationMention") =>
+        new RelationMention(
+          labels,
+          mkArgumentsFromJsonAST(mjson \ "arguments"),
+          sentence,
+          document,
+          keep,
+          foundBy
+        )
+      // Assume TextBoundMention
+      //case JString("TextBoundMention") =>
+      case _ =>
+        new TextBoundMention(
+          labels,
+          tokInterval,
+          sentence,
+          document,
+          keep,
+          foundBy
+        )
+    }
+  }
+
+  def toDocument(json: JValue): Document = {
+    // recover sentences
+    val sentences = (json \ "sentences").asInstanceOf[JArray].arr.map(sjson => toSentence(sjson)).toArray
+    // initialize document
+    val d = Document(sentences)
+    // update id
+    d.id = getStringOption(json, "id")
+    // update text
+    d.text = getStringOption(json, "text")
+    d
+  }
+
+  def toDocument(docHash: String, djson: JValue): Document = toDocument(djson \ docHash)
+  def toDocument(f: File): Document = toDocument(jsonAST(f))
+
+  def toSentence(json: JValue): Sentence = {
+
+    def getLabels(json: JValue, k: String): Option[Array[String]] = json \ k match {
+      case JNothing => None
+      case contents => Some(contents.extract[Array[String]])
+    }
+
+    val s = json.extract[Sentence]
+    // build dependencies
+    val graphs = (json \ "graphs").extract[Map[String, DirectedGraph[String]]]
+    s.dependenciesByType = GraphMap(graphs)
+    // build labels
+    s.tags = getLabels(json, "tags")
+    s.lemmas = getLabels(json, "lemmas")
+    s.entities = getLabels(json, "entities")
+    s.norms = getLabels(json, "norms")
+    s.chunks = getLabels(json, "chunks")
+    s
+  }
+
+  private def getStringOption(json: JValue, key: String): Option[String] = json \ key match {
+    case JString(s) => Some(s)
+    case _ => None
+  }
+}

--- a/src/main/scala/org/clulab/serialization/json/JSONSerializer.scala
+++ b/src/main/scala/org/clulab/serialization/json/JSONSerializer.scala
@@ -25,7 +25,7 @@ object JSONSerializer {
   def jsonAST(f: File): JValue = parse(scala.io.Source.fromFile(f).getLines.mkString)
 
   /** Produce a sequence of mentions from json */
-  def mkMentions(json: JValue): Seq[Mention] = {
+  def toMentions(json: JValue): Seq[Mention] = {
 
     require(json \ "documents" != JNothing, "\"documents\" key missing from json")
     require(json \ "mentions" != JNothing, "\"mentions\" key missing from json")
@@ -36,7 +36,7 @@ object JSONSerializer {
     mmjson.arr.map(mjson => toMention(mjson, djson))
   }
   /** Produce a sequence of mentions from a json file */
-  def toMentions(file: File): Seq[Mention] = mkMentions(jsonAST(file))
+  def toMentions(file: File): Seq[Mention] = toMentions(jsonAST(file))
 
   /** Build mention from json of mention and corresponding json map of documents <br>
     * Since a single Document can be quite large and may be shared by multiple mentions,

--- a/src/main/scala/org/clulab/serialization/json/package.scala
+++ b/src/main/scala/org/clulab/serialization/json/package.scala
@@ -1,0 +1,188 @@
+package org.clulab.serialization
+
+import org.clulab.odin._
+import org.clulab.processors.{Document, Sentence}
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Paths}
+import org.clulab.struct.{DirectedGraph, Edge, GraphMap}
+import org.json4s._
+import org.json4s.JsonDSL._
+import org.json4s.native._
+
+
+package object json {
+
+  trait JSONSerialization {
+
+    def jsonAST: JValue
+
+    def json(pretty: Boolean = false): String =
+      if (pretty) prettyJson(renderJValue(jsonAST))
+      else compactJson(renderJValue(jsonAST))
+
+  }
+
+  private def argsAST(arguments: Map[String, Seq[Mention]]): JObject = {
+    val args = arguments.map {
+      case (name, mentions) => name -> JArray(mentions.map(_.jsonAST).toList)
+    }
+    JObject(args.toList)
+  }
+
+  implicit val formats = org.json4s.DefaultFormats
+
+  implicit class MentionOps(m: Mention) extends JSONSerialization {
+    def jsonAST: JValue = m match {
+      case tb: TextBoundMention => TextBoundMentionOps(tb).jsonAST
+      case em: EventMention => EventMentionOps(em).jsonAST
+      case rm: RelationMention => RelationMentionOps(rm).jsonAST
+    }
+  }
+
+  implicit class TextBoundMentionOps(tb: TextBoundMention) extends JSONSerialization {
+
+    def jsonAST: JValue = {
+      ("type" -> "TextBoundMention") ~
+      ("labels" -> tb.labels) ~
+      ("tokenInterval" -> Map("start" -> tb.tokenInterval.start, "end" -> tb.tokenInterval.end)) ~
+      ("characterStartOffset" -> tb.startOffset) ~
+      ("characterEndOffset" -> tb.endOffset) ~
+      ("sentence" -> tb.sentence) ~
+      ("document" -> tb.document.equivalenceHash.toString) ~
+      ("keep" -> tb.keep) ~
+      ("foundBy" -> tb.foundBy)
+    }
+  }
+
+  implicit class EventMentionOps(em: EventMention) extends JSONSerialization {
+
+    def jsonAST: JValue = {
+      ("type" -> "EventMention") ~
+      ("labels" -> em.labels) ~
+      ("trigger" -> em.trigger.jsonAST) ~
+      ("arguments" -> argsAST(em.arguments)) ~
+      ("tokenInterval" -> Map("start" -> em.tokenInterval.start, "end" -> em.tokenInterval.end)) ~
+      ("characterStartOffset" -> em.startOffset) ~
+      ("characterEndOffset" -> em.endOffset) ~
+      ("sentence" -> em.sentence) ~
+      ("document" -> em.document.equivalenceHash.toString) ~
+      ("keep" -> em.keep) ~
+      ("foundBy" -> em.foundBy)
+    }
+  }
+
+  implicit class RelationMentionOps(rm: RelationMention) extends JSONSerialization {
+    def jsonAST: JValue = {
+      ("type" -> "RelationMention") ~
+      ("labels" -> rm.labels) ~
+      ("arguments" -> argsAST(rm.arguments)) ~
+      ("tokenInterval" -> Map("start" -> rm.tokenInterval.start, "end" -> rm.tokenInterval.end)) ~
+      ("characterStartOffset" -> rm.startOffset) ~
+      ("characterEndOffset" -> rm.endOffset) ~
+      ("sentence" -> rm.sentence) ~
+      ("document" -> rm.document.equivalenceHash.toString) ~
+      ("keep" -> rm.keep) ~
+      ("foundBy" -> rm.foundBy)
+    }
+  }
+
+  /** For sequences of mentions */
+  implicit class MentionSeq(mentions: Seq[Mention]) extends JSONSerialization {
+
+    def jsonAST: JValue = JSONSerializer.jsonAST(mentions)
+
+    /**
+      * Serialize mentions to json file
+      */
+    def saveJSON(file: String, pretty: Boolean): Unit = {
+      require(file.endsWith(".json"), "file should have .json extension")
+      Files.write(Paths.get(file), mentions.json(pretty).getBytes(StandardCharsets.UTF_8))
+    }
+    def saveJSON(file: File, pretty: Boolean): Unit = saveJSON(file.getAbsolutePath, pretty)
+  }
+
+  // Arrays cannot be directly converted to JValue
+  implicit class ArrayOps(s: Option[Array[String]]) {
+    def toSerializableJSON: Option[List[String]] = s match {
+      case Some(s) => Some(s.toList)
+      case None => None
+    }
+  }
+
+  implicit class ODirectedGraphOps(odg: Option[DirectedGraph[String]]) {
+    def toSerializableJSON: Option[JValue] = odg match {
+      case Some(g) => Some(g.jsonAST)
+      case None => None
+    }
+  }
+
+  implicit class DirectedGraphOps(dg: DirectedGraph[String]) extends JSONSerialization {
+    def jsonAST: JValue = {
+      ("edges" -> dg.edges.map(_.jsonAST)) ~
+      ("roots" -> dg.roots)
+    }
+  }
+
+  implicit class EdgeOps(edge: Edge[String]) extends JSONSerialization {
+    def jsonAST: JValue = {
+      ("source" -> edge.source) ~
+      ("destination" -> edge.destination) ~
+      ("relation" -> edge.relation.toString)
+    }
+  }
+
+  implicit class GraphMapOps(gm: GraphMap) extends JSONSerialization {
+    def jsonAST: JValue = Extraction.decompose(gm.toMap.mapValues(_.jsonAST))
+  }
+
+  /** For Document */
+  implicit class DocOps(doc: Document) extends JSONSerialization {
+
+    def jsonAST: JValue = {
+      // field and value are removed when value is not present
+      ("id" -> doc.id) ~
+      ("text" -> doc.text) ~
+      ("sentences" -> doc.sentences.map(_.jsonAST).toList)
+      // TODO: handle discourse tree
+      //("discourse-tree" -> discourseTree)
+    }
+
+    /**
+      * Serialize Document to json file
+      */
+    def saveJSON(file: String, pretty: Boolean): Unit = {
+      require(file.endsWith(".json"), "file should have .json extension")
+      Files.write(Paths.get(file), doc.json(pretty).getBytes(StandardCharsets.UTF_8))
+    }
+    def saveJSON(file: File, pretty: Boolean): Unit = saveJSON(file.getAbsolutePath, pretty)
+  }
+
+
+  /** For Sentence */
+  implicit class SentenceOps(s: Sentence) extends JSONSerialization {
+
+    def jsonAST: JValue = {
+      ("words" -> s.words.toList) ~
+      ("startOffsets" -> s.startOffsets.toList) ~
+      ("endOffsets" -> s.endOffsets.toList) ~
+      ("tags" -> s.tags.toSerializableJSON) ~
+      ("lemmas" -> s.lemmas.toSerializableJSON) ~
+      ("entities" -> s.entities.toSerializableJSON) ~
+      ("norms" -> s.norms.toSerializableJSON) ~
+      ("chunks" -> s.chunks.toSerializableJSON) ~
+      ("graphs" -> s.dependenciesByType.jsonAST)
+      // TODO: handle tree
+      //("syntactic-tree") -> syntacticTree)
+    }
+
+    /**
+      * Serialize Sentence to json file
+      */
+    def saveJSON(file: String, pretty: Boolean): Unit = {
+      require(file.endsWith(".json"), "file should have .json extension")
+      Files.write(Paths.get(file), s.json(pretty).getBytes(StandardCharsets.UTF_8))
+    }
+    def saveJSON(file: File, pretty: Boolean): Unit = saveJSON(file.getAbsolutePath, pretty)
+  }
+}

--- a/src/main/scala/org/clulab/serialization/json/package.scala
+++ b/src/main/scala/org/clulab/serialization/json/package.scala
@@ -38,6 +38,20 @@ package object json {
       case em: EventMention => EventMentionOps(em).jsonAST
       case rm: RelationMention => RelationMentionOps(rm).jsonAST
     }
+
+    // A mention only only contains a pointer to a document, so
+    // create a Seq[Mention] whose jsonAST includes
+    // an accompanying json map of docEquivHash -> doc's json
+    def completeAST: JValue = Seq(m).jsonAST
+
+    /**
+      * Serialize mentions to json file
+      */
+    def saveJSON(file: String, pretty: Boolean): Unit = {
+      require(file.endsWith(".json"), "file should have .json extension")
+      Files.write(Paths.get(file), Seq(m).json(pretty).getBytes(StandardCharsets.UTF_8))
+    }
+    def saveJSON(file: File, pretty: Boolean): Unit = saveJSON(file.getAbsolutePath, pretty)
   }
 
   implicit class TextBoundMentionOps(tb: TextBoundMention) extends JSONSerialization {

--- a/src/main/scala/org/clulab/struct/CorefMention.scala
+++ b/src/main/scala/org/clulab/struct/CorefMention.scala
@@ -1,0 +1,152 @@
+package org.clulab.struct
+
+import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
+
+
+/** Stores a single coreference mention */
+case class CorefMention(
+  /** Index of the sentence containing this mentions; starts at 0 */
+  sentenceIndex: Int,
+  /** Token index for the mention head word; starts at 0 */
+  headIndex: Int,
+  /** Start token offset in the sentence; starts at 0 */
+  startOffset: Int,
+  /** Offset of token immediately after this mention; starts at 0 */
+  endOffset: Int,
+  /** Id of the coreference chain containing this mention; -1 if singleton mention */
+  chainId: Int) extends Serializable {
+
+  def length = endOffset - startOffset
+
+  override def equals(other:Any):Boolean = {
+    other match {
+      case that: CorefMention =>
+        sentenceIndex == that.sentenceIndex &&
+          headIndex == that.headIndex &&
+          startOffset == that.startOffset &&
+          endOffset == that.endOffset
+      case _ => false
+    }
+  }
+
+  override def hashCode = {
+    41 * (41 * (41 * (41 + sentenceIndex))) +
+      41 * (41 * (41 + headIndex)) +
+      41 * (41 + startOffset) +
+      endOffset
+  }
+
+  override def toString:String = {
+    val os = new StringBuilder
+    os.append("(")
+    os.append(sentenceIndex)
+    os.append(", ")
+    os.append(headIndex)
+    os.append(", ")
+    os.append(startOffset)
+    os.append(", ")
+    os.append(endOffset)
+    os.append(")")
+    os.toString
+  }
+}
+
+/** Stores all the coreference chains extracted in one document */
+case class CorefChains(rawMentions: Iterable[CorefMention]) extends Serializable {
+
+  /**
+    * Indexes all mentions in a document by sentence index (starting at 0) and head index (starting at 0)
+    * This means we store only one mention per head (unlike CoreNLP which may have multiple)
+    * In case a specific processor maintains multiple mentions with same head, we keep the longest
+    */
+  val mentions:Map[(Int, Int), CorefMention] = CorefChains.mkMentions(rawMentions)
+
+  /**
+    * Indexes all coreference chains in a document using a unique id per chain
+    * These do not include singleton clusters
+    */
+  val chains:Map[Int, Iterable[CorefMention]] = CorefChains.mkChains(mentions)
+
+  /** Fetches the mention with this sentence and head indices */
+  def getMention(sentenceIndex:Int, headIndex:Int):Option[CorefMention] =
+    mentions.get((sentenceIndex, headIndex))
+
+  /** Fetches the coreference chain for the mention with this sentence and head indices; None for singletons */
+  def getChain(sentenceIndex:Int, headIndex:Int):Option[Iterable[CorefMention]] = {
+    getMention(sentenceIndex, headIndex).foreach(m => return getChain(m))
+    None
+  }
+
+  /** Fetches the coreference chain for this mention; None for singletons */
+  def getChain(mention:CorefMention):Option[Iterable[CorefMention]] = {
+    if (mention.chainId == -1) return None
+    chains.get(mention.chainId)
+  }
+
+  /** All recognized chains, without singletons */
+  def getChains:Iterable[Iterable[CorefMention]] = chains.values
+
+  /** All mentions in this document */
+  def getMentions:Iterable[CorefMention] = mentions.values
+
+  def isEmpty = mentions.isEmpty && chains.isEmpty
+}
+
+object CorefChains {
+  private def lessThanForMentions(x:CorefMention, y:CorefMention):Boolean = {
+    if (x.sentenceIndex < y.sentenceIndex) return true
+    if (x.sentenceIndex > y.sentenceIndex) return false
+
+    if (x.headIndex < y.headIndex) return true
+    if (x.headIndex > y.headIndex) return false
+
+    val diffSize = (x.endOffset - x.startOffset) - (y.endOffset - y.startOffset)
+    if (diffSize > 0) return true
+    if (diffSize < 0) return false
+
+    true
+  }
+
+  private def mkMentions(rawMentions:Iterable[CorefMention]):Map[(Int, Int), CorefMention] = {
+    // if multiple mentions with same head exist, keep only the longest
+    val sortedMentions = rawMentions.toList.sortWith(lessThanForMentions)
+    val mentionMap = new mutable.HashMap[(Int, Int), CorefMention]
+    var prevMention:CorefMention = null
+    for (m <- sortedMentions) {
+      // println(m.sentenceIndex + " " + m.headIndex + " " + m.startOffset + " " + m.endOffset)
+
+      // eliminate duplicate mentions (same sentence, same head)
+      // if found, we keep the previous, which is guaranteed to be longer due to sorting criterion
+      if (prevMention != null &&
+        prevMention.sentenceIndex == m.sentenceIndex &&
+        prevMention.headIndex == m.headIndex) {
+        assert(prevMention.length >= m.length)
+      } else {
+        mentionMap += (m.sentenceIndex, m.headIndex) -> m
+      }
+
+      prevMention = m
+    }
+    mentionMap.toMap
+  }
+
+  private def mkChains(mentions:Map[(Int, Int), CorefMention]):Map[Int, Iterable[CorefMention]] = {
+    val chainBuffer = new mutable.HashMap[Int, ListBuffer[CorefMention]]
+    for (m <- mentions.values) {
+      var cb = chainBuffer.get(m.chainId)
+      if (cb.isEmpty) {
+        val cbv = new ListBuffer[CorefMention]
+        chainBuffer += m.chainId -> cbv
+        cb = chainBuffer.get(m.chainId)
+        assert(cb.isDefined)
+      }
+      cb.get += m
+    }
+    val chainMap = new mutable.HashMap[Int, Iterable[CorefMention]]
+    for (cid <- chainBuffer.keySet) {
+      chainMap += cid -> chainBuffer.get(cid).get.toList
+    }
+    chainMap.toMap
+  }
+}

--- a/src/main/scala/org/clulab/struct/DependencyMap.scala
+++ b/src/main/scala/org/clulab/struct/DependencyMap.scala
@@ -1,0 +1,14 @@
+package org.clulab.struct
+
+import scala.collection.mutable
+
+
+class DependencyMap extends mutable.HashMap[Int, DirectedGraph[String]] {
+  override def initialSize:Int = 2 // we have very few dependency types, so let's create a small hash to save memory
+}
+
+object DependencyMap {
+  val STANFORD_BASIC = 0 // basic Stanford dependencies
+  val STANFORD_COLLAPSED = 1 // collapsed Stanford dependencies
+  val SEMANTIC_ROLES = 2 // semantic roles from CoNLL 2008-09, which includes PropBank and NomBank
+}

--- a/src/main/scala/org/clulab/struct/DirectedGraph.scala
+++ b/src/main/scala/org/clulab/struct/DirectedGraph.scala
@@ -2,6 +2,7 @@ package org.clulab.struct
 
 import scala.collection.mutable
 import scala.collection.mutable.{ArrayBuffer, ListBuffer}
+import scala.util.hashing.MurmurHash3._
 
 
 /**
@@ -18,7 +19,19 @@ case class DirectedGraph[E](edges: List[Edge[E]], roots: collection.immutable.Se
 
   val allEdges: List[(Int, Int, E)] = edges.map(e => (e.source, e.destination, e.relation))
 
-  def allEdges(): List[(Int, Int, E)] = edges
+  /**
+    * Used to compare DirectedGraphs.
+    * @return a hash (Int) based on the [[edges]] and [[roots]]
+    */
+  def equivalenceHash: Int = {
+    val stringCode = "org.clulab.struct.DirectedGraph"
+    // the seed (not counted in the length of finalizeHash)
+    // decided to use the class name
+    val h0 = stringHash(stringCode)
+    val h1 = mix(h0, edges.hashCode)
+    val h2 = mix(h1, roots.hashCode)
+    finalizeHash(h2, 2)
+  }
 
   private def computeSize(edges:List[Edge[_]]):Int = {
     var size = 0

--- a/src/main/scala/org/clulab/struct/GraphMap.scala
+++ b/src/main/scala/org/clulab/struct/GraphMap.scala
@@ -1,0 +1,19 @@
+package org.clulab.struct
+
+import scala.collection.mutable
+
+
+class GraphMap extends mutable.HashMap[String, DirectedGraph[String]] {
+  override def initialSize:Int = 2 // we have very few dependency types, so let's create a small hash to save memory
+}
+
+object GraphMap {
+  val STANFORD_BASIC = "stanford-basic" // basic Stanford dependencies
+  val STANFORD_COLLAPSED = "stanford-collapsed" // collapsed Stanford dependencies
+  val SEMANTIC_ROLES = "semantic-roles" // semantic roles from CoNLL 2008-09, which includes PropBank and NomBank
+
+  def apply(existing: Map[String, DirectedGraph[String]]): GraphMap = {
+    val gm = new GraphMap
+    gm ++= existing
+  }
+}

--- a/src/main/scala/org/clulab/swirl2/ArgumentClassifier.scala
+++ b/src/main/scala/org/clulab/swirl2/ArgumentClassifier.scala
@@ -5,13 +5,11 @@ import java.io._
 import de.bwaldvogel.liblinear.SolverType
 import org.clulab.learning._
 import org.clulab.processors.{Sentence, Document}
-import org.clulab.struct.{DirectedGraphEdgeIterator, DirectedGraph, Counter}
+import org.clulab.struct.{DirectedGraphEdgeIterator, DirectedGraph, Edge, Counter}
 import org.clulab.utils.Files
 import org.clulab.utils.StringUtils._
 import org.slf4j.LoggerFactory
-
 import ArgumentClassifier._
-
 import scala.collection.mutable
 import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 import scala.util.Random
@@ -111,8 +109,8 @@ class ArgumentClassifier {
     var correctLabeled = 0
 
     for(o <- output) {
-      val gold = o._1.allEdges()
-      val pred = o._2.allEdges()
+      val gold = o._1.allEdges
+      val pred = o._2.allEdges
 
       total += gold.size
       predicted += pred.size
@@ -159,7 +157,7 @@ class ArgumentClassifier {
 
   def classifySentence(sentence:Sentence):DirectedGraph[String] = {
     val roots = new mutable.HashSet[Int]()
-    val edges = new ListBuffer[(Int, Int, String)]
+    val edges = new ListBuffer[Edge[String]]
 
     // first, get gold predicates
     for(i <- sentence.words.indices) {
@@ -179,7 +177,7 @@ class ArgumentClassifier {
           predLabel = scores.head._1
           if (predLabel != ArgumentClassifier.NEG_LABEL) {
             history += new Tuple2(arg, predLabel) // TODO: we do not use history for now
-            edges += new Tuple3(pred, arg, predLabel)
+            edges += Edge[String](source = pred, destination = arg, predLabel)
             // argCandidates += new Tuple2(arg, scores)
           }
         }
@@ -193,7 +191,7 @@ class ArgumentClassifier {
       */
     }
 
-    new DirectedGraph[String](edges.toList, roots.toSet)
+    DirectedGraph[String](edges.toList, roots.toSet)
   }
 
   def pickWithDomainConstraints(argCands:ArrayBuffer[(Int, List[(String, Double)])]):Set[(Int, String)] = {

--- a/src/main/scala/org/clulab/swirl2/Reader.scala
+++ b/src/main/scala/org/clulab/swirl2/Reader.scala
@@ -1,17 +1,16 @@
 package org.clulab.swirl2
 
-import java.io.{FileReader, BufferedReader, PrintWriter, File}
-
+import java.io.{BufferedReader, File, FileReader, PrintWriter}
 import org.clulab.processors.fastnlp.FastNLPProcessor
-import org.clulab.processors.{DependencyMap, DocumentSerializer, Document, Processor}
-import org.clulab.struct.DirectedGraph
+import org.clulab.processors.{Document, Processor}
+import org.clulab.struct.{GraphMap, DirectedGraph}
 import org.slf4j.LoggerFactory
-
 import scala.collection.mutable
-import scala.collection.mutable.{ListBuffer, ArrayBuffer}
+import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 import scala.io.Source
-
 import Reader._
+import org.clulab.serialization.DocumentSerializer
+
 
 /**
  * Reads a CoNLL formatted file and converts it to our own representation
@@ -110,7 +109,7 @@ class Reader {
     //
     assert(document.sentences.length == semDependencies.size)
     for(i <- document.sentences.indices) {
-      document.sentences(i).setDependencies(DependencyMap.SEMANTIC_ROLES, semDependencies(i))
+      document.sentences(i).setDependencies(GraphMap.SEMANTIC_ROLES, semDependencies(i))
     }
 
     logger.debug(s"Found a total of $predCount predicates with $argCount arguments.")
@@ -157,7 +156,7 @@ class Reader {
         val depGraph = toDirectedGraph(conllTokens)
         //println(depGraph)
         // we set the gold CoNLL syntax as Stanford basic dependencies (hack)
-        sent.dependenciesByType += DependencyMap.STANFORD_BASIC -> depGraph
+        sent.dependenciesByType += GraphMap.STANFORD_BASIC -> depGraph
       }
     } else {
       proc.parse(doc)
@@ -180,7 +179,7 @@ class Reader {
       else
         roots += modifier
     }
-    new DirectedGraph[String](edges.toList, roots.toSet)
+    DirectedGraph[String](DirectedGraph.triplesToEdges[String](edges.toList), roots.toSet)
   }
 
   def mkSemanticDependencies(sentence:Array[CoNLLToken]):DirectedGraph[String] = {
@@ -214,7 +213,7 @@ class Reader {
       }
     }
 
-    new DirectedGraph[String](edges.toList, roots.toSet)
+    DirectedGraph[String](DirectedGraph.triplesToEdges[String](edges.toList), roots.toSet)
   }
 
   def mkToken(bits:Array[String]):CoNLLToken = {

--- a/src/main/scala/org/clulab/swirl2/SRL.scala
+++ b/src/main/scala/org/clulab/swirl2/SRL.scala
@@ -1,14 +1,12 @@
 package org.clulab.swirl2
 
 import java.io._
-
 import org.clulab.processors.Sentence
-import org.clulab.struct.DirectedGraph
+import org.clulab.struct.{DirectedGraph, Edge}
 import org.clulab.utils.Files
 import org.clulab.utils.StringUtils._
 import org.slf4j.LoggerFactory
 import SRL._
-
 import scala.collection.mutable
 import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 
@@ -87,7 +85,7 @@ class SRL {
 
   def classifySentence(sentence:Sentence):DirectedGraph[String] = {
     val roots = new mutable.HashSet[Int]()
-    val edges = new ListBuffer[(Int, Int, String)]
+    val edges = new ListBuffer[Edge[String]]
 
     // first, find predicates
     /*
@@ -115,13 +113,13 @@ class SRL {
           predLabel = scores.head._1
           if (predLabel != ArgumentClassifier.NEG_LABEL) {
             history += new Tuple2(arg, predLabel)
-            edges += new Tuple3(pred, arg, predLabel)
+            edges += Edge[String](source = pred , destination = arg, predLabel)
           }
         }
       }
     }
 
-    new DirectedGraph[String](edges.toList, roots.toSet)
+    DirectedGraph[String](edges.toList, roots.toSet)
   }
 
   def score(output:List[(DirectedGraph[String], DirectedGraph[String])]): Unit = {
@@ -130,8 +128,8 @@ class SRL {
     var correctUnlabeled = 0
 
     for(o <- output) {
-      val gold = o._1.allEdges()
-      val pred = o._2.allEdges()
+      val gold = o._1.allEdges
+      val pred = o._2.allEdges
 
       total += gold.size
       predicted += pred.size

--- a/src/test/scala/org/clulab/processors/TestCoreNLPProcessor.scala
+++ b/src/test/scala/org/clulab/processors/TestCoreNLPProcessor.scala
@@ -2,8 +2,10 @@ package org.clulab.processors
 
 import org.clulab.discourse.rstparser.RelationDirection
 import org.scalatest._
+
 import collection.JavaConversions.asJavaCollection
 import org.clulab.processors.corenlp.CoreNLPProcessor
+import org.clulab.struct.CorefMention
 
 /**
  * 

--- a/src/test/scala/org/clulab/serialization/TestDocumentSerializer.scala
+++ b/src/test/scala/org/clulab/serialization/TestDocumentSerializer.scala
@@ -1,6 +1,7 @@
-package org.clulab.processors
+package org.clulab.serialization
 
-import corenlp.CoreNLPProcessor
+import org.clulab.processors.Processor
+import org.clulab.processors.corenlp.CoreNLPProcessor
 import org.scalatest._
 
 class TestDocumentSerializer extends FlatSpec with Matchers {

--- a/src/test/scala/org/clulab/serialization/TestJSONSerializer.scala
+++ b/src/test/scala/org/clulab/serialization/TestJSONSerializer.scala
@@ -1,0 +1,82 @@
+package org.clulab.serialization
+
+import org.clulab.odin.ExtractorEngine
+import org.clulab.processors.fastnlp.FastNLPProcessor
+import org.clulab.serialization.json._
+import org.scalatest._
+
+
+class TestJSONSerializer extends FlatSpec with Matchers {
+
+  val proc = new FastNLPProcessor
+  val rules =
+    """
+      |# NE rules
+      |
+      |- name: "ner-person"
+      |  label: [Person, PossiblePerson, Entity]
+      |  priority: 1
+      |  type: token
+      |  pattern: |
+      |   [entity="PERSON"]+
+      |
+      |# Events
+      |
+      |# optional location and date
+      |- name: "marry-syntax-1"
+      |  label: [Marry]
+      |  priority: 3
+      |  example: "He married Jane last June in Hawaii."
+      |  type: dependency
+      |  pattern: |
+      |    trigger = [lemma="marry"]
+      |    spouse: Entity+ = <xcomp? /^nsubj/ | dobj
+    """.stripMargin
+  val engine = ExtractorEngine(rules)
+  val text = "Gonzo married Camilla."
+  val doc = proc.annotate(text)
+  val mentions = engine.extractFrom(doc)
+
+  "JSONSerializer" should "serialize/deserialize a Document to/from json correctly" in {
+    val d2 = JSONSerializer.toDocument(doc.jsonAST)
+    d2.equivalenceHash should equal (doc.equivalenceHash)
+  }
+
+  it should "serialize/deserialize a Sentence to/from json correctly " in {
+    val s2 = JSONSerializer.toSentence(doc.sentences.head.jsonAST)
+    s2.equivalenceHash should equal (doc.sentences.head.equivalenceHash)
+  }
+
+  it should "serialize/deserialize a Mention to/from json correctly " in {
+    val mns = JSONSerializer.toMentions(mentions.head.completeAST)
+    mns should have size 1
+    val m = mns.head
+    m.document.equivalenceHash should equal (mentions.head.document.equivalenceHash)
+    m.tokenInterval should equal (mentions.head.tokenInterval)
+  }
+
+  it should "serialize/deserialize a Seq[Mention] to/from json correctly " in {
+    val mentions2 = JSONSerializer.toMentions(mentions.jsonAST)
+    mentions2 should have size mentions.size
+
+    mentions2.map(_.label) should equal (mentions.map(_.label))
+    mentions2.map(_.document.equivalenceHash) should equal (mentions.map(_.document.equivalenceHash))
+  }
+
+  "A Document recovered from JSON" should "be equivalent to the original" in {
+
+    val doc2 = JSONSerializer.toDocument(doc.jsonAST)
+
+    doc.equivalenceHash should equal (doc2.equivalenceHash)
+  }
+
+  "A Sentence recovered from JSON" should "be equivalent to the original" in {
+
+    val doc2 = JSONSerializer.toDocument(doc.jsonAST)
+
+    doc.sentences should not be empty
+    doc2.sentences should not be empty
+    doc.sentences.head.equivalenceHash should equal (doc2.sentences.head.equivalenceHash)
+  }
+
+}

--- a/src/test/scala/org/clulab/utils/TestDependencyUtils.scala
+++ b/src/test/scala/org/clulab/utils/TestDependencyUtils.scala
@@ -77,7 +77,7 @@ class TestDependencyUtils extends FlatSpec with Matchers {
     val edges = List((1, 0, "det"),(1,3,"rcmod"),(3,1,"nsubj"),(3,6,"prep_at"),(6,5,"nn"),
       (8,1,"nsubj"),(8,7,"advmod"),(8,12,"dobj"),(8,20,"prep_in"),(12,9,"det"),(12,10,"nn"),
       (12,11,"nn"),(12,13,"partmod"),(13,16,"prep_for"),(16,15,"nn"),(20,19,"amod"))
-    val depGraph = new DirectedGraph[String](edges, Set(8))
+    val depGraph = new DirectedGraph[String](DirectedGraph.triplesToEdges[String](edges), Set(8))
     val tokenInterval = Interval(0, 2)
     noException shouldBe thrownBy (DependencyUtils.findHeads(tokenInterval, depGraph))
   }
@@ -89,7 +89,7 @@ class TestDependencyUtils extends FlatSpec with Matchers {
       (10, 15, "prep_for"), (13, 12, "det"), (13, 15, "conj_and"), (13, 18, "prep_of"),
       (18, 17, "det")
     )
-    val graph = new DirectedGraph(edges, Set(7))
+    val graph = DirectedGraph(DirectedGraph.triplesToEdges[String](edges), Set(7))
     val interval = Interval(4, 8)
     noException shouldBe thrownBy (DependencyUtils.findHeads(interval, graph))
   }
@@ -105,7 +105,7 @@ class TestDependencyUtils extends FlatSpec with Matchers {
       (11, 22, "prep_about"), (11, 26, "prep_with"), (14, 13, "det"), (14, 16, "prep_of"), (16, 19, "prep_in"),
       (19, 18, "det"), (22, 21, "amod"), (26, 25, "det"), (30, 29, "det"), (32, 34, "dobj"), (34, 33, "amod")
     )
-    val graph = new DirectedGraph(edges, Set(5))
+    val graph = DirectedGraph(DirectedGraph.triplesToEdges[String](edges), Set(5))
     val interval = Interval(21, 23)
     a [DependencyUtilsException] shouldBe thrownBy (DependencyUtils.findHeads(interval, graph))
   }


### PR DESCRIPTION
This pull request resolves #89.

## Summary of changes

- added `org.clulab.serialization.json` package containing implicit class conversions with `json` serialization\deserialization support for `Document`, `Sentence`, and Mentions.
  - Design avoids redundancies of including a nested `json` representation of the `Document` associated with each `Mention`.  Instead, the `Mention`'s `json` contains a pointer to its `Document` (see attached example). 
- simplified constructors for `Document` and `Sentence`
- added support for comparing contents of `Sentence`, `Document`, and `DirectedGraph` that can be used for establishing equivalence of representations for annotated text.
- some refactoring


Complete working example demonstrating `json` methods:

```scala
import org.clulab.processors.fastnlp.FastNLPProcessor
import org.clulab.processors.Document
import org.clulab.struct.Interval
import org.clulab.odin._
import org.clulab.serialization.json._
import java.io.File

val rules =
  """
    |# NE rules
    |
    |- name: "ner-person"
    |  label: [Person, PossiblePerson, Entity]
    |  priority: 1
    |  type: token
    |  pattern: |
    |   [entity="PERSON"]+
    |
    |# Events
    |
    |# optional location and date
    |- name: "marry-syntax-1"
    |  label: [Marry]
    |  priority: 3
    |  example: "He married Jane last June in Hawaii."
    |  type: dependency
    |  pattern: |
    |    trigger = [lemma="marry"]
    |    spouse: Entity+ = <xcomp? /^nsubj/ | dobj
  """.stripMargin
val engine = ExtractorEngine(rules)

val proc = new FastNLPProcessor
val text = "Gonzo married Camilla."
val doc = proc.annotate(text)
val mentions = engine.extractFrom(doc)

// print the json string for the extracted mentions
println(mentions.json(pretty=true))

// save the json to a file
mentions.saveJSON("mentions.json", pretty=true)

// deserialize the mentions json that was written in the last step
val mentions2 = JSONSerializer.toMentions(new File("mentions.json"))

// demonstrate span equivalence to the original mentions
def m2triple(m: Mention):(Int, Int, Interval) = (m.document.equivalenceHash, m.sentence, m.tokenInterval)
mentions.map(m2triple) == mentions2.map(m2triple)

// documents can also be serialized/deserialized
doc.saveJSON("document.json", pretty=true)
val d2 = JSONSerializer.toDocument(new File("document.json"))

// demonstrate equivalence of annotations
doc.equivalenceHash == d2.equivalenceHash
```

The "document.json" produced in the example above is attached here
[document.json.txt](https://github.com/clulab/processors/files/456053/document.json.txt)
.