### PR TITLE
Improvements to json serialization

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 # Changes
++ **5.9.6** - Serialize/deserialize `Document`, `Mention`, etc. to/from `json`.
 + **5.9.5** - Bug fix release: do not tag XML tags such as XREF... as named entities.
 + **5.9.4** - Update to use bioresources 1.1.15.
 + **5.9.3** - Improved support for multi-token triggers in dependency patterns in Odin.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ All our own code is licensed under Apache License Version 2.0. **However, some o
 
 (c) Mihai Surdeanu, 2013 -
 
-Authors: [Mihai Surdeanu](http://surdeanu.info/mihai/), Marco Valenzuela, Gustave Hanh-Powell, Peter Jansen, [Daniel Fried](http://www.cs.arizona.edu/~dfried/), Dane Bell, and Tom Hicks.
+Authors: [Mihai Surdeanu](http://surdeanu.info/mihai/), [Marco Valenzuela](https://github.com/marcovzla), [Gustave Hahn-Powell](https://github.com/myedibleenso), Peter Jansen, [Daniel Fried](http://www.cs.arizona.edu/~dfried/), Dane Bell, and Tom Hicks.
 
 # Changes
 + **5.9.5** - Bug fix release: do not tag XML tags such as XREF... as named entities.
@@ -49,12 +49,12 @@ This software is available on Maven Central. To use, simply add the following de
 <dependency>
    <groupId>org.clulab</groupId>
    <artifactId>processors_2.11</artifactId>
-   <version>5.9.0</version>
+   <version>5.9.5</version>
 </dependency>
 <dependency>
    <groupId>org.clulab</groupId>
    <artifactId>processors_2.11</artifactId>
-   <version>5.9.0</version>
+   <version>5.9.5</version>
    <classifier>models</classifier>
 </dependency>
 ```
@@ -63,8 +63,8 @@ The equivalent SBT dependencies are:
 
 ```scala
 libraryDependencies ++= Seq(
-    "org.clulab" %% "processors" % "5.9.0",
-    "org.clulab" %% "processors" % "5.9.0" classifier "models"
+    "org.clulab" %% "processors" % "5.9.5",
+    "org.clulab" %% "processors" % "5.9.5" classifier "models"
 )
 ```
 
@@ -346,6 +346,10 @@ val someAnnotation = serializer.load(fromString)
 Note that space required for these serialized annotations is considerably smaller (8 to 10 times) than the corresponding
 serialized Java objects. This is because we store only the information required to recreate these annotations (e.g., words, lemmas, etc.)
 without storing any of the Java/Scala objects and classes.
+
+### Serialization to/from `json`
+
+As of v5.9.6, `Document` and `Mention` instances can be serialized to/from `json` ([see the complete working example](https://gist.github.com/myedibleenso/87a3191c73938840b8ed768ec305db38)).  
 
 ## Cleaning up the interned strings
 

--- a/src/main/scala/org/clulab/processors/corenlp/CoreNLPDocument.scala
+++ b/src/main/scala/org/clulab/processors/corenlp/CoreNLPDocument.scala
@@ -28,7 +28,8 @@ object CoreNLPDocument {
     sentences: Array[Sentence],
     coref: Option[CorefChains],
     dtree: Option[DiscourseTree],
-    annotation: Option[Annotation]
+    annotation: Option[Annotation],
+    text: Option[String]
   ): CoreNLPDocument = {
     val coreDoc = new CoreNLPDocument(sentences)
     coreDoc.coreferenceChains = coref

--- a/src/main/scala/org/clulab/serialization/json/JSONSerializer.scala
+++ b/src/main/scala/org/clulab/serialization/json/JSONSerializer.scala
@@ -70,7 +70,7 @@ object JSONSerializer {
 
     // build Mention
     mjson \ "type" match {
-      case JString("EventMention") =>
+      case JString(EventMention.string) =>
         new EventMention(
           labels,
           // trigger must be TextBoundMention
@@ -81,7 +81,7 @@ object JSONSerializer {
           keep,
           foundBy
         )
-      case JString("RelationMention") =>
+      case JString(RelationMention.string) =>
         new RelationMention(
           labels,
           mkArgumentsFromJsonAST(mjson \ "arguments"),
@@ -90,9 +90,7 @@ object JSONSerializer {
           keep,
           foundBy
         )
-      // Assume TextBoundMention
-      //case JString("TextBoundMention") =>
-      case _ =>
+      case JString(TextBoundMention.string) =>
         new TextBoundMention(
           labels,
           tokInterval,
@@ -101,6 +99,7 @@ object JSONSerializer {
           keep,
           foundBy
         )
+      case other => throw new Exception(s"unrecognized mention type '${other.toString}'")
     }
   }
 
@@ -115,7 +114,6 @@ object JSONSerializer {
     d.text = getStringOption(json, "text")
     d
   }
-
   def toDocument(docHash: String, djson: JValue): Document = toDocument(djson \ docHash)
   def toDocument(f: File): Document = toDocument(jsonAST(f))
 

--- a/src/main/scala/org/clulab/serialization/json/JSONSerializer.scala
+++ b/src/main/scala/org/clulab/serialization/json/JSONSerializer.scala
@@ -87,14 +87,11 @@ object JSONSerializer {
               mnsjson: JArray <- something.extract[Map[String, JArray]].values
               mjson <- mnsjson.arr
               if (mjson \ "id").extract[String] == mentionID
-            //_ = println(s"mjson: ${pretty(render(mjson))}\n")
             } yield mjson
 
             argsjson.toList match {
               case Nil => None
-              case j :: _ =>
-                println(s"j: ${pretty(render(j))}\n")
-                Some(toMention(j, djson))
+              case j :: _ => Some(toMention(j, djson))
             }
         }
       }

--- a/src/main/scala/org/clulab/serialization/json/JSONSerializer.scala
+++ b/src/main/scala/org/clulab/serialization/json/JSONSerializer.scala
@@ -1,9 +1,10 @@
 package org.clulab.serialization.json
 
 import java.io.File
+import org.clulab.odin
 import org.clulab.odin._
 import org.clulab.processors.{Document, Sentence}
-import org.clulab.struct.{DirectedGraph, GraphMap, Interval}
+import org.clulab.struct.{DirectedGraph, Edge, GraphMap, Interval}
 import org.json4s.JsonDSL._
 import org.json4s._
 import org.json4s.native.JsonMethods._
@@ -68,14 +69,68 @@ object JSONSerializer {
       case e: org.json4s.MappingException => Map.empty[String, Seq[Mention]]
     }
 
+
+
+    /** Build mention paths from json */
+    def toPaths(json: JValue, djson: JValue): Map[String, Map[Mention, odin.SynPath]] = {
+
+      /** Create mention from args json for given id */
+      def findMention(mentionID: String, json: JValue, djson: JValue): Option[Mention] = {
+        // inspect arguments for matching ID
+        json \ "arguments" match {
+          // if we don't have arguments, we can't produce a Mention
+          case JNothing => None
+          // Ahoy! There be args!
+          case something =>
+            // flatten the Seq[Mention.jsonAST] for each arg
+            val argsjson: Iterable[JValue] = for {
+              mnsjson: JArray <- something.extract[Map[String, JArray]].values
+              mjson <- mnsjson.arr
+              if (mjson \ "id").extract[String] == mentionID
+            //_ = println(s"mjson: ${pretty(render(mjson))}\n")
+            } yield mjson
+
+            argsjson.toList match {
+              case Nil => None
+              case j :: _ =>
+                println(s"j: ${pretty(render(j))}\n")
+                Some(toMention(j, djson))
+            }
+        }
+      }
+
+      // build paths
+      json \ "paths" match {
+        case JNothing => Map.empty[String, Map[Mention, odin.SynPath]]
+        case contents => for {
+          (role, innermap) <- contents.extract[Map[String, Map[String, JValue]]]
+        } yield {
+          // make inner map (Map[Mention, odin.SynPath])
+          val pathMap = for {
+            (mentionID: String, pathJSON: JValue) <- innermap.toSeq
+            mOp = findMention(mentionID, json, djson)
+            // were we able to recover a mention?
+            if mOp.nonEmpty
+            m = mOp.get
+            edges: Seq[Edge[String]] = pathJSON.extract[Seq[Edge[String]]]
+            synPath: odin.SynPath = DirectedGraph.edgesToTriples[String](edges)
+          } yield m -> synPath
+          // marry role with (arg -> path) info
+          role -> pathMap.toMap
+        }
+      }
+    }
+
     // build Mention
     mjson \ "type" match {
       case JString(EventMention.string) =>
         new EventMention(
           labels,
+          tokInterval,
           // trigger must be TextBoundMention
           toMention(mjson \ "trigger", djson).asInstanceOf[TextBoundMention],
           mkArgumentsFromJsonAST(mjson \ "arguments"),
+          paths = toPaths(mjson, djson),
           sentence,
           document,
           keep,
@@ -84,7 +139,9 @@ object JSONSerializer {
       case JString(RelationMention.string) =>
         new RelationMention(
           labels,
+          tokInterval,
           mkArgumentsFromJsonAST(mjson \ "arguments"),
+          paths = toPaths(mjson, djson),
           sentence,
           document,
           keep,

--- a/src/main/scala/org/clulab/serialization/json/package.scala
+++ b/src/main/scala/org/clulab/serialization/json/package.scala
@@ -168,6 +168,7 @@ package object json {
 
     def jsonAST: JValue = {
       ("type" -> EventMention.string) ~
+      ("text" -> em.text) ~
       ("labels" -> em.labels) ~
       ("trigger" -> em.trigger.jsonAST) ~
       ("arguments" -> argsAST(em.arguments)) ~
@@ -207,6 +208,7 @@ package object json {
 
     def jsonAST: JValue = {
       ("type" -> RelationMention.string) ~
+      ("text" -> rm.text) ~
       ("labels" -> rm.labels) ~
       ("arguments" -> argsAST(rm.arguments)) ~
       ("tokenInterval" -> Map("start" -> rm.tokenInterval.start, "end" -> rm.tokenInterval.end)) ~

--- a/src/main/scala/org/clulab/struct/DirectedGraph.scala
+++ b/src/main/scala/org/clulab/struct/DirectedGraph.scala
@@ -250,6 +250,10 @@ object DirectedGraph {
     triple <- triples
   } yield Edge[E](source = triple._1, destination = triple._2, relation = triple._3)
 
+  def edgesToTriples[E](edges: Seq[Edge[E]]): Seq[(Int, Int, E)] = for {
+    edge <- edges
+  } yield (edge.source, edge.destination, edge.relation)
+
   /**
    * Constructs a graph from Stanford dependencies
    * Note: Stanford indices start at 1, so we will decrement all indices by 1


### PR DESCRIPTION
This is an amendment to #90 in which I've added more tests for `json` serialization/deserialization, as well as inclusion of paths for mentions produced by a graph-based pattern (i.e., rules over syntactic dependencies).  

@danebell requested we include the paths field to better understand how our dependency rules match.  Though its inclusion increases the size of the `Mention` `json`, I think it carries its weight in terms of utility.  

You can check out an example of this here in "paths" entry spanning lines 119-132 in `mentions.json`: https://gist.github.com/myedibleenso/87a3191c73938840b8ed768ec305db38#file-mentions-json 

I also updated the `CHANGES.md` as requested.