### PR TITLE
Document -> .jsonAST optimization for Seq[Mention]

### DIFF
--- a/src/main/scala/org/clulab/serialization/json/JSONSerializer.scala
+++ b/src/main/scala/org/clulab/serialization/json/JSONSerializer.scala
@@ -16,7 +16,12 @@ object JSONSerializer {
   implicit val formats = DefaultFormats
 
   def jsonAST(mentions: Seq[Mention]): JValue = {
-    val docsMap = mentions.map(m => m.document.equivalenceHash.toString -> m.document.jsonAST).toMap
+    val docsMap = mentions.toSet
+      // create a set of Documents
+      // in order to avoid calling jsonAST for duplicate docs
+      .map(m => m.document)
+      .map(doc => doc.equivalenceHash.toString -> doc.jsonAST)
+      .toMap
     val mentionList = JArray(mentions.map(_.jsonAST).toList)
 
     ("documents" -> docsMap) ~

--- a/src/main/scala/org/clulab/serialization/json/JSONSerializer.scala
+++ b/src/main/scala/org/clulab/serialization/json/JSONSerializer.scala
@@ -16,12 +16,13 @@ object JSONSerializer {
   implicit val formats = DefaultFormats
 
   def jsonAST(mentions: Seq[Mention]): JValue = {
-    val docsMap = mentions.toSet
+    val docsMap: Map[String, JValue] = {
       // create a set of Documents
       // in order to avoid calling jsonAST for duplicate docs
-      .map(m => m.document)
-      .map(doc => doc.equivalenceHash.toString -> doc.jsonAST)
-      .toMap
+      val docs: Set[Document] = mentions.map(m => m.document).toSet
+      docs.map(doc => doc.equivalenceHash.toString -> doc.jsonAST)
+        .toMap
+    }
     val mentionList = JArray(mentions.map(_.jsonAST).toList)
 
     ("documents" -> docsMap) ~


### PR DESCRIPTION
Another optimization for `json` serialization following #90, #91, and #92.  This avoids generating the json AST for duplicate documents by first creating a set of distinct documents.