### PR TITLE
Update build files to use released Bioresources 1.1.17.

### DIFF
--- a/corenlp/build.sbt
+++ b/corenlp/build.sbt
@@ -2,7 +2,7 @@ name := "processors-corenlp"
 
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "2.2.4" % "test",
-  "org.clulab" % "bioresources" % "1.1.15",
+  "org.clulab" % "bioresources" % "1.1.17",
   "com.io7m.xom" % "xom" % "1.2.10",
   "org.json4s" %% "json4s-native" % "3.2.11",
   "edu.stanford.nlp" % "stanford-corenlp" % "3.5.1",

--- a/main/build.sbt
+++ b/main/build.sbt
@@ -4,7 +4,7 @@ libraryDependencies ++= Seq(
   "org.scala-lang" % "scala-reflect" % scalaVersion.value,
   "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.3",
   "org.scalatest" %% "scalatest" % "2.2.4" % "test",
-  "org.clulab" % "bioresources" % "1.1.15",
+  "org.clulab" % "bioresources" % "1.1.17",
   "com.io7m.xom" % "xom" % "1.2.10",
   "org.json4s" %% "json4s-native" % "3.2.11",
   "ch.qos.logback" % "logback-classic" % "1.0.10",


### PR DESCRIPTION
Sync Processors with released version which Reach is already using.