### PR TITLE
Fixed bug related to ^ in lookbehinds

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 # Changes
++ **6.0.2** - Fixed odin bug related to` ^` in lookbehinds
 + **6.0.1** - Added support to odin for redefining variables.
 + **6.0.1** - Added support to odin for matching mention arguments.
 + **6.0.1** - Added support to odin for cross-sentence patterns.

--- a/main/src/main/scala/org/clulab/odin/impl/ThompsonVM.scala
+++ b/main/src/main/scala/org/clulab/odin/impl/ThompsonVM.scala
@@ -97,7 +97,7 @@ object ThompsonVM {
       case i: MatchToken if doc.sentences(sent).words.isDefinedAt(t.tok) && i.c.matches(t.tok, sent, doc, state) =>
         val nextTok = if (t.dir == LeftToRight) t.tok + 1 else t.tok - 1
         mkThreads(nextTok, i.next, t.dir, t.groups, t.mentions, t.partialGroups)
-      case i: MatchSentenceStart if t.tok == 0 =>
+      case i: MatchSentenceStart if (t.tok == 0) || (t.dir == RightToLeft && t.tok == -1) =>
         mkThreads(t.tok, i.next, t.dir, t.groups, t.mentions, t.partialGroups)
       case i: MatchSentenceEnd if t.tok == doc.sentences(sent).size =>
         mkThreads(t.tok, i.next, t.dir, t.groups, t.mentions, t.partialGroups)


### PR DESCRIPTION
We discovered a bug in Odin, where a `^` (sentence start) wasn't being recognized in a lookbehind (ex. `(?<= ^ Following []*? ",") @Event`).   You can see that the fix is a small one.  A test is included.