### PR TITLE
corenlp should depend on models

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -74,7 +74,7 @@ lazy val main = project
 
 lazy val corenlp = project
   .settings(commonSettings: _*)
-  .dependsOn(main % "test->test;compile->compile", models % "test")
+  .dependsOn(main % "test->test;compile->compile", models)
 
 lazy val models = project
   .settings(commonSettings: _*)


### PR DESCRIPTION
The `corenlp` subproject now depends on `models` and `main` for compilation and tests.