### PR TITLE
Close file after reading

### DIFF
--- a/main/src/main/scala/org/clulab/serialization/json/JSONSerializer.scala
+++ b/main/src/main/scala/org/clulab/serialization/json/JSONSerializer.scala
@@ -29,7 +29,12 @@ object JSONSerializer {
     ("mentions" -> mentionList)
   }
 
-  def jsonAST(f: File): JValue = parse(scala.io.Source.fromFile(f).getLines.mkString)
+  def jsonAST(f: File): JValue = {
+    val source = scala.io.Source.fromFile(f)
+    val contents = source.getLines.mkString
+    source.close()
+    parse(contents)
+  }
 
   /** Produce a sequence of mentions from json */
   def toMentions(json: JValue): Seq[Mention] = {


### PR DESCRIPTION
This corrects a bug in the `json` serialization code where a read file was not being closed.  