### PR TITLE
Remove Phase3 override file to phase3 branch only.

### DIFF
--- a/corenlp/src/main/scala/org/clulab/processors/bionlp/ner/KBLoader.scala
+++ b/corenlp/src/main/scala/org/clulab/processors/bionlp/ner/KBLoader.scala
@@ -14,7 +14,7 @@ import scala.collection.mutable.{ListBuffer, ArrayBuffer}
   * Loads the KBs from bioresources under org/clulab/reach/kb/ner
   * These must be generated offline by KBGenerator; see bioresources/ner_kb.sh
   * User: mihais. 2/7/16.
-  * Last Modified: Begin adding Phase3 override file.
+  * Last Modified: Remove Phase3 override file to phase3 branch only.
   */
 object KBLoader {
   val logger = LoggerFactory.getLogger(classOf[BioNLPProcessor])
@@ -37,7 +37,6 @@ object KBLoader {
   )
 
   val NER_OVERRIDE_KBS = List(
-    "org/clulab/reach/kb/Phase3-Override.tsv.gz",
     "org/clulab/reach/kb/NER-Grounding-Override.tsv.gz"
   )
 


### PR DESCRIPTION
We agreed not to depend on MITRE Phase3 override files since they conflict with other collaborator's judgements, but the master branch was accidentally contaminated some time back. This change relegates the Phase3 override file to the `phase3` branch only.