### PR TITLE
Add and use config file in Processors

### DIFF
--- a/corenlp/build.sbt
+++ b/corenlp/build.sbt
@@ -2,8 +2,10 @@ name := "processors-corenlp"
 
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "2.2.4" % "test",
+  "ai.lum" %% "common" % "0.0.7",
   "org.clulab" % "bioresources" % "1.1.21",
   "com.io7m.xom" % "xom" % "1.2.10",
+  "com.typesafe" % "config" % "1.2.1",
   "org.json4s" %% "json4s-native" % "3.2.11",
   "edu.stanford.nlp" % "stanford-corenlp" % "3.5.1",
   "edu.stanford.nlp" % "stanford-corenlp" % "3.5.1" classifier "models",

--- a/corenlp/src/main/resources/reference.conf
+++ b/corenlp/src/main/resources/reference.conf
@@ -34,5 +34,5 @@ kbloader: {
   ],
 
   # File to keep track of entities that should not be labeled if they are lowercase or initial upper case. */
-  stopListfile: "org/clulab/reach/kb/ner_stoplist.txt"
+  stopListFile: "org/clulab/reach/kb/ner_stoplist.txt"
 }

--- a/corenlp/src/main/resources/reference.conf
+++ b/corenlp/src/main/resources/reference.conf
@@ -1,0 +1,38 @@
+#
+# Configuration file for the corenlp branch of the Processors library.
+#
+
+# Configuration for the knowledge base loading/processing code:
+kbloader: {
+  # List of NER entity labeling files to be read by the NER.
+  # NB: Order is important as it indicates priority!
+  nerKBs: [
+    "org/clulab/reach/kb/ner/Gene_or_gene_product.tsv.gz",
+    "org/clulab/reach/kb/ner/Family.tsv.gz",
+    "org/clulab/reach/kb/ner/Cellular_component.tsv.gz",
+    "org/clulab/reach/kb/ner/Simple_chemical.tsv.gz",
+    "org/clulab/reach/kb/ner/Site.tsv.gz",
+    "org/clulab/reach/kb/ner/BioProcess.tsv.gz",
+    "org/clulab/reach/kb/ner/Species.tsv.gz",
+    "org/clulab/reach/kb/ner/CellLine.tsv.gz",
+    "org/clulab/reach/kb/ner/TissueType.tsv.gz",
+    "org/clulab/reach/kb/ner/CellType.tsv.gz",
+    "org/clulab/reach/kb/ner/Organ.tsv.gz"
+  ],
+
+  # List of NER/grounding override files for NER to process, in order.
+  # NB: The overrides used here affect the grounding results in the Reach project.
+  overrides: [
+    # "org/clulab/reach/kb/Phase3-Override.tsv.gz",
+    "org/clulab/reach/kb/NER-Grounding-Override.tsv.gz"
+  ],
+
+  # List of KB files which receive special handling by the tokenizer to avoid overly-aggressive tokenization.
+  unslashables: [
+    "org/clulab/reach/kb/ProteinFamilies.tsv.gz",
+    "org/clulab/reach/kb/PFAM-families.tsv.gz"
+  ],
+
+  # File to keep track of entities that should not be labeled if they are lowercase or initial upper case. */
+  stopListfile: "org/clulab/reach/kb/ner_stoplist.txt"
+}


### PR DESCRIPTION
Added reference.conf file to corenlp arm of Processors. Configured it for several KBLoader variables.

This addresses issues #130 and #131.