### PR TITLE
Issue 487: try to fix lib clash

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,3 +1,3 @@
--J-Xmx6G
+-J-Xmx5G
 -J-XX:+CMSClassUnloadingEnabled
 -J-XX:+UseConcMarkSweepGC

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 # Changes
++ **6.0.4** - Use consistent SBT version across projects. Fix lib clash: allow ai.lum.common to dicate typesafe.config version.
 + **6.0.3** - Added FastBioNLPProcessor. Update for Bioresources 1.1.22 containing updated MITRE Phase3 override KB.
 + **6.0.3** - The rule NER is now a singleton object, so it can be shared between different processor objects.
 + **6.0.3** - Remove use of Phase3 override file to phase3 branch only.

--- a/corenlp/build.sbt
+++ b/corenlp/build.sbt
@@ -5,7 +5,6 @@ libraryDependencies ++= Seq(
   "ai.lum" %% "common" % "0.0.7",
   "org.clulab" % "bioresources" % "1.1.22",
   "com.io7m.xom" % "xom" % "1.2.10",
-  "com.typesafe" % "config" % "1.2.1",
   "org.json4s" %% "json4s-native" % "3.2.11",
   "edu.stanford.nlp" % "stanford-corenlp" % "3.5.1",
   "edu.stanford.nlp" % "stanford-corenlp" % "3.5.1" classifier "models",


### PR DESCRIPTION
allow ai.lum.common to dicate typesafe.config version. Also reduced test memory to 5G to try to avoid Travis failure.