### PR TITLE
json4s version bump

### DIFF
--- a/main/build.sbt
+++ b/main/build.sbt
@@ -6,7 +6,8 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "2.2.4" % "test",
   "org.clulab" % "bioresources" % "1.1.22",
   "com.io7m.xom" % "xom" % "1.2.10",
-  "org.json4s" %% "json4s-native" % "3.2.11",
+  "org.json4s" %% "json4s-core" % "3.5.0",
+  "org.json4s" %% "json4s-native" % "3.5.0",
   "ch.qos.logback" % "logback-classic" % "1.0.10",
   "org.slf4j" % "slf4j-api" % "1.7.10",
   "log4j" % "log4j" % "1.2.17", // this is used by our maltparser clone; otherwise not in use

--- a/main/src/main/scala/org/clulab/serialization/json/package.scala
+++ b/main/src/main/scala/org/clulab/serialization/json/package.scala
@@ -15,13 +15,17 @@ import scala.util.hashing.MurmurHash3._
 
 package object json {
 
+  /** Method for debugging json */
+  def stringify(json: JValue, pretty: Boolean): String = pretty match {
+    case true => prettyJson(renderJValue(json))
+    case false => compactJson(renderJValue(json))
+  }
+
   trait JSONSerialization {
 
     def jsonAST: JValue
 
-    def json(pretty: Boolean = false): String =
-      if (pretty) prettyJson(renderJValue(jsonAST))
-      else compactJson(renderJValue(jsonAST))
+    def json(pretty: Boolean = false): String = stringify(jsonAST, pretty)
 
   }
 


### PR DESCRIPTION
I've just upgraded the version of `json4s` and added a convenience method for `JValue` -> `json` string that is useable by thing not using the `JSONSerialization` trait.