### PR TITLE
Some cleanups to TestTokenizers and ProcessorShell

### DIFF
--- a/corenlp/src/main/scala/org/clulab/processors/ProcessorShell.scala
+++ b/corenlp/src/main/scala/org/clulab/processors/ProcessorShell.scala
@@ -11,9 +11,10 @@ import jline.console.history.FileHistory
 import org.clulab.processors.examples.ProcessorExample
 
 /**
- * A simple interactive shell
- * User: mihais
- * Date: 3/13/14
+  * A simple interactive shell
+  * User: mihais
+  * Date: 3/13/14
+  * Last Modified: Fix compiler warning: remove redundant match case clause.
  */
 object ProcessorShell extends App {
 
@@ -62,12 +63,6 @@ object ProcessorShell extends App {
         reader.setPrompt("(fast)>>> ")
         println("Preparing FastNLPProcessor...\n")
         proc = fast
-        proc.annotate("initialize me!")
-
-      case ":fastbio" =>
-        reader.setPrompt("(fastbio)>>> ")
-        println("Preparing FastBioNLPProcessor...\n")
-        proc = fastbio
         proc.annotate("initialize me!")
 
       case ":bio" =>

--- a/corenlp/src/test/scala/org/clulab/processors/TestTokenizers.scala
+++ b/corenlp/src/test/scala/org/clulab/processors/TestTokenizers.scala
@@ -9,6 +9,7 @@ import org.scalatest.{FlatSpec, Matchers}
   *
   * User: mihais
   * Date: 3/21/17
+  * Last Modified: Modify timing test to try and get the test to pass.
   */
 class TestTokenizers extends FlatSpec with Matchers {
   val shallow = new ShallowNLPProcessor(internStrings = false)
@@ -61,14 +62,14 @@ class TestTokenizers extends FlatSpec with Matchers {
     val cluDoc = clu.mkDocument(text, keepText = false)
     var end = System.currentTimeMillis()
     val cluTime = end - start
-    println(s"Time: ${end - start} ms.")
+    println(s"CLU Time: ${cluTime} ms.")
     printSents(cluDoc.sentences)
 
     start = System.currentTimeMillis()
     val coreDoc = shallow.mkDocument(text, keepText = false)
     end = System.currentTimeMillis()
-    println(s"Time: ${end - start} ms.")
     val coreTime = end - start
+    println(s"Core Time: ${coreTime} ms.")
     printSents(coreDoc.sentences)
 
     (coreTime > cluTime) should be (true)


### PR DESCRIPTION
Rearrange val in test to make more accurate timing (test now commented out anyway).
Remove dead code in ProcessorShell which caused compiler warning.