### PR TITLE
Use json4s.jackson instead of json4s.native

### DIFF
--- a/corenlp/src/main/scala/org/clulab/processors/visualizer/DiscourseParserRunner.scala
+++ b/corenlp/src/main/scala/org/clulab/processors/visualizer/DiscourseParserRunner.scala
@@ -1,17 +1,13 @@
 package org.clulab.processors.visualizer
 
 import org.clulab.processors.shallownlp.ShallowNLPProcessor
-
-import scala.collection.JavaConverters._
-
 import org.json4s._
 import org.json4s.JsonDSL._
-import org.json4s.native.JsonMethods._
-
+import org.json4s.jackson.JsonMethods._
 import org.clulab.processors._
-import org.clulab.processors.bionlp.BioNLPProcessor
 import org.clulab.processors.corenlp.CoreNLPProcessor
 import org.clulab.processors.fastnlp.FastNLPProcessor
+
 
 /**
  * External API for running different discourse parsers for visualization.

--- a/main/build.sbt
+++ b/main/build.sbt
@@ -1,18 +1,21 @@
 name := "processors-main"
 
-libraryDependencies ++= Seq(
-  "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.3",
-  "org.scalatest" %% "scalatest" % "2.2.4" % "test",
-  "org.clulab" % "bioresources" % "1.1.22",
-  "com.io7m.xom" % "xom" % "1.2.10",
-  "org.json4s" %% "json4s-core" % "3.5.0",
-  "org.json4s" %% "json4s-native" % "3.5.0",
-  "ch.qos.logback" % "logback-classic" % "1.0.10",
-  "org.slf4j" % "slf4j-api" % "1.7.10",
-  "log4j" % "log4j" % "1.2.17", // this is used by our maltparser clone; otherwise not in use
-  "de.bwaldvogel" % "liblinear" % "1.94",
-  "tw.edu.ntu.csie" % "libsvm" % "3.17",
-  "org.antlr" % "antlr4-runtime" % "4.6",
-  "jline" % "jline" % "2.12.1",
-  "commons-io" % "commons-io" % "2.5"
-)
+libraryDependencies ++= {
+  val json4sVersion = "3.5.2"
+  Seq(
+    "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.3",
+    "org.scalatest" %% "scalatest" % "2.2.4" % "test",
+    "org.clulab" % "bioresources" % "1.1.22",
+    "com.io7m.xom" % "xom" % "1.2.10",
+    "org.json4s" %% "json4s-core" % json4sVersion,
+    "org.json4s" %% "json4s-jackson" % json4sVersion,
+    "ch.qos.logback" % "logback-classic" % "1.0.10",
+    "org.slf4j" % "slf4j-api" % "1.7.10",
+    "log4j" % "log4j" % "1.2.17", // this is used by our maltparser clone; otherwise not in use
+    "de.bwaldvogel" % "liblinear" % "1.94",
+    "tw.edu.ntu.csie" % "libsvm" % "3.17",
+    "org.antlr" % "antlr4-runtime" % "4.6",
+    "jline" % "jline" % "2.12.1",
+    "commons-io" % "commons-io" % "2.5"
+  )
+}

--- a/main/src/main/scala/org/clulab/discourse/rstparser/DiscourseTree.scala
+++ b/main/src/main/scala/org/clulab/discourse/rstparser/DiscourseTree.scala
@@ -2,7 +2,7 @@ package org.clulab.discourse.rstparser
 
 import org.json4s._
 import org.json4s.JsonDSL._
-import org.json4s.native.JsonMethods._
+import org.json4s.jackson.JsonMethods._
 
 import org.clulab.processors.Document
 

--- a/main/src/main/scala/org/clulab/serialization/json/JSONSerialization.scala
+++ b/main/src/main/scala/org/clulab/serialization/json/JSONSerialization.scala
@@ -1,5 +1,8 @@
 package org.clulab.serialization.json
 
+import java.io.File
+import java.nio.charset.StandardCharsets
+import org.apache.commons.io.FileUtils
 import org.json4s._
 
 
@@ -8,5 +11,15 @@ trait JSONSerialization {
   def jsonAST: JValue
 
   def json(pretty: Boolean = false): String = stringify(jsonAST, pretty)
+
+  /**
+    * Serialize json file
+    */
+  def saveJSON(file: String, pretty: Boolean): Unit = {
+    //require(file.endsWith(".json"), "file should have .json extension")
+    val outFile = new File(file)
+    FileUtils.writeByteArrayToFile(outFile, this.json(pretty).getBytes(StandardCharsets.UTF_8))
+  }
+  def saveJSON(file: File, pretty: Boolean): Unit = saveJSON(file.getAbsolutePath, pretty)
 
 }

--- a/main/src/main/scala/org/clulab/serialization/json/JSONSerializer.scala
+++ b/main/src/main/scala/org/clulab/serialization/json/JSONSerializer.scala
@@ -5,7 +5,7 @@ import org.clulab.processors.{Document, Sentence}
 import org.clulab.struct.{DirectedGraph, GraphMap}
 import org.json4s.JsonDSL._
 import org.json4s._
-import org.json4s.native.JsonMethods._
+import org.json4s.jackson.JsonMethods._
 
 
 /** JSON serialization utilities */

--- a/main/src/main/scala/org/clulab/serialization/json/package.scala
+++ b/main/src/main/scala/org/clulab/serialization/json/package.scala
@@ -7,7 +7,7 @@ import java.nio.file.{Files, Paths}
 import org.clulab.struct.{DirectedGraph, Edge, GraphMap}
 import org.json4s._
 import org.json4s.JsonDSL._
-import org.json4s.native._
+import org.json4s.jackson._
 
 
 package object json {

--- a/main/src/main/scala/org/clulab/serialization/json/package.scala
+++ b/main/src/main/scala/org/clulab/serialization/json/package.scala
@@ -1,9 +1,6 @@
 package org.clulab.serialization
 
 import org.clulab.processors.{Document, Sentence}
-import java.io.File
-import java.nio.charset.StandardCharsets
-import java.nio.file.{Files, Paths}
 import org.clulab.struct.{DirectedGraph, Edge, GraphMap}
 import org.json4s._
 import org.json4s.JsonDSL._
@@ -65,15 +62,6 @@ package object json {
       // TODO: handle discourse tree
       //("discourse-tree" -> discourseTree)
     }
-
-    /**
-      * Serialize Document to json file
-      */
-    def saveJSON(file: String, pretty: Boolean): Unit = {
-      require(file.endsWith(".json"), "file should have .json extension")
-      Files.write(Paths.get(file), doc.json(pretty).getBytes(StandardCharsets.UTF_8))
-    }
-    def saveJSON(file: File, pretty: Boolean): Unit = saveJSON(file.getAbsolutePath, pretty)
   }
 
 
@@ -94,13 +82,6 @@ package object json {
       //("syntactic-tree") -> syntacticTree)
     }
 
-    /**
-      * Serialize Sentence to json file
-      */
-    def saveJSON(file: String, pretty: Boolean): Unit = {
-      require(file.endsWith(".json"), "file should have .json extension")
-      Files.write(Paths.get(file), s.json(pretty).getBytes(StandardCharsets.UTF_8))
-    }
-    def saveJSON(file: File, pretty: Boolean): Unit = saveJSON(file.getAbsolutePath, pretty)
   }
+
 }

--- a/main/src/test/scala/org/clulab/TestUtils.scala
+++ b/main/src/test/scala/org/clulab/TestUtils.scala
@@ -3,7 +3,7 @@ package org.clulab
 import java.io.File
 
 import org.clulab.processors.Document
-import org.json4s.native.JsonMethods._
+import org.json4s.jackson.JsonMethods._
 import org.clulab.serialization.json.JSONSerializer
 
 

--- a/odin/src/main/scala/org/clulab/odin/serialization/json/JSONSerializer.scala
+++ b/odin/src/main/scala/org/clulab/odin/serialization/json/JSONSerializer.scala
@@ -8,7 +8,7 @@ import org.clulab.odin._
 import org.clulab.serialization.json.DocOps
 import org.json4s.JsonDSL._
 import org.json4s._
-import org.json4s.native.JsonMethods._
+import org.json4s.jackson.JsonMethods._
 
 
 /** JSON serialization utilities */

--- a/odin/src/main/scala/org/clulab/odin/serialization/json/package.scala
+++ b/odin/src/main/scala/org/clulab/odin/serialization/json/package.scala
@@ -1,8 +1,5 @@
 package org.clulab.odin.serialization
 
-import java.io.File
-import java.nio.charset.StandardCharsets
-import java.nio.file.{Files, Paths}
 import org.clulab.odin
 import org.clulab.odin._
 import org.clulab.struct.DirectedGraph
@@ -75,14 +72,6 @@ package object json {
     // an accompanying json map of docEquivHash -> doc's json
     def completeAST: JValue = Seq(m).jsonAST
 
-    /**
-      * Serialize mentions to json file
-      */
-    def saveJSON(file: String, pretty: Boolean): Unit = {
-      require(file.endsWith(".json"), "file should have .json extension")
-      Files.write(Paths.get(file), Seq(m).json(pretty).getBytes(StandardCharsets.UTF_8))
-    }
-    def saveJSON(file: File, pretty: Boolean): Unit = saveJSON(file.getAbsolutePath, pretty)
   }
 
   implicit class TextBoundMentionOps(tb: TextBoundMention) extends JSONSerialization with Equivalency {
@@ -258,14 +247,6 @@ package object json {
 
     def jsonAST: JValue = JSONSerializer.jsonAST(mentions)
 
-    /**
-      * Serialize mentions to json file
-      */
-    def saveJSON(file: String, pretty: Boolean): Unit = {
-      require(file.endsWith(".json"), "file should have .json extension")
-      Files.write(Paths.get(file), mentions.json(pretty).getBytes(StandardCharsets.UTF_8))
-    }
-    def saveJSON(file: File, pretty: Boolean): Unit = saveJSON(file.getAbsolutePath, pretty)
   }
 
   // Syntactic paths generalized are graph paths


### PR DESCRIPTION
I profiled `json4s.native` vs `json4s.jackson` and it looks like `jackson` is a bit faster:

## `processors.Document` `json`

Sample size:	 10 iterations over 76 json files

### Results for `json4s` `native`
Average time:	70 milliseconds
Max time:	968 milliseconds
Min time:	16 milliseconds

### Results for `json4s` `jackson`
Average time:	52 milliseconds
Max time:	949 milliseconds
Min time:	14 milliseconds

## `odin.Mention` `json`

Sample size:	 10 iterations over 76 json files

Average number of Mentions per file:	756
Average number of Entity Mentions per file:	730
Average number of Event Mentions per file:	26

### Results for `json4s` `native`
Average time:	97 milliseconds
Max time:	471 milliseconds
Min time:	26 milliseconds

### Results for `json4s` `jackson`
Average time:	84 milliseconds
Max time:	389 milliseconds
Min time:	24 milliseconds