### PR TITLE
Update to support both 2.12 and 2.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,8 @@ import ReleaseTransformations._
 
 lazy val commonSettings = Seq(
   organization := "org.clulab",
-  scalaVersion := "2.11.8",
+  scalaVersion := "2.11.11",
+  crossScalaVersions := Seq("2.11.11", "2.12.3"),
   scalacOptions ++= Seq("-feature", "-unchecked", "-deprecation"),
   parallelExecution in Test := false,
   scalacOptions in (Compile, doc) += "-no-link-warnings", // suppresses problems with scaladoc @throws links

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,8 @@ import ReleaseTransformations._
 
 lazy val commonSettings = Seq(
   organization := "org.clulab",
-  scalaVersion := "2.11.11",
+  //scalaVersion := "2.11.11",
+  scalaVersion := "2.12.3",
   crossScalaVersions := Seq("2.11.11", "2.12.3"),
   scalacOptions ++= Seq("-feature", "-unchecked", "-deprecation"),
   parallelExecution in Test := false,

--- a/build.sbt
+++ b/build.sbt
@@ -93,13 +93,13 @@ releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,
   inquireVersions,
   runClean,
-  runTest,
+  releaseStepCommandAndRemaining("+test"),
   setReleaseVersion,
   commitReleaseVersion,
   tagRelease,
-  ReleaseStep(action = Command.process("publishSigned", _)),
+  releaseStepCommandAndRemaining("+publishSigned"),
   setNextVersion,
   commitNextVersion,
-  ReleaseStep(action = Command.process("sonatypeReleaseAll", _)),
+  releaseStepCommandAndRemaining("sonatypeReleaseAll"),
   pushChanges
 )

--- a/corenlp/build.sbt
+++ b/corenlp/build.sbt
@@ -3,7 +3,7 @@ name := "processors-corenlp"
 libraryDependencies ++= {
   val akkaV = "2.5.4"
   Seq (
-    "ai.lum"             %%  "common"            % "0.0.8-SNAPSHOT",
+    "ai.lum"             %%  "common"            % "0.0.8",
     "edu.stanford.nlp"    %  "stanford-corenlp"  % "3.5.1",
     "edu.stanford.nlp"    %  "stanford-corenlp"  % "3.5.1" classifier "models",
     "org.clulab"          %  "bioresources"      % "1.1.24",

--- a/corenlp/build.sbt
+++ b/corenlp/build.sbt
@@ -3,13 +3,13 @@ name := "processors-corenlp"
 libraryDependencies ++= {
   val akkaV = "2.5.4"
   Seq (
-    "ai.lum"             %%  "common"            % "0.0.7",
+    "ai.lum"             %%  "common"            % "0.0.8-SNAPSHOT",
     "edu.stanford.nlp"    %  "stanford-corenlp"  % "3.5.1",
     "edu.stanford.nlp"    %  "stanford-corenlp"  % "3.5.1" classifier "models",
     "org.clulab"          %  "bioresources"      % "1.1.24",
 
     // logging
-    "com.typesafe.scala-logging"  %%  "scala-logging"    % "3.4.0",
+    "com.typesafe.scala-logging"  %%  "scala-logging"    % "3.7.2",
     "ch.qos.logback"               %  "logback-classic"  % "1.0.10",
     "org.slf4j"                    %  "slf4j-api"        % "1.7.10",
 

--- a/main/build.sbt
+++ b/main/build.sbt
@@ -3,8 +3,8 @@ name := "processors-main"
 libraryDependencies ++= {
   val json4sVersion = "3.5.2"
   Seq(
-    "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.3",
-    "org.scalatest" %% "scalatest" % "2.2.4" % "test",
+    "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4",
+    "org.scalatest" %% "scalatest" % "3.0.1" % "test",
     "org.clulab" % "bioresources" % "1.1.24",
     "com.io7m.xom" % "xom" % "1.2.10",
     "org.json4s" %% "json4s-core" % json4sVersion,

--- a/main/src/main/scala/org/clulab/processors/clu/syntax/EnsembleModel.scala
+++ b/main/src/main/scala/org/clulab/processors/clu/syntax/EnsembleModel.scala
@@ -63,22 +63,17 @@ class EnsembleModel(val individualOutputs:Array[DirectedGraph[String]]) {
     val depMap = toDependencyMap(individualOutputs)
 
     // create the actual dependency list
-    val l = new ListBuffer[Dependency]
-    for(depKey <- depMap.keySet) {
-      val votes = depMap.get(depKey)
-      assert(votes.nonEmpty)
-      val dep = Dependency(depKey._1, depKey._2, depKey._3, votes.get.toSet)
-      l += dep
-    }
-
-    l.toList
+    depMap.map {
+      case (depKey, votes) =>
+        Dependency(depKey._1, depKey._2, depKey._3, votes.toSet)
+    }(collection.breakOut)
   }
 
   def toDirectedGraph(deps:List[Dependency]):DirectedGraph[String] = {
     val edges = new ListBuffer[Edge[String]]
     val roots = new mutable.HashSet[Int]()
 
-    for(dep <- deps) {
+    deps.foreach { dep =>
       if(dep.head == 0) {
         assert(dep.modifier > 0)
         roots += dep.modifier - 1
@@ -87,6 +82,7 @@ class EnsembleModel(val individualOutputs:Array[DirectedGraph[String]]) {
         assert(dep.head > 0)
         edges += Edge[String](dep.head - 1, dep.modifier - 1, dep.label)
       }
+      ()
     }
 
     new DirectedGraph[String](edges.toList, roots.toSet)

--- a/main/src/main/scala/org/clulab/processors/clu/syntax/MaltUtils.scala
+++ b/main/src/main/scala/org/clulab/processors/clu/syntax/MaltUtils.scala
@@ -51,6 +51,7 @@ object MaltUtils {
       } else {
         edgeBuffer += Edge(source = head, destination = modifier, relation = in(label, internStrings))
       }
+      ()
     }
 
     new DirectedGraph[String](edgeBuffer.toList, roots.toSet)

--- a/main/src/main/scala/org/clulab/swirl2/Reader.scala
+++ b/main/src/main/scala/org/clulab/swirl2/Reader.scala
@@ -176,6 +176,7 @@ class Reader {
         edges += new Tuple3(head, modifier, tokens(modifier).dep._2)
       else
         roots += modifier
+      ()
     }
     DirectedGraph[String](DirectedGraph.triplesToEdges[String](edges.toList), roots.toSet)
   }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.16

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.4")


### PR DESCRIPTION
I made a couple non-functional changes, but then decided to not do the rest.  I would be happy to help, just wanted to make sure I was going down the right path.  With this command `release` will handle both `2.11` and `2.12`.  It's pinned to a SNAPSHOT of lum-ai/common, which I submitted a pr for https://github.com/lum-ai/common/pull/2