### PR TITLE
Redo uses of io.Source which confused compiler.

### DIFF
--- a/corenlp/src/main/scala/org/clulab/processors/BioNLPProcessorFile.scala
+++ b/corenlp/src/main/scala/org/clulab/processors/BioNLPProcessorFile.scala
@@ -1,6 +1,7 @@
 package org.clulab.processors
 
 import java.io.PrintWriter
+import scala.io.Source
 
 import org.clulab.processors.bionlp.BioNLPProcessor
 import org.clulab.serialization.DocumentSerializer
@@ -9,6 +10,7 @@ import org.clulab.serialization.DocumentSerializer
  * Runs BioNLPProcessor on a single text file. The output is serialized in a .ser output file.
  * User: mihais
  * Date: 12/8/14
+ * Last Modified: Fix compiler issue: import scala.io.Source.
  */
 object BioNLPProcessorFile {
   def main(args:Array[String]) {
@@ -20,7 +22,7 @@ object BioNLPProcessorFile {
 
       val outputFile = inputFile + ".ser"
 
-      val content = io.Source.fromFile(inputFile).getLines().mkString("\n")
+      val content = Source.fromFile(inputFile).getLines().mkString("\n")
       println(s"Processing file with name ${inputFile}, containing ${content.size} characters...")
       val doc = proc.annotate(content)
 

--- a/corenlp/src/main/scala/org/clulab/processors/BioNLPProcessorFilesByLine.scala
+++ b/corenlp/src/main/scala/org/clulab/processors/BioNLPProcessorFilesByLine.scala
@@ -2,16 +2,18 @@ package org.clulab.processors
 
 import java.io.{File, PrintWriter}
 
+import scala.io.Source
+import scala.collection.mutable.ListBuffer
+
 import org.clulab.processors.bionlp.BioNLPProcessor
 import org.clulab.serialization.DocumentSerializer
 import org.clulab.utils.Files
-
-import scala.collection.mutable.ListBuffer
 
 /**
  * Runs BioNLPProcessor on a bunch of files, where each file stores one sentence per line
  * User: mihais
  * Date: 12/5/14
+ * Last Modified: Fix compiler issue: import scala.io.Source.
  */
 object BioNLPProcessorFilesByLine {
   val EXT = "sents" // extension of files to be processed
@@ -39,7 +41,7 @@ object BioNLPProcessorFilesByLine {
 
   def fileToSentences(file:File):List[String] = {
     val sents = new ListBuffer[String]
-    io.Source.fromFile(file).getLines().foreach(sents += _)
+    Source.fromFile(file).getLines().foreach(sents += _)
     sents.toList
   }
 }

--- a/corenlp/src/main/scala/org/clulab/processors/bionlp/ner/CRFNER.scala
+++ b/corenlp/src/main/scala/org/clulab/processors/bionlp/ner/CRFNER.scala
@@ -2,30 +2,31 @@ package org.clulab.processors.bionlp.ner
 
 import java.util
 import java.util.Properties
+import java.util.{List => JavaList}
 
-import org.clulab.processors.{Processor, Sentence}
-import org.clulab.processors.bionlp.{BioNLPPOSTaggerPostProcessor, BioNLPProcessor}
-import org.clulab.utils.StringUtils
+import org.slf4j.LoggerFactory
+
+import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
+import scala.collection.mutable.ListBuffer
+import scala.io.{ Source, StdIn }
+
 import edu.stanford.nlp.ie.crf.CRFClassifier
 import edu.stanford.nlp.ling.CoreAnnotations.AnswerAnnotation
 import edu.stanford.nlp.ling.CoreLabel
 
-import scala.collection.JavaConversions._
-import scala.collection.JavaConverters._
-import java.util.{List => JavaList}
-
-import org.slf4j.LoggerFactory
-import CRFNER._
+import org.clulab.processors.{Processor, Sentence}
+import org.clulab.processors.bionlp.{BioNLPPOSTaggerPostProcessor, BioNLPProcessor}
 import org.clulab.sequences.SeqScorer
+import org.clulab.utils.StringUtils
 
-import scala.collection.mutable.ListBuffer
-import scala.io.StdIn
-
+import CRFNER._
 
 /**
  * Our own BIO NER trained on the BioCreative 2 dataset, using the Stanford CRF
  * User: mihais
  * Date: 2/27/15
+ * Last Modified: Fix compiler issue: import scala.io.Source.
  */
 class CRFNER {
   var crfClassifier:Option[CRFClassifier[CoreLabel]] = None
@@ -86,7 +87,7 @@ object CRFNER {
     val sentences = new util.ArrayList[JavaList[CoreLabel]]()
     var crtSentence = new util.ArrayList[CoreLabel]()
     var totalTokens = 0
-    for (line <- io.Source.fromFile(path).getLines()) {
+    for (line <- Source.fromFile(path).getLines()) {
       val trimmed = line.trim
       if (trimmed.isEmpty) {
         if (crtSentence.size() > 0) {

--- a/corenlp/src/main/scala/org/clulab/processors/bionlp/ner/KBGenerator.scala
+++ b/corenlp/src/main/scala/org/clulab/processors/bionlp/ner/KBGenerator.scala
@@ -5,15 +5,17 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.zip.{GZIPInputStream, GZIPOutputStream}
 
-import org.clulab.processors.bionlp.BioNLPProcessor
-import edu.stanford.nlp.ling.CoreAnnotations.TokensAnnotation
-import edu.stanford.nlp.pipeline.Annotation
-import org.clulab.processors.shallownlp.ShallowNLPProcessor
-import org.slf4j.{Logger, LoggerFactory}
-
 import scala.collection.mutable
 import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 import scala.collection.JavaConverters._
+import scala.io.Source
+
+import edu.stanford.nlp.ling.CoreAnnotations.TokensAnnotation
+import edu.stanford.nlp.pipeline.Annotation
+
+import org.clulab.processors.bionlp.BioNLPProcessor
+import org.clulab.processors.shallownlp.ShallowNLPProcessor
+import org.slf4j.{Logger, LoggerFactory}
 
 case class KBEntry(kbName:String, neLabel:String, validSpecies:Set[String])
 
@@ -21,7 +23,7 @@ case class KBEntry(kbName:String, neLabel:String, validSpecies:Set[String])
   * This is used in bioresources to format the data into a format that is easy to load at runtime
   * User: mihais
   * Date: 2/7/16
-  * Last Modified: Update for 5-column NER override file format.
+  * Last Modified: Fix compiler issue: import scala.io.Source.
   */
 object KBGenerator {
   val logger: Logger = LoggerFactory.getLogger(classOf[BioNLPProcessor])
@@ -61,7 +63,7 @@ object KBGenerator {
 
   def loadConfig(configFile:String):Seq[KBEntry] = {
     val entries = new ListBuffer[KBEntry]
-    for(line <- io.Source.fromFile(configFile).getLines()) {
+    for(line <- Source.fromFile(configFile).getLines()) {
       val trimmedLine = line.trim
       if(! trimmedLine.isEmpty && ! trimmedLine.startsWith("#")) {
         val tokens = trimmedLine.split("\t")

--- a/corenlp/src/main/scala/org/clulab/processors/corenlp/chunker/TrainChunker.scala
+++ b/corenlp/src/main/scala/org/clulab/processors/corenlp/chunker/TrainChunker.scala
@@ -3,6 +3,7 @@ package org.clulab.processors.corenlp.chunker
 import java.io.FileInputStream
 import java.util.zip.GZIPInputStream
 import scala.collection.mutable
+import scala.io.Source
 import edu.stanford.nlp.ling.{ CoreLabel, CoreAnnotations }
 
 object TrainChunker extends App {
@@ -61,7 +62,7 @@ object TrainChunker extends App {
 
   def readData(path: String): Array[Array[CoreLabel]] = {
     val is = new GZIPInputStream(new FileInputStream(path))
-    val source = io.Source.fromInputStream(is)
+    val source = Source.fromInputStream(is)
     val text = source.mkString
     source.close()
     // sentences are separated by an empty line

--- a/main/src/main/scala/org/clulab/discourse/rstparser/ConnectiveMatcher.scala
+++ b/main/src/main/scala/org/clulab/discourse/rstparser/ConnectiveMatcher.scala
@@ -1,16 +1,19 @@
 package org.clulab.discourse.rstparser
 
 import java.io.{InputStreamReader, BufferedReader}
-
-import org.slf4j.LoggerFactory
-import scala.collection.mutable.ArrayBuffer
 import java.util.regex.Pattern
+import org.slf4j.LoggerFactory
+
+import scala.collection.mutable.ArrayBuffer
+import scala.io.Source
+
 import org.clulab.processors.{Sentence, Document}
 
 /**
  * Matches a set of known connectives in a given document
  * User: mihais
  * Date: 5/21/14
+ * Last Modified: Fix compiler issue: import scala.io.Source.
  */
 class ConnectiveMatcher
 
@@ -27,7 +30,7 @@ object ConnectiveMatcher {
 
   def loadConnectives(path:String):Iterable[Array[String]] = {
     val is = RSTParser.getClass.getClassLoader.getResourceAsStream(path)
-    val lines = io.Source.fromInputStream(is).getLines().toList.sortWith(desc)
+    val lines = Source.fromInputStream(is).getLines().toList.sortWith(desc)
     //println(lines)
     logger.debug("Loaded " + lines.length + " discourse connectives.")
     is.close()

--- a/main/src/main/scala/org/clulab/embeddings/word2vec/Word2vec.scala
+++ b/main/src/main/scala/org/clulab/embeddings/word2vec/Word2vec.scala
@@ -1,19 +1,21 @@
 package org.clulab.embeddings.word2vec
 
-import scala.io.Source
-import scala.collection.mutable.ArrayBuffer
-import org.slf4j.LoggerFactory
 import java.io._
-import org.clulab.utils.MathUtils
 import java.nio.{ ByteBuffer, ByteOrder }
+
+import org.slf4j.LoggerFactory
+import org.clulab.utils.MathUtils
 import org.apache.commons.io.{ IOUtils, FileUtils }
+
+import scala.collection.mutable.ArrayBuffer
+import scala.io.Source
 
 /**
  * Implements similarity metrics using the word2vec matrix
  * IMPORTANT: In our implementation, words are lower cased but NOT lemmatized or stemmed (see sanitizeWord)
  * User: mihais, dfried, gus
  * Date: 11/25/13
- *
+ * Last Modified: Fix compiler issue: import scala.io.Source.
  */
 
 // matrixConstructor is lazy, meant to save memory space if we're caching features
@@ -27,7 +29,7 @@ class Word2Vec(matrixConstructor: => Map[String, Array[Double]]) {
   }
 
   /** alternate constructor to allow loading from a source, possibly with a set of words to constrain the vocab */
-  def this(src: io.Source, wordsToUse: Option[Set[String]]) = {
+  def this(src: Source, wordsToUse: Option[Set[String]]) = {
     this(Word2Vec.loadMatrixFromSource(src, wordsToUse)._1)
   }
 
@@ -451,14 +453,14 @@ object Word2Vec {
 
   private def loadMatrixFromStream(is: InputStream, wordsToUse: Option[Set[String]]):(Map[String, Array[Double]], Int) = {
     logger.debug("Started to load word2vec matrix from stream ...")
-    val src: Source = io.Source.fromInputStream(is, "iso-8859-1")
+    val src: Source = Source.fromInputStream(is, "iso-8859-1")
     val lines: Iterator[String] = src.getLines
     val matrix = buildMatrix(lines, wordsToUse)
     src.close()
     logger.debug("Completed matrix loading.")
     matrix
   }
-  private def loadMatrixFromSource(src: io.Source, wordsToUse: Option[Set[String]]):(Map[String, Array[Double]], Int) = {
+  private def loadMatrixFromSource(src: Source, wordsToUse: Option[Set[String]]):(Map[String, Array[Double]], Int) = {
     logger.debug("Started to load word2vec matrix from source ...")
     val lines: Iterator[String] = src.getLines()
     val matrix = buildMatrix(lines, wordsToUse)

--- a/main/src/main/scala/org/clulab/learning/Dataset.scala
+++ b/main/src/main/scala/org/clulab/learning/Dataset.scala
@@ -4,7 +4,7 @@ import scala.collection.mutable
 import scala.collection.mutable.{ListBuffer, ArrayBuffer}
 import org.clulab.struct.Counter
 import org.clulab.struct.Lexicon
-import scala.io.BufferedSource
+import scala.io.{BufferedSource, Source}
 import java.util.zip.GZIPInputStream
 import java.io.{FileWriter, PrintWriter, FileInputStream, BufferedInputStream}
 import org.slf4j.LoggerFactory
@@ -14,6 +14,7 @@ import RVFDataset._
  * Parent class for classification datasets
  * User: mihais
  * Date: 4/23/13
+ * Last Modified: Fix compiler issue: import scala.io.Source.
  */
 abstract class Dataset[L, F](
   val labelLexicon:Lexicon[L],
@@ -376,9 +377,9 @@ object RVFDataset {
   def mkDatasetFromSvmLightResource(path: String): RVFDataset[Int, String] = {
     val stream = getClass.getClassLoader.getResourceAsStream(path)
     val source = if (path endsWith ".gz") {
-      io.Source.fromInputStream(new GZIPInputStream(stream))
+      Source.fromInputStream(new GZIPInputStream(stream))
     } else {
-      io.Source.fromInputStream(stream)
+      Source.fromInputStream(stream)
     }
     mkDatasetFromSvmLightFormat(source)
   }
@@ -387,9 +388,9 @@ object RVFDataset {
   def mkDatasetFromSvmLightFormat(filename: String): RVFDataset[Int, String] = {
     val source = if (filename endsWith ".gz") {
       val stream = new GZIPInputStream(new BufferedInputStream(new FileInputStream(filename)))
-      io.Source.fromInputStream(stream)
+      Source.fromInputStream(stream)
     } else {
-      io.Source.fromFile(filename)
+      Source.fromFile(filename)
     }
     mkDatasetFromSvmLightFormat(source)
   }
@@ -462,9 +463,9 @@ object RVFDataset {
   def mkDatumsFromSvmLightResource(path: String): Iterable[Datum[Int, String]] = {
     val stream = getClass.getClassLoader.getResourceAsStream(path)
     val source = if (path endsWith ".gz") {
-      io.Source.fromInputStream(new GZIPInputStream(stream))
+      Source.fromInputStream(new GZIPInputStream(stream))
     } else {
-      io.Source.fromInputStream(stream)
+      Source.fromInputStream(stream)
     }
     mkDatumsFromSvmLightFormat(source)
   }
@@ -473,9 +474,9 @@ object RVFDataset {
   def mkDatumsFromSvmLightFormat(filename: String): Iterable[Datum[Int, String]] = {
     val source = if (filename endsWith ".gz") {
       val stream = new GZIPInputStream(new BufferedInputStream(new FileInputStream(filename)))
-      io.Source.fromInputStream(stream)
+      Source.fromInputStream(stream)
     } else {
-      io.Source.fromFile(filename)
+      Source.fromFile(filename)
     }
     mkDatumsFromSvmLightFormat(source)
   }

--- a/main/src/main/scala/org/clulab/learning/RankingDataset.scala
+++ b/main/src/main/scala/org/clulab/learning/RankingDataset.scala
@@ -1,17 +1,20 @@
 package org.clulab.learning
 
-import scala.collection.mutable.{ListBuffer, ArrayBuffer}
-import org.clulab.struct.Counter
-import org.clulab.struct.Lexicon
-import scala.io.BufferedSource
-import org.slf4j.LoggerFactory
 import java.util.zip.GZIPInputStream
 import java.io.{FileWriter, PrintWriter, FileInputStream, FileOutputStream, ObjectInputStream, ObjectOutputStream, BufferedInputStream}
+import org.slf4j.LoggerFactory
+
+import scala.collection.mutable.{ListBuffer, ArrayBuffer}
+import scala.io.{ BufferedSource, Source }
+
+import org.clulab.struct.Counter
+import org.clulab.struct.Lexicon
 
 /**
  * Parent class for all datasets used for ranking problems
  * User: mihais
  * Date: 4/23/13
+ * Last Modified: Fix compiler issue: import scala.io.Source.
  */
 trait RankingDataset[F] {
   var featureLexicon = new Lexicon[F]
@@ -278,9 +281,9 @@ object RVFRankingDataset {
   def mkDatasetFromSvmRankResource(path: String): RVFRankingDataset[String] = {
     val stream = getClass.getClassLoader.getResourceAsStream(path)
     val source = if (path endsWith ".gz") {
-      io.Source.fromInputStream(new GZIPInputStream(stream))
+      Source.fromInputStream(new GZIPInputStream(stream))
     } else {
-      io.Source.fromInputStream(stream)
+      Source.fromInputStream(stream)
     }
     mkDatasetFromSvmRankFormat(source)
   }
@@ -289,9 +292,9 @@ object RVFRankingDataset {
   def mkDatasetFromSvmRankFormat(filename: String): RVFRankingDataset[String] = {
     val source = if (filename endsWith ".gz") {
       val stream = new GZIPInputStream(new BufferedInputStream(new FileInputStream(filename)))
-      io.Source.fromInputStream(stream)
+      Source.fromInputStream(stream)
     } else {
-      io.Source.fromFile(filename)
+      Source.fromFile(filename)
     }
     mkDatasetFromSvmRankFormat(source)
   }
@@ -357,9 +360,9 @@ object RVFRankingDataset {
   def mkDatumsFromSvmRankResource(path: String): Iterable[Iterable[Datum[Int, String]]] = {
     val stream = getClass.getClassLoader.getResourceAsStream(path)
     val source = if (path endsWith ".gz") {
-      io.Source.fromInputStream(new GZIPInputStream(stream))
+      Source.fromInputStream(new GZIPInputStream(stream))
     } else {
-      io.Source.fromInputStream(stream)
+      Source.fromInputStream(stream)
     }
     mkDatumsFromSvmRankFormat(source)
   }
@@ -368,9 +371,9 @@ object RVFRankingDataset {
   def mkDatumsFromSvmRankFormat(filename: String): Iterable[Iterable[Datum[Int, String]]] = {
     val source = if (filename endsWith ".gz") {
       val stream = new GZIPInputStream(new BufferedInputStream(new FileInputStream(filename)))
-      io.Source.fromInputStream(stream)
+      Source.fromInputStream(stream)
     } else {
-      io.Source.fromFile(filename)
+      Source.fromFile(filename)
     }
     mkDatumsFromSvmRankFormat(source)
   }

--- a/main/src/main/scala/org/clulab/learning/SVMRankingClassifier.scala
+++ b/main/src/main/scala/org/clulab/learning/SVMRankingClassifier.scala
@@ -1,21 +1,25 @@
 package org.clulab.learning
 
 import java.io._
-import org.slf4j.LoggerFactory
-import SVMRankingClassifier.logger
-import org.clulab.struct.{Counters, Counter}
-import scala.sys.process._
-import scala.collection.mutable.ArrayBuffer
-import scala.Serializable
 import java.util.Properties
+import org.slf4j.LoggerFactory
+
+import scala.Serializable
+import scala.collection.mutable.ArrayBuffer
+import scala.io.Source
+import scala.sys.process._
+
+import org.clulab.struct.{ Counters, Counter, Lexicon }
 import org.clulab.utils.StringUtils
-import org.clulab.struct.Lexicon
+
+import SVMRankingClassifier.logger
 
 /**
  * Wrapper for SVMrank: trains using svm_rank_learn but predicts using native Scala code
  * Only the linear kernel is supported
  * User: mihais
  * Date: 4/23/13
+ * Last Modified: Fix compiler issue: import scala.io.Source.
  */
 class SVMRankingClassifier[F] (
                                 val workingDir:String,
@@ -179,7 +183,7 @@ class SVMRankingClassifier[F] (
   def loadModelWeights(modelPath:String):Array[Double] = {
     var modelLine:Option[String] = None
     var numFeats:Int = 0
-    for(line <- scala.io.Source.fromFile(modelPath).getLines()) {
+    for(line <- Source.fromFile(modelPath).getLines()) {
       val (content, comment) = splitSVMLine(line)
       if(comment.contains("kernel type") &&
         content.toInt != 0) {

--- a/main/src/main/scala/org/clulab/processors/clu/syntax/EvaluateMalt.scala
+++ b/main/src/main/scala/org/clulab/processors/clu/syntax/EvaluateMalt.scala
@@ -2,11 +2,12 @@ package org.clulab.processors.clu.syntax
 
 import java.io.{BufferedReader, File, FileReader}
 
+import scala.collection.mutable.ArrayBuffer
+import scala.io.Source
+
 import org.maltparser.concurrent.ConcurrentUtils
 import org.maltparser.core.lw.helper.Utils
 import org.slf4j.LoggerFactory
-
-import scala.collection.mutable.ArrayBuffer
 
 class EvaluateMalt
 
@@ -14,11 +15,12 @@ class EvaluateMalt
  * Evaluates a model produced by TrainMalt
  * User: mihais
  * Date: 1/5/14
+ * Last Modified: Fix compiler issue: import scala.io.Source.
  */
 object EvaluateMalt {
 
   val logger = LoggerFactory.getLogger(classOf[EvaluateMalt])
-  
+
   def main(args:Array[String]) {
     if (args.length != 2) {
       println("Usage: org.clulab.processors.clulab.syntax.EvaluateMalt <model file name> <testing treebank in conllx format>")
@@ -115,7 +117,7 @@ object EvaluateMalt {
 
   def readDependencies(fn:String):Array[EvalDependency] = {
     val deps = new ArrayBuffer[EvalDependency]()
-    for(line <- io.Source.fromFile(fn).getLines()) {
+    for(line <- Source.fromFile(fn).getLines()) {
       val content = line.trim
       if(content.length > 0) {
         val tokens = content.split("\\s+")

--- a/main/src/main/scala/org/clulab/sequences/ColumnsToDocument.scala
+++ b/main/src/main/scala/org/clulab/sequences/ColumnsToDocument.scala
@@ -2,18 +2,19 @@ package org.clulab.sequences
 
 import java.io.InputStream
 
+import scala.collection.mutable.ArrayBuffer
+import scala.io.Source
+
 import org.clulab.processors.clu.CluProcessor
 import org.clulab.processors.{Document, Processor, Sentence}
 import org.slf4j.{Logger, LoggerFactory}
-
-import scala.collection.mutable.ArrayBuffer
-import scala.io.Source
 
 class ColumnsToDocument
 
 /**
   * Converts the CoNLLX column-based format to our Document by reading only words and POS tags
   * Created by mihais on 6/8/17.
+  * Last Modified: Fix compiler issue: import scala.io.Source.
   */
 object ColumnsToDocument {
   val logger:Logger = LoggerFactory.getLogger(classOf[ColumnsToDocument])
@@ -24,12 +25,12 @@ object ColumnsToDocument {
   val proc = new CluProcessor()
 
   def readFromFile(fn:String, wordPos:Int = WORD_POS_CONLLX, tagPos:Int = TAG_POS_CONLLX): Document = {
-    val source = io.Source.fromFile(fn)
+    val source = Source.fromFile(fn)
     readFromSource(source, wordPos, tagPos)
   }
 
   def readFromStream(stream:InputStream, wordPos:Int = WORD_POS_CONLLX, tagPos:Int = TAG_POS_CONLLX): Document = {
-    val source = io.Source.fromInputStream(stream)
+    val source = Source.fromInputStream(stream)
     readFromSource(source, wordPos, tagPos)
   }
 

--- a/main/src/main/scala/org/clulab/swirl2/SRL.scala
+++ b/main/src/main/scala/org/clulab/swirl2/SRL.scala
@@ -1,19 +1,23 @@
 package org.clulab.swirl2
 
 import java.io._
+
+import scala.collection.mutable
+import scala.collection.mutable.{ArrayBuffer, ListBuffer}
+import scala.io.Source
+
 import org.clulab.processors.Sentence
 import org.clulab.struct.{DirectedGraph, Edge}
 import org.clulab.utils.Files
 import org.clulab.utils.StringUtils._
 import org.slf4j.LoggerFactory
 import SRL._
-import scala.collection.mutable
-import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 
 /**
   * Implements the entire SRL pipeline
   * User: mihais
   * Date: 3/3/16
+  * Last Modified: Fix compiler issue: import scala.io.Source.
   */
 class SRL {
   var predClassifier:Option[PredicateClassifier] = None
@@ -46,7 +50,7 @@ class SRL {
   }
 
   def transferContent(fromFile:File, to:PrintWriter): Unit = {
-    val source = io.Source.fromFile(fromFile)
+    val source = Source.fromFile(fromFile)
     for(line <- source.getLines())
       to.println(line)
     source.close()

--- a/main/src/test/scala/org/clulab/TestUtils.scala
+++ b/main/src/test/scala/org/clulab/TestUtils.scala
@@ -2,10 +2,11 @@ package org.clulab
 
 import java.io.File
 
-import org.clulab.processors.Document
-import org.json4s.jackson.JsonMethods._
-import org.clulab.serialization.json.JSONSerializer
+import scala.io.Source
 
+import org.clulab.processors.Document
+import org.clulab.serialization.json.JSONSerializer
+import org.json4s.jackson.JsonMethods._
 
 object TestUtils {
 
@@ -24,7 +25,7 @@ object TestUtils {
     */
   def readFile(path: String) = {
     val stream = getClass.getClassLoader.getResourceAsStream(path)
-    val source = io.Source.fromInputStream(stream)
+    val source = Source.fromInputStream(stream)
     val data = source.mkString
     source.close()
     data

--- a/main/src/test/scala/org/clulab/learning/TestSVMRankingClassifier.scala
+++ b/main/src/test/scala/org/clulab/learning/TestSVMRankingClassifier.scala
@@ -1,8 +1,10 @@
 package org.clulab.learning
 
+import java.io.{File, PrintWriter}
+
 import org.scalatest._
 import scala.collection.mutable.{ArrayBuffer, ListBuffer}
-import java.io.{File, PrintWriter}
+import scala.io.Source
 import scala.sys.process._
 
 object NeedsExternalBinary extends Tag("NeedsExternalBinary")
@@ -11,6 +13,7 @@ object NeedsExternalBinary extends Tag("NeedsExternalBinary")
   * Tests training svm_rank; needs the svm_rank_classify in the $PATH!
   * User: mihais
   * Date: 4/25/13
+  * Last Modified: Fix compiler issue: import scala.io.Source.
   */
 class TestSVMRankingClassifier extends FlatSpec with Matchers {
 
@@ -52,7 +55,7 @@ class TestSVMRankingClassifier extends FlatSpec with Matchers {
     exitCode should be (0)
 
     val svmRankClassifyScores =
-      io.Source.fromFile("./predictions").getLines().map(l => l.toDouble).toArray
+      Source.fromFile("./predictions").getLines().map(l => l.toDouble).toArray
     val ourScores = scores.toArray
     svmRankClassifyScores(0) should be (ourScores(0))
     svmRankClassifyScores(1) should be (ourScores(1))

--- a/odin/src/main/scala/org/clulab/odin/impl/OdinResourceManager.scala
+++ b/odin/src/main/scala/org/clulab/odin/impl/OdinResourceManager.scala
@@ -1,11 +1,14 @@
 package org.clulab.odin.impl
 
 import java.io.{BufferedInputStream, InputStream}
+import scala.io.Source
 
 /**
  * Manage resources for Odin
  * @param embeddings: handles a word embeddings resource for distributional similarity comparisons; standard word vector format?
- * */
+ * Author: Gus Hahn-Powell.
+ * Last Modified: Fix compiler issue: import scala.io.Source.
+ */
 class OdinResourceManager(val embeddings: Option[EmbeddingsResource])
 
 object OdinResourceManager {
@@ -32,9 +35,9 @@ object OdinResourceManager {
   }
 
   // YOU NEED TO CLOSE ME!!!
-  def getSource(path: String): io.Source = {
+  def getSource(path: String): Source = {
     val url = RuleReader.mkURL(path)
-    io.Source.fromURL(url)
+    Source.fromURL(url)
   }
 
   def buildResources(resourcesMap: Map[String, String]): Map[String, Option[OdinResource]] = {

--- a/odin/src/main/scala/org/clulab/odin/impl/RuleReader.scala
+++ b/odin/src/main/scala/org/clulab/odin/impl/RuleReader.scala
@@ -7,7 +7,8 @@ import java.nio.charset.Charset
 import org.apache.commons.text.StrSubstitutor
 
 import scala.collection.JavaConverters._
-import scala.io.Codec
+import scala.io.{ Codec, Source }
+
 import org.yaml.snakeyaml.Yaml
 import org.yaml.snakeyaml.constructor.{ Constructor, ConstructorException }
 import org.clulab.odin._
@@ -17,7 +18,7 @@ class RuleReader(val actions: Actions, val charset: Charset) {
 
   import RuleReader._
 
-  // codec to be used by io.Source
+  // codec to be used by scala.io.Source
   implicit val codec: Codec = new Codec(charset)
 
   // invokes actions through reflection
@@ -208,7 +209,7 @@ class RuleReader(val actions: Actions, val charset: Charset) {
     case t: Collection[_] => Taxonomy(t.asInstanceOf[Collection[Any]])
     case path: String =>
       val url = mkURL(path)
-      val source = io.Source.fromURL(url)
+      val source = Source.fromURL(url)
       val input = source.mkString
       source.close()
       val yaml = new Yaml(new Constructor(classOf[Collection[Any]]))
@@ -238,7 +239,7 @@ class RuleReader(val actions: Actions, val charset: Charset) {
       res
     }
     val url = mkURL(path)
-    val source = io.Source.fromURL(url)
+    val source = Source.fromURL(url)
     val input = source.mkString // slurp
     source.close()
     // read rules and vars from file

--- a/odin/src/main/scala/org/clulab/odin/serialization/json/JSONSerializer.scala
+++ b/odin/src/main/scala/org/clulab/odin/serialization/json/JSONSerializer.scala
@@ -1,11 +1,15 @@
 package org.clulab.odin.serialization.json
 
 import java.io.File
+
+import scala.io.Source
+
 import org.clulab.processors.Document
 import org.clulab.struct.{DirectedGraph, Edge, Interval}
 import org.clulab.odin
 import org.clulab.odin._
 import org.clulab.serialization.json.DocOps
+
 import org.json4s.JsonDSL._
 import org.json4s._
 import org.json4s.jackson.JsonMethods._
@@ -32,7 +36,7 @@ object JSONSerializer {
   }
 
   def jsonAST(f: File): JValue = {
-    val source = scala.io.Source.fromFile(f)
+    val source = Source.fromFile(f)
     val contents = source.getLines.mkString
     source.close()
     parse(contents)

--- a/odin/src/test/scala/org/clulab/odin/TestVariables.scala
+++ b/odin/src/test/scala/org/clulab/odin/TestVariables.scala
@@ -1,12 +1,14 @@
 package org.clulab.odin
 
+import scala.io.Source
+
 import org.scalatest.{ Matchers, FlatSpec }
 
 
 class TestVariables extends FlatSpec with Matchers {
 
   def readResource(filename: String): String = {
-    val source = io.Source.fromURL(getClass.getResource(filename))
+    val source = Source.fromURL(getClass.getResource(filename))
     val data = source.mkString
     source.close()
     data


### PR DESCRIPTION
Made the usages of `io.Source` consistent across many files by explicit import of `scala.io.Source`. This solves a problem I ran into where these usages suddenly confused the compiler when a single Akka library dependency was added.