### PR TITLE
Update to use Scala 2.11.11, ...

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import ReleaseTransformations._
 
 lazy val commonSettings = Seq(
   organization := "org.clulab",
-  scalaVersion := "2.11.8",
+  scalaVersion := "2.11.11",
   scalacOptions ++= Seq("-feature", "-unchecked", "-deprecation"),
   parallelExecution in Test := false,
   scalacOptions in (Compile, doc) += "-no-link-warnings", // suppresses problems with scaladoc @throws links

--- a/corenlp/build.sbt
+++ b/corenlp/build.sbt
@@ -3,13 +3,13 @@ name := "processors-corenlp"
 libraryDependencies ++= {
   val akkaV = "2.5.4"
   Seq (
-    "ai.lum"             %%  "common"            % "0.0.7",
+    "ai.lum"             %%  "common"            % "0.0.8",
     "edu.stanford.nlp"    %  "stanford-corenlp"  % "3.5.1",
     "edu.stanford.nlp"    %  "stanford-corenlp"  % "3.5.1" classifier "models",
     "org.clulab"          %  "bioresources"      % "1.1.24",
 
     // logging
-    "com.typesafe.scala-logging"  %%  "scala-logging"    % "3.4.0",
+    "com.typesafe.scala-logging"  %%  "scala-logging"    % "3.7.2",
     "ch.qos.logback"               %  "logback-classic"  % "1.0.10",
     "org.slf4j"                    %  "slf4j-api"        % "1.7.10",
 

--- a/main/build.sbt
+++ b/main/build.sbt
@@ -5,8 +5,8 @@ libraryDependencies ++= {
   val json4sVersion = "3.5.2"
 
   Seq(
-    "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.3",
-    "org.scalatest" %% "scalatest" % "2.2.4" % "test",
+    "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4",
+    "org.scalatest" %% "scalatest" % "3.0.1" % "test",
     "org.clulab" % "bioresources" % "1.1.24",
     "com.io7m.xom" % "xom" % "1.2.10",
     "org.json4s" %% "json4s-core" % json4sVersion,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.4")


### PR DESCRIPTION
include some non-problematic library and plugin updates. This brings the 2.11 path more towards the 2.12 branch, which will be integrated later.