### PR TITLE
Allow for removing lexicon members

### DIFF
--- a/main/src/main/scala/org/clulab/struct/Lexicon.scala
+++ b/main/src/main/scala/org/clulab/struct/Lexicon.scala
@@ -35,6 +35,22 @@ class Lexicon[T] extends Serializable {
     }
   }
 
+  /**
+    * Removes a member from the lexicon and returns its (former) index, or -1 if it was not found in the lexicon
+    */
+  def remove(s:T): Int = synchronized {
+    if (lexicon.contains(s)) {
+      val i = lexicon(s)
+      lexicon.remove(s)
+      lexicon.foreach{
+        case (k, after) if after > i => lexicon(k) = after - 1
+        case before => ()
+      }
+      index.remove(i)
+      i
+    } else -1
+  }
+
   def exists(i:Int):Boolean = i < index.size
 
   def contains(f:T):Boolean = lexicon.contains(f)
@@ -45,7 +61,8 @@ class Lexicon[T] extends Serializable {
    * Fetches the string with the given index from the lexicon
    * This deliberately does NOT check for bounds for fast access.
    * Use exists() if you want to make sure that your index exists.
-   * @param i Index of the string in the lexicon
+    *
+    * @param i Index of the string in the lexicon
    * @return The string corresponding to the index
    */
   def get(i:Int):T = index(i)
@@ -99,6 +116,7 @@ class Lexicon[T] extends Serializable {
     * Maps feature indices from their old value to the new values given in the map
     * If an existing feature does not appear in the map, it is simply not included in the new lexicon
     *   (this is to support feature selection)
+    *
     * @param indexMap Map from old index to new index
     */
   def mapIndicesTo(indexMap:Map[Int, Int]): Lexicon[T] = {

--- a/main/src/test/scala/org/clulab/struct/TestLexicon.scala
+++ b/main/src/test/scala/org/clulab/struct/TestLexicon.scala
@@ -1,0 +1,40 @@
+package org.clulab.struct
+
+import org.scalatest.{Matchers, FlatSpec}
+
+/**
+  * Tests Lexicon methods
+  * User: dane
+  * Date: 12/06/2017
+  */
+class TestLexicon extends FlatSpec with Matchers {
+  "Lexicon" should "add and remove items successfully" in {
+    val bort = new Lexicon[String]
+
+    bort.add("pour") // index 0
+    bort.add("pour") // no update
+    bort.add("pour") // no update
+    bort.add("cheesecake") // index 1
+    bort.add("pin") // index 2
+    bort.add("flour") // index 3
+    bort.add("chicken") // index 4
+
+    bort.size should be (5)
+
+    val pinIx = bort.remove("pin")
+    pinIx should be (2)
+
+    val nonsenseIx = bort.remove("nonsense")
+    nonsenseIx should be (-1)
+
+    bort.get("chicken") should not be empty
+    bort.get("chicken").get should be (3) // update indices
+
+    val toRemove = 1
+    val noCheesecake = (0 until toRemove).map(i => i -> i) ++ ((toRemove + 1) until bort.size).map(i => i -> (i - 1))
+    val alsoBort = bort.mapIndicesTo(noCheesecake.toMap)
+
+    alsoBort.size should be (3)
+    alsoBort.get(2) should be ("chicken")
+  }
+}


### PR DESCRIPTION
This small change allows easy removal of a single Lexicon member. E.g.,

```
import org.clulab.struct.Lexicon

val bort = new Lexicon[String]

bort.add("pour") // index 0
bort.add("cheesecake") // index 1
bort.add("pin") // index 2
bort.add("flour") // index 3
bort.add("chicken") // index 4

bort.remove("pin") // returns 2

bort.remove("nonsense") // returns -1

// removal updates indices
bort
// chicken -> 3
// flour -> 2
// pour -> 0
// cheesecake -> 1
```