### PR TITLE
adding ability to import variables

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 # Changes
++ **7.0.1** - Added feature to Odin to import variables from a file. Works similarly to taxonomies.
 + **7.0.0** - Updated library to use Scala 2.12 by default. Add ability to remove lexicon members.
 + **7.0.0** - Retrained our two discourse parsers (constituent- and dependency-syntax based) to work with universal dependencies.
 + **7.0.0** - Switched to CoreNLP 3.8.0 and universal dependencies.


### PR DESCRIPTION
@marcovzla  added the ability to import vars, which will allow us to keep triggers/variables in one yml file to be references by others.  
as was done with taxonomy, a string following the vars: def will be treated as a path

(@marcovzla there were actually no additional changes on my local to push)