### PR TITLE
Account for line separators in document serialization

### DIFF
--- a/main/src/main/scala/org/clulab/serialization/DocumentSerializer.scala
+++ b/main/src/main/scala/org/clulab/serialization/DocumentSerializer.scala
@@ -105,7 +105,7 @@ class DocumentSerializer extends LazyLogging {
     if (charCount < 1) return ""            // sanity check
     var buffer = new Array[Char](charCount)
     r.read(buffer, 0, charCount)
-    r.skip(1)                               // skip over last newline
+    r.skip(OS_INDEPENDENT_LINE_SEPARATOR.size) // skip over last line separator
     new String(buffer)
   }
 
@@ -238,7 +238,12 @@ class DocumentSerializer extends LazyLogging {
       val txtLen = doc.text.get.length
       if (txtLen > 0) {
         os.println(START_TEXT + SEP + txtLen)
-        os.println(doc.text.get)            // adds extra end-of-line character
+        // Do not add OS-specific separator with println in case client and server use different conventions.
+        os.print(doc.text.get)                 
+        // Instead, use a separator that is independent of operating system.
+        // Or at the very least, use system property line.separator to account for println.
+        // See loadText which must be coordinated with this decision.
+        os.print(OS_INDEPENDENT_LINE_SEPARATOR)
       }
     }
 
@@ -442,6 +447,8 @@ class DocumentSerializer extends LazyLogging {
 }
 
 object DocumentSerializer {
+  protected val OS_INDEPENDENT_LINE_SEPARATOR = "\n"
+
   val NIL = "_"
   val SEP = "\t"
 

--- a/main/src/test/scala/org/clulab/serialization/json/TestJSONSerializer.scala
+++ b/main/src/test/scala/org/clulab/serialization/json/TestJSONSerializer.scala
@@ -1,5 +1,7 @@
 package org.clulab.serialization.json
 
+import org.clulab.processors.Document
+import org.clulab.serialization.DocumentSerializer
 import org.clulab.TestUtils.jsonStringToDocument
 import org.json4s._
 import org.scalatest._
@@ -53,6 +55,21 @@ class TestJSONSerializer extends FlatSpec with Matchers {
     doc.sentences should not be empty
     doc2.sentences should not be empty
     doc.sentences.head.equivalenceHash should equal (doc2.sentences.head.equivalenceHash)
+  }
+  
+  "A Document saved and loaded" should "have JSON equivalent to the original" in {
+    class Scratch(var document: Document) extends JSONSerialization {
+      def jsonAST: JValue = document.jsonAST
+    }
+    
+    doc.text = Some("This is a test") // Original failing test requires text
+    val documentSerializer = new DocumentSerializer()
+    val expectedDocAsJSON = new Scratch(doc).json()
+    val docSaved = documentSerializer.save(doc, keepText = true)
+    val docLoaded = documentSerializer.load(docSaved)
+    val actualDocAsJSON = new Scratch(docLoaded).json()
+    
+    actualDocAsJSON should equal (expectedDocAsJSON)
   }
 
 }


### PR DESCRIPTION
This is necessary in order to run under Windows.  Reach uses v6.3.0 of processors currently and I'm not sure of the best way to get this change into something that reach can use.  It may not work on v7.  Eidos is using v7.0.1 right now, but could easily be moved up to v7.0.2.