### PR TITLE
silence warnings

### DIFF
--- a/main/src/main/scala/org/clulab/struct/DirectedGraph.scala
+++ b/main/src/main/scala/org/clulab/struct/DirectedGraph.scala
@@ -212,6 +212,7 @@ case class DirectedGraph[E](edges: List[Edge[E]], roots: collection.immutable.Se
       for ((Seq(n1, n2), edge) <- pairs zip edgePath) yield edge match {
         case (`n1`, `n2`, dep) => (n1, n2, dep, ">")
         case (`n2`, `n1`, dep) => (n2, n1, dep, "<")
+        case _ => sys.error("unrecognized edge")
       }
     }
   }

--- a/odin/src/main/scala/org/clulab/odin/impl/GraphPatternCompiler.scala
+++ b/odin/src/main/scala/org/clulab/odin/impl/GraphPatternCompiler.scala
@@ -102,6 +102,7 @@ class GraphPatternCompiler(unit: String, config: OdinConfig) extends TokenPatter
       case pat ~ "?" => new OptionalGraphPattern(pat)
       case pat ~ "*" => new KleeneGraphPattern(pat)
       case pat ~ "+" => new ConcatGraphPattern(pat, new KleeneGraphPattern(pat))
+      case _ => sys.error("unrecognized quantifiedGraphPattern operator")
     }
 
   // helper function that repeats a pattern N times
@@ -134,6 +135,7 @@ class GraphPatternCompiler(unit: String, config: OdinConfig) extends TokenPatter
           val opt = repeatPattern(new OptionalGraphPattern(pat), n - m)
           new ConcatGraphPattern(req, opt)
       }
+      case _ => sys.error("unrecognized rangeGraphPattern")
     }
 
   def lookaroundGraphPattern: Parser[GraphPatternNode] =
@@ -203,6 +205,7 @@ class ArgumentPattern(
       case (_, RangedQuantifier(None, Some(maxRep))) =>
         if (matches.size > maxRep) matches.combinations(maxRep).toList
         else Seq(matches)
+      case _ => sys.error("unrecognized argument quantifier")
     }
   }
 }

--- a/odin/src/main/scala/org/clulab/odin/impl/RuleReader.scala
+++ b/odin/src/main/scala/org/clulab/odin/impl/RuleReader.scala
@@ -204,7 +204,7 @@ class RuleReader(val actions: Actions, val charset: Charset) {
 
   /** Reads the variables declared directly or imports them from a file */
   def readOrImportVars(data: Any): Map[String, String] = data match {
-    case vars: JMap[String, Any] => vars.asScala.mapValues(s => cleanVar(s.toString)).toMap
+    case vars: JMap[_, _] => vars.asScala.map{ case (k,v) => k.toString -> cleanVar(v.toString) }.toMap
     case path: String =>
       val url = mkURL(path)
       val source = Source.fromURL(url)

--- a/odin/src/main/scala/org/clulab/odin/impl/TokenConstraintParsers.scala
+++ b/odin/src/main/scala/org/clulab/odin/impl/TokenConstraintParsers.scala
@@ -46,6 +46,7 @@ trait TokenConstraintParsers extends StringMatcherParsers {
   def negatedConstraint: Parser[TokenConstraint] = opt("!") ~ atomicConstraint ^^ {
     case None ~ constraint => constraint
     case Some("!") ~ constraint => new NegatedConstraint(constraint)
+    case _ => sys.error("unrecognized negatedConstraint operator")
   }
 
   def atomicConstraint: Parser[TokenConstraint] =
@@ -69,6 +70,7 @@ trait TokenConstraintParsers extends StringMatcherParsers {
       case prod ~ list => (prod /: list) {
         case (lhs, "+" ~ rhs) => new Addition(lhs, rhs)
         case (lhs, "-" ~ rhs) => new Subtraction(lhs, rhs)
+        case _ => sys.error("unrecognized numericExpression operator")
       }
     }
 
@@ -79,13 +81,15 @@ trait TokenConstraintParsers extends StringMatcherParsers {
         case (lhs, "/" ~ rhs) => new Division(lhs, rhs)
         case (lhs, "//" ~ rhs) => new EuclideanQuotient(lhs, rhs)
         case (lhs, "%" ~ rhs) => new EuclideanRemainder(lhs, rhs)
+        case _ => sys.error("unrecognized productExpression operator")
       }
     }
 
   def termExpression: Parser[NumericExpression] = opt("-" | "+") ~ atomicExpression ^^ {
+    case None ~ expr => expr
     case Some("-") ~ expr => new NegativeExpression(expr)
     case Some("+") ~ expr => expr
-    case None ~ expr => expr
+    case _ => sys.error("unrecognized termExpression operator")
   }
 
   def atomicExpression: Parser[NumericExpression] =

--- a/odin/src/main/scala/org/clulab/odin/impl/TokenPatternCompiler.scala
+++ b/odin/src/main/scala/org/clulab/odin/impl/TokenPatternCompiler.scala
@@ -69,6 +69,7 @@ class TokenPatternParsers(val unit: String, val config: OdinConfig) extends Toke
   def capturePattern: Parser[ProgramFragment] =
     "(?<" ~ stringLiteral ~ ">" ~ splitPattern ~ ")" ^^ {
       case "(?<" ~ name ~ ">" ~ frag ~ ")" => frag.capture(name)
+      case _ => sys.error("unrecognized capturePattern")
     }
 
   def mentionPattern: Parser[ProgramFragment] =
@@ -88,6 +89,7 @@ class TokenPatternParsers(val unit: String, val config: OdinConfig) extends Toke
       case frag ~ "*?" => frag.lazyStar
       case frag ~ "+" => frag.greedyPlus
       case frag ~ "+?" => frag.lazyPlus
+      case _ => sys.error("unrecognized repeatedPattern operator")
     }
 
   // positive integer
@@ -98,6 +100,7 @@ class TokenPatternParsers(val unit: String, val config: OdinConfig) extends Toke
     atomicPattern ~ "{" ~ opt(int) ~ "," ~ opt(int) ~ ("}" ||| "}?") ^^ {
       case frag ~ "{" ~ from ~ "," ~ to ~ "}" => frag.greedyRange(from, to)
       case frag ~ "{" ~ from ~ "," ~ to ~ "}?" => frag.lazyRange(from, to)
+      case _ => sys.error("unrecognized rangePattern")
     }
 
   def exactPattern: Parser[ProgramFragment] =
@@ -129,6 +132,7 @@ class TokenPatternParsers(val unit: String, val config: OdinConfig) extends Toke
   def capturePatternRev: Parser[ProgramFragment] =
     "(?<" ~ stringLiteral ~ ">" ~ splitPatternRev ~ ")" ^^ {
       case "(?<" ~ name ~ ">" ~ frag ~ ")" => frag.capture(name)
+      case _ => sys.error("unrecognized capturePatternRev")
     }
 
   def atomicPatternRev: Parser[ProgramFragment] =
@@ -143,12 +147,14 @@ class TokenPatternParsers(val unit: String, val config: OdinConfig) extends Toke
       case frag ~ "*?" => frag.lazyStar
       case frag ~ "+" => frag.greedyPlus
       case frag ~ "+?" => frag.lazyPlus
+      case _ => sys.error("unrecognized repeatedPatternRev operator")
     }
 
   def rangePatternRev: Parser[ProgramFragment] =
     atomicPatternRev ~ "{" ~ opt(int) ~ "," ~ opt(int) ~ ("}" ||| "}?") ^^ {
       case frag ~ "{" ~ from ~ "," ~ to ~ "}" => frag.greedyRange(from, to)
       case frag ~ "{" ~ from ~ "," ~ to ~ "}?" => frag.lazyRange(from, to)
+      case _ => sys.error("unrecognized rangePatternRev")
     }
 
   def exactPatternRev: Parser[ProgramFragment] =


### PR DESCRIPTION
The main cause of the warnings was that we were not checking explicitly
for impossible cases when doing pattern matching. For example,
a grammar rule may specify that only three quantifier operators exist
(`*`, `+`, `?`) but the compiler doesn't know this and complains because
we don't have a case for any string other than `"*"`, `"+"`, and `"?"`.  We added
an explicit case for handling these (impossible) situations that throws an exception,
which should never happen.

resolves #228 