### PR TITLE
release tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -96,7 +96,7 @@ releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,
   inquireVersions,
   runClean,
-  releaseStepCommandAndRemaining("+test"),
+  runTest,
   setReleaseVersion,
   commitReleaseVersion,
   tagRelease,


### PR DESCRIPTION
reverted to `runTest` release step to be able to skip it using `sbt 'release skip-tests'`