### PR TITLE
Added support for class weights in LibSvm's classifier

### DIFF
--- a/main/src/main/scala/org/clulab/learning/LibSVMClassifier.scala
+++ b/main/src/main/scala/org/clulab/learning/LibSVMClassifier.scala
@@ -11,12 +11,6 @@ import java.io._
 
 import org.clulab.learning._
 
-class KernelType
-
-case object LinearKernel extends KernelType
-case object PolynomialKernel extends KernelType
-case object RBFKernel extends KernelType
-case object SigmoidKernel extends KernelType
 
 /**
   * Modified from mihais's Liblinear wrapper by dfried on 5/2/14

--- a/main/src/main/scala/org/clulab/learning/LibSVMClassifier.scala
+++ b/main/src/main/scala/org/clulab/learning/LibSVMClassifier.scala
@@ -12,6 +12,7 @@ import java.io._
 import org.clulab.learning._
 
 
+
 /**
   * Modified from mihais's Liblinear wrapper by dfried on 5/2/14
   * Further modified by enrique on 5/15/18


### PR DESCRIPTION
An overloaded variant of the train method of _LibSvmClassifier_ allows for optional weights to handle class balancing.

I had to add support for this for FocusedReading and believe it can be useful for the users in general