### PR TITLE
Increase memory in .sbtopts

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,3 +1,3 @@
--J-Xmx5G
+-J-Xmx6G
 -J-XX:+CMSClassUnloadingEnabled
 -J-XX:+UseConcMarkSweepGC


### PR DESCRIPTION
The Travis build is periodically failing with out of memory complaints.