### PR TITLE
Repetitions

### DIFF
--- a/odin/src/main/scala/org/clulab/odin/impl/GraphPatternCompiler.scala
+++ b/odin/src/main/scala/org/clulab/odin/impl/GraphPatternCompiler.scala
@@ -121,9 +121,9 @@ class GraphPatternCompiler(unit: String, config: OdinConfig) extends TokenPatter
   def rangeGraphPattern: Parser[GraphPatternNode] =
     atomicGraphPattern ~ "{" ~ opt(int) ~ "," ~ opt(int) ~ "}" ^^ {
       case pat ~ "{" ~ from ~ "," ~ to ~ "}" => (from, to) match {
-        case (None, None) =>
-          sys.error("invalid range")
-        case (None, Some(n)) =>
+        case (None | Some(0), None) =>
+          new KleeneGraphPattern(pat)
+        case (None | Some(0), Some(n)) =>
           repeatPattern(new OptionalGraphPattern(pat), n)
         case (Some(m), None) =>
           val req = repeatPattern(pat, m)

--- a/odin/src/test/scala/org/clulab/odin/TestGraphPattern.scala
+++ b/odin/src/test/scala/org/clulab/odin/TestGraphPattern.scala
@@ -8,6 +8,18 @@ import org.scalatest._
 // Tests operating over Universal dependencies
 class TestGraphPattern extends FlatSpec with Matchers {
 
+  "graph range {0,n}" should "not throw an exception" in {
+    val rule = """
+      | - name: DummyRule
+      |   label: DummyLabel
+      |   pattern: |
+      |     trigger = x
+      |     arg:Arg = >nsubj{0,5} # range equivalent to {,5}
+      |""".stripMargin
+    // just ensure the rule compiles
+    val ee = ExtractorEngine(rule)
+  }
+
   "GraphPattern" should "support multiline patterns" in {
 
     // "I saw Kermit at the pond."


### PR DESCRIPTION
Allow repetitions in dependency patterns to start from zero explicitly.

`range{0,5}` should be equal to `range{,5}`