### PR TITLE
split Serializer.load()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 # Changes
++ **7.4.2** - Added Serializer.load(filename, classLoader)
 + **7.4.2** - Added SpanishCluProcessor and PortugueseCluProcessor, which currently include tokenization, POS tagging, and parsing of universal dependencies.
 + **7.4.1** - Expose Sentence.norms in Odin rules.
 + **7.4.0** - Added a bidirectional POS model that performs 0.1% better on WSJ.

--- a/main/src/main/scala/org/clulab/utils/Serializer.scala
+++ b/main/src/main/scala/org/clulab/utils/Serializer.scala
@@ -14,7 +14,11 @@ object Serializer {
 
   /** loads object from file */
   def load[A](filename: String): A = {
-    val cl = getClass().getClassLoader()
+    load(filename, getClass().getClassLoader())
+  }
+
+  /** loads object from file */
+  def load[A](filename: String, cl: ClassLoader): A = {
     val fis = new FileInputStream(filename)
     val ois = new ClassLoaderObjectInputStream(cl, fis)
     val obj = ois.readObject().asInstanceOf[A]


### PR DESCRIPTION
Adds a version of `Serializer.load()` that takes a `ClassLoader` as an argument.
Preserves the current one that uses `Serializer.getClass.getClassLoader` by default.
Closes #258 