### PR TITLE
Show how it would work with new version of fatdynet

### DIFF
--- a/main/src/main/scala/org/clulab/fatdynet/Model.scala
+++ b/main/src/main/scala/org/clulab/fatdynet/Model.scala
@@ -1,0 +1,51 @@
+package org.clulab.fatdynet
+
+import edu.cmu.dynet._
+
+import org.clulab.fatdynet.design.Artifact
+import org.clulab.fatdynet.design.Design
+
+class Model(val name: String, parameterCollection: ParameterCollection,
+    val artifacts: Seq[Artifact], val designs: Seq[Design]) {
+  require(artifacts.size == designs.size)
+
+  def getParameterCollection: ParameterCollection = parameterCollection
+
+  protected val artifactsAndDesigns: Seq[(Artifact, Design)] = artifacts.zip(designs)
+
+  def getParameter(index: Int): Parameter = getParameterAndDesign(index)._1
+
+  def getLookupParameter(index: Int): LookupParameter = getLookupParameterAndDesign(index)._1
+
+  def getRnnBuilder(index: Int): RnnBuilder = getRnnBuilderAndDesign(index)._1
+
+  def getParameterSize: Int = artifactsAndDesigns.count { case (artifact, _) => artifact.isParameter }
+
+  def getLookupParameterSize: Int = artifactsAndDesigns.count { case (artifact, _) => artifact.isLookupParameter }
+
+  def getRnnBuilderSize: Int = artifactsAndDesigns.count { case (artifact, _) => artifact.isRnnBuilder }
+
+  def getParameterAndDesign(index: Int): (Parameter, Design) = {
+    val (artifact, design) = artifactsAndDesigns
+        .filter { case (artifact, _) => artifact.isParameter }
+        .apply(index)
+
+    (artifact.parameter.get, design)
+  }
+
+  def getLookupParameterAndDesign(index: Int): (LookupParameter, Design) = {
+    val (artifact, design) = artifactsAndDesigns
+        .filter { case (artifact, _) => artifact.isLookupParameter }
+        .apply(index)
+
+    (artifact.lookupParameter.get, design)
+  }
+
+  def getRnnBuilderAndDesign(index: Int): (RnnBuilder, Design) = {
+    val (artifact, design) = artifactsAndDesigns
+        .filter { case (artifact, _) => artifact.isRnnBuilder }
+        .apply(index)
+
+    (artifact.rnnBuilder.get, design)
+  }
+}

--- a/main/src/main/scala/org/clulab/fatdynet/Repo.scala
+++ b/main/src/main/scala/org/clulab/fatdynet/Repo.scala
@@ -1,0 +1,143 @@
+package org.clulab.fatdynet
+
+import edu.cmu.dynet._
+
+import org.clulab.fatdynet.design._
+import org.clulab.fatdynet.parser._
+import org.clulab.fatdynet.utils.Closer.AutoCloser
+import org.clulab.fatdynet.utils.Header
+import org.clulab.fatdynet.utils.Loader
+
+import scala.collection.mutable.ArrayBuffer
+import scala.io.Source
+
+class Repo(val filename: String) {
+
+  class ParseException(cause: Exception, line: Option[String] = None, lineNo: Option[Int] = None) extends RuntimeException {
+
+    def this(cause: Exception, line: String, lineNo: Int) = this(cause, Option(line), Option(lineNo))
+
+    override def toString(): String = {
+      cause.getMessage
+    }
+  }
+
+  protected def getDesigns(parserFactories: Seq[Repo.ParserFactory], designs: ArrayBuffer[Design], optionParser: Option[Parser], line: String, lineNo: Int): Option[Parser] = {
+    var currentOptionsParser = optionParser
+
+    try {
+      val header = new Header(line, lineNo)
+      val parsed = currentOptionsParser.isDefined && currentOptionsParser.get.parse(header)
+
+      if (currentOptionsParser.isDefined && !parsed) {
+        // !parsed implies that the parser has completed its job and needs to finish().
+        designs += currentOptionsParser.get.finish()
+        currentOptionsParser = None
+      }
+      if (currentOptionsParser.isEmpty) {
+        currentOptionsParser = parserFactories.foldLeft(currentOptionsParser) { case (optionParser, parserFactory) =>
+          optionParser.orElse(parserFactory(header))
+        }
+        currentOptionsParser.map(_.parse(header)).getOrElse(throw new Exception("Parser is not defined."))
+      }
+    }
+    catch {
+      case exception: Exception => throw new ParseException(exception, line, lineNo)
+    }
+    currentOptionsParser
+  }
+
+  def getDesigns(parserFactories: Seq[Repo.ParserFactory] = Repo.parserFactories): Seq[Design] = {
+    val designs: ArrayBuffer[Design] = new ArrayBuffer
+
+    try {
+      var currentParser: Option[Parser] = None
+
+      Source.fromFile(filename).autoClose { source =>
+        source
+            .getLines
+            .zipWithIndex
+            .filter { case (line, _) => line.startsWith("#") }
+            .foreach { case (line, lineNo) =>
+              currentParser = getDesigns(parserFactories, designs, currentParser, line, lineNo)
+            }
+        currentParser.foreach { parser => designs += parser.finish() } // Force finish at end of file.
+      }
+    }
+    catch {
+      case exception: ParseException => throw exception
+      case exception: Exception => throw new ParseException(exception)
+    }
+
+    designs
+  }
+
+  protected def reorderDesigns(designs: Seq[Design]): Seq[Design] = {
+    designs.sortWith { (left, right) => left.index.get < right.index.get }
+  }
+
+  protected def orderDesigns(designs: Seq[Design]): Seq[Design] = {
+    val isReorderable = designs.nonEmpty && designs.forall { design => !design.isPotentiallyReorderable || design.isActuallyReorderable }
+
+    if (false) { // isReorderable) {
+      val reorderable = designs.filter(_.isActuallyReorderable)
+      val reordered = reorderDesigns(reorderable)
+      var pos = 0
+      // Try to avoid this by saving in a canonical order.
+      val ordered = designs.map { design =>
+        if (design.isActuallyReorderable) {
+          // "Insert" the next one from the ordered sequence.
+          val result = reordered(pos)
+          pos += 1
+          result
+        }
+        else design // Stick with what we've got.
+      }
+
+      ordered
+    }
+    else designs
+  }
+
+  def getModel(designs: Seq[Design], name: String): Model = {
+    val parameterCollection = new ParameterCollection
+    val namedDesigns = designs.filter(_.name == name)
+    val orderedDesigns = orderDesigns(namedDesigns)
+    val artifacts = orderedDesigns.map { design =>
+        design.build(parameterCollection)
+    }
+
+    new Loader.ClosableModelLoader(filename).autoClose { modelLoader =>
+        if (artifacts.size > 1)
+          // They must have been thrown together into a parameter collection
+          modelLoader.populateModel(parameterCollection, name)
+        else
+          artifacts.foreach { artifact =>
+            artifact.populate(modelLoader, parameterCollection)
+          }
+    }
+    new Model(name, parameterCollection, artifacts, orderedDesigns)
+  }
+}
+
+object Repo {
+  type ParserFactory = Header => Option[Parser]
+
+  val parserFactories: Array[ParserFactory] = Array(
+    CompactVanillaLstmParser.mkParser,
+    CoupledLstmParser.mkParser,
+    FastLstmParser.mkParser,
+    GruParser.mkParser,
+    SimpleRnnParser.mkParser,
+
+    BidirectionalTreeLstmParser.mkParser, // Must be before other vanilla-lstm-builder
+    UnidirectionalTreeLstmParser.mkParser, // Must be before other vanilla-lstm-builder
+
+    LstmParser.mkParser, // Uses vanilla-lstm-builder
+    VanillaLstmParser.mkParser, // Uses vanilla-lstm-builder, so hidden by LstmParser
+
+    // These need to be last so that buildType is not used in the name.
+    ParameterParser.mkParser,
+    LookupParameterParser.mkParser
+  )
+}

--- a/main/src/main/scala/org/clulab/fatdynet/apps/PairExampleApp.scala
+++ b/main/src/main/scala/org/clulab/fatdynet/apps/PairExampleApp.scala
@@ -1,0 +1,233 @@
+package org.clulab.fatdynet.apps
+
+import edu.cmu.dynet._
+import org.clulab.fatdynet.utils.Closer.AutoCloser
+import org.clulab.fatdynet.utils.Loader
+import org.clulab.fatdynet.utils.Loader.ClosableModelSaver
+import org.clulab.fatdynet.utils.Transducer
+
+import scala.util.Random
+
+case class PairModel(w: Parameter, b: Parameter, v: Parameter, a: Parameter, model: ParameterCollection)
+
+case class PairTransformation(inputs: Array[Int], output: Int) {
+
+  override def toString(): String = getClass.getSimpleName + "(" + inputs.mkString("(", ", ", ")") + " -> " + output.toString() + ")"
+
+  // Testing
+  def transform(inputValues: Array[Float]): Unit = {
+    inputs.indices.foreach { index =>
+      inputValues(index) = inputs(index)
+    }
+  }
+
+  // Training
+  def transform(inputValues: Array[Float], outputValue: FloatPointer): Unit = {
+    transform(inputValues)
+    outputValue.set(output)
+  }
+}
+
+object PairExampleApp {
+  protected val random: Random = new Random(1234L)
+
+  val LAYERS_SIZE = 1
+
+  val  INPUT_SIZE = 1
+  val HIDDEN_SIZE = 4
+  val OUTPUT_SIZE = 1
+
+  val ITERATIONS = 2000
+
+  val transformations: Seq[PairTransformation] = Seq(
+    // For pairs of ones anywhere in sequence
+    PairTransformation(Array(0, 0), 0),
+    PairTransformation(Array(0, 1), 0),
+    PairTransformation(Array(1, 0), 0),
+    PairTransformation(Array(1, 1), 1),
+
+    PairTransformation(Array(0, 0, 0), 0),
+    PairTransformation(Array(0, 0, 1), 0),
+    PairTransformation(Array(0, 1, 0), 0),
+    PairTransformation(Array(0, 1, 1), 1),
+    PairTransformation(Array(1, 0, 0), 0),
+    PairTransformation(Array(1, 0, 1), 0),
+    PairTransformation(Array(1, 1, 0), 1),
+    PairTransformation(Array(1, 1, 1), 1),
+
+    PairTransformation(Array(0, 0, 0, 0), 0),
+    PairTransformation(Array(0, 0, 0, 1), 0),
+    PairTransformation(Array(0, 0, 1, 0), 0),
+    PairTransformation(Array(0, 0, 1, 1), 1),
+    PairTransformation(Array(0, 1, 0, 0), 0),
+    PairTransformation(Array(0, 1, 0, 1), 0),
+    PairTransformation(Array(0, 1, 1, 0), 1),
+    PairTransformation(Array(0, 1, 1, 1), 1),
+    PairTransformation(Array(1, 0, 0, 0), 0),
+    PairTransformation(Array(1, 0, 0, 1), 0),
+    PairTransformation(Array(1, 0, 1, 0), 0),
+    PairTransformation(Array(1, 0, 1, 1), 1),
+    PairTransformation(Array(1, 1, 0, 0), 1),
+    PairTransformation(Array(1, 1, 0, 1), 1),
+    PairTransformation(Array(1, 1, 1, 0), 1),
+    PairTransformation(Array(1, 1, 1, 1), 1),
+
+    PairTransformation(Array(0, 0, 0, 0, 0), 0),
+    PairTransformation(Array(0, 0, 0, 0, 1), 0),
+    PairTransformation(Array(0, 0, 0, 1, 0), 0),
+    PairTransformation(Array(0, 0, 0, 1, 1), 1),
+    PairTransformation(Array(0, 0, 1, 0, 0), 0),
+    PairTransformation(Array(0, 0, 1, 0, 1), 0),
+    PairTransformation(Array(0, 0, 1, 1, 0), 1),
+    PairTransformation(Array(0, 0, 1, 1, 1), 1),
+    PairTransformation(Array(0, 1, 0, 0, 0), 0),
+    PairTransformation(Array(0, 1, 0, 0, 1), 0),
+    PairTransformation(Array(0, 1, 0, 1, 0), 0),
+    PairTransformation(Array(0, 1, 0, 1, 1), 1),
+    PairTransformation(Array(0, 1, 1, 0, 0), 1),
+    PairTransformation(Array(0, 1, 1, 0, 1), 1),
+    PairTransformation(Array(0, 1, 1, 1, 0), 1),
+    PairTransformation(Array(0, 1, 1, 1, 1), 1),
+
+    PairTransformation(Array(1, 0, 0, 0, 0), 0),
+    PairTransformation(Array(1, 0, 0, 0, 1), 0),
+    PairTransformation(Array(1, 0, 0, 1, 0), 0),
+    PairTransformation(Array(1, 0, 0, 1, 1), 1),
+    PairTransformation(Array(1, 0, 1, 0, 0), 0),
+    PairTransformation(Array(1, 0, 1, 0, 1), 0),
+    PairTransformation(Array(1, 0, 1, 1, 0), 1),
+    PairTransformation(Array(1, 0, 1, 1, 1), 1),
+    PairTransformation(Array(1, 1, 0, 0, 0), 1),
+    PairTransformation(Array(1, 1, 0, 0, 1), 1),
+    PairTransformation(Array(1, 1, 0, 1, 0), 1),
+    PairTransformation(Array(1, 1, 0, 1, 1), 1),
+    PairTransformation(Array(1, 1, 1, 0, 0), 1),
+    PairTransformation(Array(1, 1, 1, 0, 1), 1),
+    PairTransformation(Array(1, 1, 1, 1, 0), 1),
+    PairTransformation(Array(1, 1, 1, 1, 1), 1)
+  )
+
+  protected def mkPredictionGraph(pairModel: PairModel, xValues: Seq[Float], builder: RnnBuilder): Expression = {
+    // The graph will grow and grow without this next line.
+    ComputationGraph.renew()
+    // Use the new graph.
+    builder.newGraph()
+
+    val xs = xValues.map(Expression.input)
+    val builderOutputs = Transducer.transduce(builder, xs)
+    val builderOutput = builderOutputs.last
+
+    val W = Expression.parameter(pairModel.w)
+    val b = Expression.parameter(pairModel.b)
+    val V = Expression.parameter(pairModel.v)
+    val a = Expression.parameter(pairModel.a)
+    val y = V * Expression.tanh(W * builderOutput + b) + a
+
+    y
+  }
+
+  def train: (PairModel, Seq[Float], RnnBuilder) = {
+    val model = new ParameterCollection
+    val trainer = new SimpleSGDTrainer(model) // i.e., stochastic gradient descent trainer
+
+    val WParameter = model.addParameters(Dim(HIDDEN_SIZE, HIDDEN_SIZE))
+    val bParameter = model.addParameters(Dim(HIDDEN_SIZE))
+    val VParameter = model.addParameters(Dim(OUTPUT_SIZE, HIDDEN_SIZE))
+    val aParameter = model.addParameters(Dim(OUTPUT_SIZE))
+
+    val rnnModel = new ParameterCollection
+    val builder = new LstmBuilder(LAYERS_SIZE, INPUT_SIZE, HIDDEN_SIZE, rnnModel)
+    val pairModel = PairModel(WParameter, bParameter, VParameter, aParameter, rnnModel)
+
+    val yValue = new FloatPointer // because OUTPUT_SIZE is 1
+
+    for (iteration <- 0 until ITERATIONS) {
+      val lossValue = random.shuffle(transformations).map { transformation =>
+      val xValues = new Array[Float](transformation.inputs.length)
+
+        transformation.transform(xValues, yValue)
+
+        val yPrediction = mkPredictionGraph(pairModel, xValues, builder)
+        val y = Expression.input(transformation.output)
+
+        val loss = Expression.squaredDistance(yPrediction, y)
+        val lossValue = loss.value().toFloat()
+
+//        println()
+//        println("Computation graphviz structure:")
+//        ComputationGraph.printGraphViz()
+
+        ComputationGraph.backward(loss)
+        trainer.update()
+        lossValue
+      }.sum
+
+      println(s"index = $iteration, loss = $lossValue")
+      trainer.learningRate *= 0.999f
+    }
+
+    val results = predict(pairModel, builder)
+
+    (pairModel, results, builder)
+  }
+
+  def predict(pairModel: PairModel, builder: RnnBuilder): Seq[Float] = {
+    var count = 0
+
+    println
+    val result = transformations.map { transformation =>
+      val xValues = new Array[Float](transformation.inputs.length)
+
+      transformation.transform(xValues)
+
+      val yPrediction = mkPredictionGraph(pairModel, xValues, builder)
+      val yValue = yPrediction.value().toFloat()
+      val correct = transformation.output == yValue.round
+
+      if (correct)
+        count += 1
+      println(s"TRANSFORMATION = $transformation, PREDICTION = $yValue, CORRECT = $correct")
+      yValue
+    }
+    val accuracy = count / transformations.size.toFloat
+
+    println(s"Accuracy: $count / ${transformations.size} = $accuracy")
+    result
+  }
+
+  def save(filename: String, pairModel: PairModel): Unit = {
+    new ClosableModelSaver(filename).autoClose { saver =>
+      saver.addParameter(pairModel.w, "/W")
+      saver.addParameter(pairModel.b, "/b")
+      saver.addParameter(pairModel.v, "/V")
+      saver.addParameter(pairModel.a, "/a")
+      saver.addModel(pairModel.model, "/model")
+    }
+  }
+
+  def load(filename: String): (PairModel, RnnBuilder) = {
+    val (optionBuilder, optionModel, parameters, _) = Loader.loadLstm(filename)
+    val WParameters = parameters("/W")
+    val bParameters = parameters("/b")
+    val VParameters = parameters("/V")
+    val aParameters = parameters("/a")
+
+    (PairModel(WParameters, bParameters, VParameters, aParameters, optionModel.get), optionBuilder.get)
+  }
+
+  def main(args: Array[String]) {
+    val filename = "PairModel.dat"
+
+    Initialize.initialize(Map("random-seed" -> 2522620396L))
+
+    val (pairModel1, initialResults, builder1) = train
+    val expectedResults = predict(pairModel1, builder1)
+    save(filename, pairModel1)
+
+    val (pairModel2, builder2) = load(filename)
+    val actualResults = predict(pairModel2, builder2)
+
+    assert(initialResults == expectedResults)
+    assert(expectedResults == actualResults)
+  }
+}

--- a/main/src/main/scala/org/clulab/fatdynet/apps/XorExampleApp.scala
+++ b/main/src/main/scala/org/clulab/fatdynet/apps/XorExampleApp.scala
@@ -1,0 +1,167 @@
+package org.clulab.fatdynet.apps
+
+import edu.cmu.dynet._
+import org.clulab.fatdynet.utils.Closer.AutoCloser
+import org.clulab.fatdynet.utils.Loader
+import org.clulab.fatdynet.utils.Loader.ClosableModelSaver
+
+import scala.util.Random
+
+case class XorModel(w: Parameter, b: Parameter, v: Parameter, a: Parameter)
+
+case class XorTransformation(input1: Int, input2: Int, output: Int) {
+
+  override def toString(): String = getClass.getSimpleName + "((" + input1 + ", " + input2 + ") -> " + output + ")"
+
+  // Testing
+  def transform(inputValues: FloatVector): Unit = {
+    inputValues.update(0, input1)
+    inputValues.update(1, input2)
+  }
+
+  // Training
+  def transform(inputValues: FloatVector, outputValue: FloatPointer): Unit = {
+    transform(inputValues)
+    outputValue.set(output)
+  }
+}
+
+object XorExampleApp {
+  protected val random: Random = new Random(1234L)
+
+  val  INPUT_SIZE = 2
+  val HIDDEN_SIZE = 2
+  val OUTPUT_SIZE = 1
+
+  val ITERATIONS = 400
+
+  val transformations: Seq[XorTransformation] = Seq(
+    // input1, input2, output = input1 ^ input2
+    XorTransformation(0, 0, 0),
+    XorTransformation(0, 1, 1),
+    XorTransformation(1, 0, 1),
+    XorTransformation(1, 1, 0)
+  )
+
+  protected def mkPredictionGraph(xorModel: XorModel, xValues: FloatVector): Expression = {
+    ComputationGraph.renew()
+
+    val x = Expression.input(Dim(xValues.length), xValues)
+
+    val W = Expression.parameter(xorModel.w)
+    val b = Expression.parameter(xorModel.b)
+    val V = Expression.parameter(xorModel.v)
+    val a = Expression.parameter(xorModel.a)
+    val y = V * Expression.tanh(W * x + b) + a
+
+    y
+  }
+
+  def train: (XorModel, Seq[Float]) = {
+    val model = new ParameterCollection
+    val trainer = new SimpleSGDTrainer(model) // i.e., stochastic gradient descent trainer
+
+    val WParameter = model.addParameters(Dim(HIDDEN_SIZE, INPUT_SIZE))
+    val bParameter = model.addParameters(Dim(HIDDEN_SIZE))
+    val VParameter = model.addParameters(Dim(OUTPUT_SIZE, HIDDEN_SIZE))
+    val aParameter = model.addParameters(Dim(OUTPUT_SIZE))
+    val xorModel = XorModel(WParameter, bParameter, VParameter, aParameter)
+
+    // Xs will be the input values; the corresponding expression is created later in mkPredictionGraph.
+    val xValues = new FloatVector(INPUT_SIZE)
+    // Y will be the expected output value, which we _input_ from gold data.
+    val yValue = new FloatPointer // because OUTPUT_SIZE is 1
+
+    val yPrediction = mkPredictionGraph(xorModel, xValues)
+    // This is done after mkPredictionGraph so that the values are not made stale by it.
+    val y = Expression.input(yValue)
+    val loss = Expression.squaredDistance(yPrediction, y)
+
+//    println()
+//    println("Computation graphviz structure:")
+//    ComputationGraph.printGraphViz()
+
+    for (iteration <- 0 until ITERATIONS) {
+      val lossValue = random.shuffle(transformations).map { transformation =>
+        transformation.transform(xValues, yValue)
+
+        val lossValue = ComputationGraph.forward(loss).toFloat()
+
+        ComputationGraph.backward(loss)
+        trainer.update()
+        lossValue
+      }.sum / transformations.length
+
+      println(s"index = $iteration, loss = $lossValue")
+      trainer.learningRate *= 0.999f
+    }
+
+    val results = predict(xorModel, xValues, yPrediction)
+
+    (xorModel, results)
+  }
+
+  protected def predict(xorModel: XorModel, xValues: FloatVector, yPrediction: Expression): Seq[Float] = {
+    var count = 0
+
+    println
+    val result = transformations.map { transformation =>
+      transformation.transform(xValues)
+      ComputationGraph.forward(yPrediction)
+
+      val yValue = yPrediction.value().toFloat()
+      val correct = transformation.output == yValue.round
+
+      if (correct)
+        count += 1
+      println(s"TRANSFORMATION = $transformation, PREDICTION = $yValue, CORRECT = $correct")
+      yValue
+    }
+    val accuracy = count / transformations.size.toFloat
+
+    println(s"Accuracy: $count / ${transformations.size} = $accuracy")
+    result
+  }
+
+  def predict(xorModel: XorModel): Seq[Float] = {
+    val xValues = new FloatVector(INPUT_SIZE)
+    val yPrediction = mkPredictionGraph(xorModel, xValues)
+
+    predict(xorModel, xValues, yPrediction)
+  }
+
+  def save(filename: String, xorModel: XorModel): Unit = {
+    new ClosableModelSaver(filename).autoClose { saver =>
+      saver.addParameter(xorModel.w, "/W")
+      saver.addParameter(xorModel.b, "/b")
+      saver.addParameter(xorModel.v, "/V")
+      saver.addParameter(xorModel.a, "/a")
+    }
+  }
+
+  def load(filename: String): XorModel = {
+    val (parameters, _) = Loader.loadParameters(filename)
+    val WParameters = parameters("/W")
+    val bParameters = parameters("/b")
+    val VParameters = parameters("/V")
+    val aParameters = parameters("/a")
+
+    XorModel(WParameters, bParameters, VParameters, aParameters)
+  }
+
+  def main(args: Array[String]) {
+    val filename = "XorModel.dat"
+
+    Initialize.initialize(Map("random-seed" -> 2522620396L))
+
+    val (xorModel1, initialResults) = train
+    val expectedResults = predict(xorModel1)
+    save(filename, xorModel1)
+
+    val xorModel2 = load(filename)
+    val actualResults = predict(xorModel2)
+
+    assert(initialResults == expectedResults)
+    assert(expectedResults == actualResults)
+  }
+}

--- a/main/src/main/scala/org/clulab/fatdynet/apps/XorScalaApp.scala
+++ b/main/src/main/scala/org/clulab/fatdynet/apps/XorScalaApp.scala
@@ -1,0 +1,10 @@
+package org.clulab.fatdynet.apps
+
+import edu.cmu.dynet.examples.XorScala
+
+object XorScalaApp {
+
+  def main(args: Array[String]) {
+    XorScala.main(args)
+  }
+}

--- a/main/src/main/scala/org/clulab/fatdynet/design/Design.scala
+++ b/main/src/main/scala/org/clulab/fatdynet/design/Design.scala
@@ -1,0 +1,141 @@
+package org.clulab.fatdynet.design
+
+import edu.cmu.dynet.ParameterCollection
+import edu.cmu.dynet._
+
+import scala.collection.mutable.ListBuffer
+
+class Artifact(val name: String, val parameter: Option[Parameter],
+    val lookupParameter: Option[LookupParameter], val rnnBuilder: Option[RnnBuilder]) {
+
+  def this(name: String, parameter: Parameter) = this(name, Some(parameter), None, None)
+
+  def this(name: String, lookupParameter: LookupParameter) = this(name, None, Some(lookupParameter), None)
+
+  def this(name: String, rnnBuilder: RnnBuilder) = this(name, None, None, Some(rnnBuilder))
+
+  def isParameter: Boolean = parameter.isDefined
+
+  def isLookupParameter: Boolean = lookupParameter.isDefined
+
+  def isRnnBuilder: Boolean = rnnBuilder.isDefined
+
+  def populate(modelLoader: ModelLoader, parameterCollection: ParameterCollection): Unit = {
+    if (isParameter)
+      modelLoader.populateParameter(parameter.get, name)
+    else if (isLookupParameter)
+      modelLoader.populateLookupParameter(lookupParameter.get, name)
+    else if (isRnnBuilder)
+      modelLoader.populateModel(parameterCollection, name)
+  }
+}
+
+abstract class Design(val name: String, val index: Option[Int]) {
+
+  def build(parameterCollection: ParameterCollection): Artifact
+
+  def isPotentiallyReorderable = false
+
+  def isActuallyReorderable = isPotentiallyReorderable && index.nonEmpty
+}
+
+class ParameterDesign(name: String, index: Option[Int], val dims: Dim)
+    extends Design(name, index) {
+
+  override def isPotentiallyReorderable: Boolean = true
+
+  override def build(parameterCollection: ParameterCollection): Artifact =
+      new Artifact(name, parameterCollection.addParameters(dims))
+}
+
+class LookupParameterDesign(name: String, index: Option[Int], val n: Long, val dims: Dim)
+    extends Design(name, index) {
+
+  override def isPotentiallyReorderable: Boolean = true
+
+  override def build(parameterCollection: ParameterCollection): Artifact =
+      new Artifact(name, parameterCollection.addLookupParameters(n, dims))
+}
+
+abstract class RnnBuilderDesign(name: String, globalIndex: Int, localIndex: Int,
+    val layers: Long, val inputDim: Long, val hiddenDim: Long)
+    extends Design(name, None) {
+
+  def newArtifact(rnnBuilder: RnnBuilder): Artifact = new Artifact(name, rnnBuilder)
+}
+
+class CompactVanillaLstmBuilderDesign(name: String, globalIndex: Int, localIndex: Int,
+    layers: Long, inputDim: Long, hiddenDim: Long)
+    extends RnnBuilderDesign(name, globalIndex, localIndex, layers, inputDim, hiddenDim) {
+
+  override def build(parameterCollection: ParameterCollection): Artifact =
+      newArtifact(new CompactVanillaLSTMBuilder(layers, inputDim, hiddenDim, parameterCollection))
+}
+
+class CoupledLstmBuilderDesign(name: String, globalIndex: Int, localIndex: Int,
+    layers: Long, inputDim: Long, hiddenDim: Long)
+    extends RnnBuilderDesign(name, globalIndex, localIndex, layers, inputDim, hiddenDim) {
+
+  override def build(parameterCollection: ParameterCollection): Artifact =
+      newArtifact(new CoupledLstmBuilder(layers, inputDim, hiddenDim, parameterCollection))
+}
+
+class FastLstmBuilderDesign(name: String, globalIndex: Int, localIndex: Int,
+    layers: Long, inputDim: Long, hiddenDim: Long)
+    extends RnnBuilderDesign(name, globalIndex, localIndex, layers, inputDim, hiddenDim) {
+
+  override def build(parameterCollection: ParameterCollection): Artifact =
+      newArtifact(new FastLstmBuilder(layers, inputDim, hiddenDim, parameterCollection))
+}
+
+class GruBuilderDesign(name: String, globalIndex: Int, localIndex: Int,
+    layers: Long, inputDim: Long, hiddenDim: Long)
+    extends RnnBuilderDesign(name, globalIndex, localIndex, layers, inputDim, hiddenDim) {
+
+  override def build(parameterCollection: ParameterCollection): Artifact =
+      newArtifact(new GruBuilder(layers, inputDim, hiddenDim, parameterCollection))
+}
+
+class LstmBuilderDesign(name: String, globalIndex: Int, localIndex: Int,
+  layers: Long, inputDim: Long, hiddenDim: Long, val lnLSTM: Boolean)
+    extends RnnBuilderDesign(name, globalIndex, localIndex, layers, inputDim, hiddenDim) {
+
+  override def build(parameterCollection: ParameterCollection): Artifact  =
+      newArtifact(new LstmBuilder(layers, inputDim, hiddenDim, parameterCollection, lnLSTM))
+}
+
+abstract class TreeLstmBuilderDesign(name: String, globalIndex: Int, localIndex: Int,
+    layers: Long, inputDim: Long, hiddenDim: Long)
+    extends RnnBuilderDesign(name, globalIndex, localIndex, layers, inputDim, hiddenDim)
+
+class BidirectionalTreeLstmBuilderDesign(name: String, globalIndex: Int, localIndex: Int,
+    layers: Long, inputDim: Long, hiddenDim: Long)
+    extends TreeLstmBuilderDesign(name, globalIndex, localIndex, layers, inputDim, hiddenDim) {
+
+  override def build(parameterCollection: ParameterCollection): Artifact =
+      newArtifact(new BidirectionalTreeLSTMBuilder(layers, inputDim, hiddenDim, parameterCollection))
+}
+
+class UnidirectionalTreeLstmBuilderDesign(name: String, globalIndex: Int, localIndex: Int,
+    layers: Long, inputDim: Long, hiddenDim: Long)
+    extends TreeLstmBuilderDesign(name, globalIndex, localIndex, layers, inputDim, hiddenDim) {
+
+  override def build(parameterCollection: ParameterCollection): Artifact =
+      newArtifact(new UnidirectionalTreeLSTMBuilder(layers, inputDim, hiddenDim, parameterCollection))
+}
+
+class SimpleRnnBuilderDesign(name: String, globalIndex: Int, localIndex: Int,
+    layers: Long, inputDim: Long, hiddenDim: Long, val supportLags: Boolean)
+    extends RnnBuilderDesign(name, globalIndex, localIndex, layers, inputDim, hiddenDim) {
+
+  override def build(parameterCollection: ParameterCollection): Artifact =
+      newArtifact(new SimpleRnnBuilder(layers, inputDim, hiddenDim, parameterCollection))
+}
+
+class VanillaLstmBuilderDesign(name: String, globalIndex: Int, localIndex: Int,
+    layers: Long, inputDim: Long, hiddenDim: Long, val lnLSTM: Boolean)
+    extends RnnBuilderDesign(name, globalIndex, localIndex, layers, inputDim, hiddenDim) {
+
+  override def build(parameterCollection: ParameterCollection): Artifact =
+      newArtifact(new VanillaLstmBuilder(layers, inputDim, hiddenDim, parameterCollection, lnLSTM))
+}

--- a/main/src/main/scala/org/clulab/fatdynet/parser/Parser.scala
+++ b/main/src/main/scala/org/clulab/fatdynet/parser/Parser.scala
@@ -1,0 +1,457 @@
+package org.clulab.fatdynet.parser
+
+import java.util.regex.Matcher
+import java.util.regex.Pattern
+
+import edu.cmu.dynet._
+import org.clulab.fatdynet.design._
+import org.clulab.fatdynet.utils.Header
+
+abstract class Parser(val name: String) {
+
+  def parse(header: Header): Boolean = false
+
+  def finish(): Design
+}
+
+abstract class ParamParser(name: String, val dims: Array[Int], index: Option[Int]) extends Parser(name)
+
+object ParamParser {
+  val nameRegex = "^(.*)"
+  val indexRegex = "_(0|[1-9][0-9]*)$"
+  val pattern = (nameRegex + "/" + indexRegex).r.pattern
+
+  def getNameAndIndex(objectName: String): (String, Option[Int]) = {
+    val matcher = pattern.matcher(objectName)
+
+    if (matcher.matches) {
+      val name = matcher.group(1)
+      val index = Option(matcher.group(2)).map(_.toInt)
+
+      (name, index)
+    }
+    else (objectName, None)
+  }
+}
+
+class ParameterParser(name: String, dims: Array[Int], index: Option[Int]) extends ParamParser(name, dims, index) {
+
+  override def parse(header: Header): Boolean = false // Only single line possible
+
+  override def finish(): Design = {
+    new ParameterDesign(name, index, Dim(dims))
+  }
+}
+
+object ParameterParser {
+  val objectType = "#Parameter#"
+
+  def mkParser(header: Header): Option[Parser] = {
+    if (header.objectType != objectType) None
+    else {
+      val (name, index) = ParamParser.getNameAndIndex(header.objectName)
+
+      Some(new ParameterParser(name, header.dims, index))
+    }
+  }
+}
+
+class LookupParameterParser(name: String, dims: Array[Int], index: Option[Int]) extends ParamParser(name, dims, index) {
+
+  override def parse(header: Header): Boolean = false // Only single line possible
+
+  override def finish(): Design = {
+    new LookupParameterDesign(name, index, dims.last, Dim(dims.dropRight(1)))
+  }
+}
+
+object LookupParameterParser {
+  val objectType = "#LookupParameter#"
+
+  def mkParser(header: Header): Option[Parser] = {
+    if (header.objectType != objectType) None
+    else {
+      val (name, index) = ParamParser.getNameAndIndex(header.objectName)
+
+      Some(new LookupParameterParser(name, header.dims, index))
+    }
+  }
+}
+
+abstract class RnnParser(name: String, val outerIndex: Int) extends Parser(name) {
+  protected val pattern: Pattern
+  protected var innerIndex: Int = 0 // Already processed first line
+  protected var inputDim: Int = -1
+  protected var hiddenDim: Int = -1
+  protected var count: Int = 0 // Number of lines overall
+
+  def isMatch(matcher: Matcher): Boolean = {
+    matcher.matches &&
+        RnnParser.getName(matcher) == name &&
+        RnnParser.getOuterIndex(matcher) == outerIndex &&
+        RnnParser.getInnerIndex(matcher) == innerIndex
+  }
+
+  def innerIndexDivideOrThrow(divisor: Int): Int = {
+    if (!(innerIndex > 0 && innerIndex % divisor == 0))
+      throw new Exception(s"For the ${this.getClass.getSimpleName}, the innerIndex should be a positive multiple of $divisor, but it was $innerIndex.")
+    innerIndex / divisor
+  }
+}
+
+object RnnParser {
+  val objectType = "#Parameter#"
+  val nameRegex = "^(.*)"
+  val outerIndexRegex = "(_[1-9][0-9]*)?"
+  val innerIndexRegex = "_(0|[1-9][0-9]*)$"
+
+  def pattern(builderType: String): Pattern = (nameRegex + "/" + builderType + outerIndexRegex + "/" + innerIndexRegex).r.pattern
+
+  def getName(matcher: Matcher): String = matcher.group(1)
+
+  def getOuterIndex(matcher: Matcher): Int = {
+    Option(matcher.group(2)).map(_.substring(1).toInt).getOrElse(0)
+  }
+
+  def getInnerIndex(matcher: Matcher): Int = {
+    matcher.group(matcher.groupCount).toInt
+  }
+
+  def mkParser(header: Header, pattern: Pattern, maker: (String, Int) => RnnParser): Option[Parser] = {
+    val matcher = pattern.matcher(header.objectName)
+
+    if (header.objectType != objectType || !matcher.matches() || getInnerIndex(matcher) != 0) None
+    else Some(maker(getName(matcher), getOuterIndex(matcher)))
+  }
+}
+
+abstract class SimpleParser(name: String, outerIndex: Int) extends RnnParser(name, outerIndex)
+
+/**
+  * This parser has to read only one line in order to figure out the number of hidden layers.
+  */
+abstract class SimpleSingleParser(name: String, outerIndex: Int) extends SimpleParser(name, outerIndex) {
+
+  override def parse(header: Header): Boolean = {
+    val matcher = pattern.matcher(header.objectName)
+
+    if (isMatch(matcher)) {
+      if (innerIndex == 0) {
+        inputDim = header.dims.last
+        hiddenDim = header.dims.head
+      }
+      innerIndex += 1
+      count += 1
+      true
+    }
+    else false
+  }
+}
+
+/**
+  * This parser has to read two lines in order to figure out the number of hidden layers.
+  */
+abstract class SimpleDoubleParser(name: String, outerIndex: Int) extends SimpleParser(name, outerIndex) {
+
+  override def parse(header: Header): Boolean = {
+    val matcher = pattern.matcher(header.objectName)
+
+    if (isMatch(matcher)) {
+      if (innerIndex == 0)
+          inputDim = header.dims.last
+      else if (innerIndex == 1)
+          hiddenDim = header.dims.last
+      innerIndex += 1
+      count += 1
+      true
+    }
+    else false
+  }
+}
+
+/**
+  * This parser has to keep track of the lnLstmCount which means it always reads two lines.
+  */
+abstract class ComplexParser(name: String, outerIndex: Int) extends RnnParser(name, outerIndex) {
+  protected val lnLstmPattern: Pattern = ComplexParser.lnLstmPattern
+  protected var lnLstmCount = 0
+  protected var lnLstmSize = -1
+
+  override def parse(header: Header): Boolean = {
+    val matcher = pattern.matcher(header.objectName)
+
+    if (isMatch(matcher)) {
+      if (innerIndex == 0) {
+        inputDim = header.dims.last
+        lnLstmSize = header.dims.head
+      }
+      else if (innerIndex == 1)
+        hiddenDim = header.dims.last
+      innerIndex += 1
+      count += 1
+      true
+    }
+    else {
+      val lnLstmMatcher = lnLstmPattern.matcher(header.objectName)
+      // We can't tell a normal variable apart from the lnLstm values, but the dimension is a good hint.
+      if (count > 0 && header.dims.head == lnLstmSize && lnLstmMatcher.matches && ComplexParser.getLstmName(lnLstmMatcher) == name) {
+          // && ComplexParser.getLstmIndex(lnLstmMatcher) == lnLstmCount) {
+          // This will not work if there are multiple ComplexRnns in the same file.  The index is not reset.
+        lnLstmCount += 1
+        count += 1
+        true
+      }
+      else false
+    }
+  }
+}
+
+object ComplexParser {
+  val lnLstmPattern: Pattern = (RnnParser.nameRegex + "/" + RnnParser.innerIndexRegex).r.pattern
+
+  def getLstmIndex(matcher: Matcher): Int = {
+    matcher.group(matcher.groupCount).toInt
+  }
+
+  def getLstmName(matcher: Matcher): String = matcher.group(1)
+}
+
+class CompactVanillaLstmParser(name: String, outerIndex: Int) extends SimpleDoubleParser(name, outerIndex) {
+  protected val pattern: Pattern = CompactVanillaLstmParser.pattern
+
+  def finish(): Design = {
+    new CompactVanillaLstmBuilderDesign(name, 3, 4, layers = innerIndexDivideOrThrow(3), inputDim, hiddenDim)
+  }
+}
+
+object CompactVanillaLstmParser {
+  val builderType = "compact-vanilla-lstm-builder"
+  val pattern: Pattern = RnnParser.pattern(builderType)
+
+  def mkParser(header: Header): Option[Parser] = {
+    RnnParser.mkParser(header, pattern, (name: String, outerIndex: Int) =>
+      new CompactVanillaLstmParser(name, outerIndex))
+  }
+}
+
+class CoupledLstmParser(name: String, outerIndex: Int) extends SimpleSingleParser(name, outerIndex) {
+  protected val pattern: Pattern = CoupledLstmParser.pattern
+
+  def finish(): Design = {
+    new CoupledLstmBuilderDesign(name, 3, 4, layers = innerIndexDivideOrThrow(11), inputDim, hiddenDim)
+  }
+}
+
+object CoupledLstmParser {
+  val builderType = "lstm-builder"
+  val pattern: Pattern = RnnParser.pattern(builderType)
+
+  def mkParser(header: Header): Option[Parser] = {
+    RnnParser.mkParser(header, pattern, (name: String, outerIndex: Int) =>
+        new CoupledLstmParser(name, outerIndex))
+  }
+}
+
+class FastLstmParser(name: String, outerIndex: Int) extends SimpleSingleParser(name, outerIndex) {
+  protected val pattern: Pattern = FastLstmParser.pattern
+
+  def finish(): Design = {
+    new FastLstmBuilderDesign(name, 3, 5, layers = innerIndexDivideOrThrow(11), inputDim, hiddenDim)
+  }
+}
+
+object FastLstmParser {
+  val builderType = "fast-lstm-builder"
+  val pattern: Pattern = RnnParser.pattern(builderType)
+
+  def mkParser(header: Header): Option[Parser] = {
+    RnnParser.mkParser(header, pattern, (name: String, outerIndex: Int) =>
+      new FastLstmParser(name, outerIndex))
+  }
+}
+
+class GruParser(name: String, outerIndex: Int) extends SimpleSingleParser(name, outerIndex) {
+  protected val pattern: Pattern = GruParser.pattern
+
+  def finish(): Design = {
+    new GruBuilderDesign(name, 4, 6, layers = innerIndexDivideOrThrow(9), inputDim, hiddenDim)
+  }
+}
+
+object GruParser {
+  val builderType = "gru-builder"
+  val pattern: Pattern = RnnParser.pattern(builderType)
+
+  def mkParser(header: Header): Option[Parser] = {
+    RnnParser.mkParser(header, pattern, (name: String, outerIndex: Int) =>
+        new GruParser(name, outerIndex))
+  }
+}
+
+class LstmParser(name: String, outerIndex: Int) extends ComplexParser(name, outerIndex) {
+  protected val pattern: Pattern = LstmParser.pattern
+
+  def finish(): Design = {
+    if (!(innerIndex > 0 && innerIndex % 3 == 0 && (lnLstmCount == 0 || lnLstmCount == innerIndex * 2)))
+      throw new Exception(s"For the ${this.getClass.getSimpleName}, the innerIndex should be a positive multiple of 3.  It is $innerIndex.  " +
+          s"Also, lnLstmCount should be 0 or twice innerIndex.  It is $lnLstmCount.")
+    new LstmBuilderDesign(name, 5, 4, layers = innerIndex / 3, inputDim, hiddenDim, lnLstmCount > 0)
+  }
+}
+
+object LstmParser {
+  val builderType = "vanilla-lstm-builder"
+  val pattern: Pattern = RnnParser.pattern(builderType)
+
+  def mkParser(header: Header): Option[Parser] = {
+    RnnParser.mkParser(header, pattern, (name: String, outerIndex: Int) =>
+        new LstmParser(name, outerIndex))
+  }
+}
+
+class BidirectionalTreeLstmParser(name: String, outerIndex: Int) extends SimpleParser(name, outerIndex) {
+  protected val pattern: Pattern = BidirectionalTreeLstmParser.pattern
+  protected var innerIndex2: Int = 0
+
+  override def isMatch(matcher: Matcher): Boolean = {
+    matcher.matches && {
+      val newName = RnnParser.getName(matcher)
+      val newOuterIndex = RnnParser.getOuterIndex(matcher)
+      val newInnerIndex = RnnParser.getInnerIndex(matcher)
+      val biIndex = BidirectionalTreeLstmParser.getBiIndex(matcher)
+
+      newName == name && newOuterIndex == outerIndex && (
+        (biIndex == 0 && newInnerIndex == innerIndex) ||
+        (biIndex == 1 && newInnerIndex == innerIndex2)
+      )
+    }
+  }
+
+  override def parse(header: Header): Boolean = {
+    val matcher = pattern.matcher(header.objectName)
+
+    if (isMatch(matcher)) {
+      val biIndex = BidirectionalTreeLstmParser.getBiIndex(matcher)
+
+      if (biIndex == 0) {
+        if (innerIndex == 0) {
+          inputDim = header.dims.last
+          hiddenDim = header.dims.head
+        }
+        innerIndex += 1
+      }
+      else
+        innerIndex2 += 1
+      count += 1
+      true
+    }
+    else false
+  }
+
+  def finish(): Design = {
+    if (innerIndex != innerIndex2)
+      throw new Exception(s"For the ${this.getClass.getSimpleName}, the two inner indexes must be equal, but they are $innerIndex and $innerIndex2.")
+    new BidirectionalTreeLstmBuilderDesign(name, 5, 4, layers = innerIndexDivideOrThrow(3), inputDim, hiddenDim / 2)
+  }
+}
+
+object BidirectionalTreeLstmParser {
+  val builderType = "bidirectional-tree-lstm-builder"
+  val pattern: Pattern = (RnnParser.nameRegex + "/" +  builderType + RnnParser.outerIndexRegex + "/vanilla-lstm-builder(_1)?" + "/" + RnnParser.innerIndexRegex).r.pattern
+
+  def getBiIndex(matcher: Matcher): Int = {
+    Option(matcher.group(3)).map(_.substring(1).toInt).getOrElse(0)
+  }
+
+  def mkParser(header: Header): Option[Parser] = {
+    RnnParser.mkParser(header, pattern, (name: String, outerIndex: Int) =>
+        new BidirectionalTreeLstmParser(name, outerIndex))
+  }
+}
+
+class UnidirectionalTreeLstmParser(name: String, outerIndex: Int) extends SimpleDoubleParser(name, outerIndex) {
+  protected val pattern: Pattern = UnidirectionalTreeLstmParser.pattern
+
+  def finish(): Design = {
+    new UnidirectionalTreeLstmBuilderDesign(name, 5, 3, layers = innerIndexDivideOrThrow(3), inputDim, hiddenDim)
+  }
+}
+
+object UnidirectionalTreeLstmParser {
+  val builderType = "unidirectional-tree-lstm-builder"
+  val pattern: Pattern = (RnnParser.nameRegex + "/" +  builderType + RnnParser.outerIndexRegex + "/vanilla-lstm-builder/" + RnnParser.innerIndexRegex).r.pattern
+
+  def mkParser(header: Header): Option[Parser] = {
+    RnnParser.mkParser(header, pattern, (name: String, outerIndex: Int) =>
+        new UnidirectionalTreeLstmParser(name, outerIndex))
+  }
+}
+
+class SimpleRnnParser(name: String, outerIndex: Int) extends RnnParser(name, outerIndex) {
+  protected val pattern: Pattern = SimpleRnnParser.pattern
+  protected var singleDimCount = 0
+
+  override def parse(header: Header): Boolean = {
+    val matcher = pattern.matcher(header.objectName)
+
+    if (isMatch(matcher)) {
+      if (innerIndex == 0) {
+        inputDim = header.dims.last
+        hiddenDim = header.dims.head
+      }
+      else
+        if (header.dims.length == 1)
+          singleDimCount += 1
+      innerIndex += 1
+      count += 1
+      true
+    }
+    else false
+  }
+
+  def finish(): Design = {
+    if (!(singleDimCount > 0))
+      throw new Exception(s"For the ${this.getClass.getSimpleName}, singleDimCount must be non-zero, but it is $singleDimCount.")
+
+    val ratio = innerIndex / singleDimCount
+    val supportLags = ratio == 4
+
+    if (!(innerIndex > 0 && innerIndex % singleDimCount == 0 && (ratio == 3 || ratio == 4)))
+      throw new Exception(s"For the ${this.getClass.getSimpleName}, the innerIndex of $innerIndex should be a positive multiple of singleDimCount, which is $singleDimCount.  " +
+          s"The multiple should be 3 or 4.  It is $ratio.")
+    new SimpleRnnBuilderDesign(name, 5, 4, layers = innerIndex / ratio, inputDim, hiddenDim, supportLags)
+  }
+}
+
+object SimpleRnnParser {
+  val builderType = "simple-rnn-builder"
+  val pattern: Pattern = RnnParser.pattern(builderType)
+
+  def mkParser(header: Header): Option[Parser] = {
+    RnnParser.mkParser(header, pattern, (name: String, outerIndex: Int) =>
+        new SimpleRnnParser(name, outerIndex))
+  }
+}
+
+class VanillaLstmParser(name: String, outerIndex: Int) extends ComplexParser(name, outerIndex) {
+  protected val pattern: Pattern = VanillaLstmParser.pattern
+
+  def finish(): Design = {
+    val divisor = 3
+
+    if (!(innerIndex > 0 && innerIndex % divisor == 0 && (lnLstmCount == 0 || lnLstmCount == innerIndex * 2)))
+      throw new Exception(s"For the ${this.getClass.getSimpleName}, the innerIndex should be a positive multiple of $divisor.  It is is $innerIndex.  " +
+          s"Also, lnLstmCount should be 0 or twice innerIndex.  It is $lnLstmCount.")
+    new VanillaLstmBuilderDesign(name, 3, 5, layers = innerIndex / divisor, inputDim, hiddenDim, lnLstmCount > 0)
+  }
+}
+
+object VanillaLstmParser {
+  val builderType = "vanilla-lstm-builder"
+  val pattern: Pattern = RnnParser.pattern(builderType)
+
+  def mkParser(header: Header): Option[Parser] = {
+    RnnParser.mkParser(header, pattern, (name: String, outerIndex: Int) =>
+        new VanillaLstmParser(name, outerIndex))
+  }
+}

--- a/main/src/main/scala/org/clulab/fatdynet/utils/Closer.scala
+++ b/main/src/main/scala/org/clulab/fatdynet/utils/Closer.scala
@@ -1,0 +1,61 @@
+package org.clulab.fatdynet.utils
+
+import scala.util.control.NonFatal
+
+object Closer {
+
+  protected type Closeable = {def close(): Unit}
+
+  def close[Resource <: Closeable](resource: => Resource): Unit = resource.close()
+
+  // This is so that exceptions caused during close are caught, but don't
+  // prevent the registration of any previous exception.
+  // See also https://medium.com/@dkomanov/scala-try-with-resources-735baad0fd7d.
+  // Others have resource: => Closeable, but I want the resource evaluated beforehand
+  // so that it doesn't throw an exception before there is anything to close.
+  def autoClose[Resource <: Closeable, Result](resource: Resource)(function: Resource => Result): Result = {
+
+    val (result: Option[Result], exception: Option[Throwable]) = try {
+      (Some(function(resource)), None)
+    }
+    catch {
+      case exception: Throwable => (None, Some(exception))
+    }
+
+    val closeException: Option[Throwable] = Option(resource).flatMap { resource =>
+      try {
+        resource.close()
+        None
+      }
+      catch {
+        case exception: Throwable => Some(exception)
+      }
+    }
+
+    (exception, closeException) match {
+      case (None, None) => result.get
+      case (Some(ex), None) => throw ex
+      case (None, Some(ex)) => throw ex
+      case (Some(ex), Some(closeEx)) => (ex, closeEx) match {
+        case (e, NonFatal(nonfatal)) =>
+          // Put the potentially fatal one first.
+          e.addSuppressed(nonfatal)
+          throw e
+        case (NonFatal(nonfatal), e) =>
+          // Put the potentially fatal one first.
+          e.addSuppressed(nonfatal)
+          throw e
+        case (e, closeE) =>
+          // On tie, put exception before closeException.
+          e.addSuppressed(closeE)
+          throw e
+      }
+    }
+  }
+
+  // Allow for alternative syntax closeable.autoClose { closeable => ... }
+  implicit class AutoCloser[Resource <: Closer.Closeable](resource: Resource) {
+
+    def autoClose[Result](function: Resource => Result): Result = Closer.autoClose(resource)(function)
+  }
+}

--- a/main/src/main/scala/org/clulab/fatdynet/utils/Deleter.scala
+++ b/main/src/main/scala/org/clulab/fatdynet/utils/Deleter.scala
@@ -1,0 +1,57 @@
+package org.clulab.fatdynet.utils
+
+import scala.util.control.NonFatal
+
+object Deleter {
+
+  protected type Deleteable = {def delete(): Boolean}
+
+  def delete[Resource <: Deleteable](resource: => Resource): Unit = resource.delete()
+
+  // See also Closer
+  def autoDelete[Resource <: Deleteable, Result](resource: Resource)(function: Resource => Result): Result = {
+
+    val (result: Option[Result], exception: Option[Throwable]) = try {
+      (Some(function(resource)), None)
+    }
+    catch {
+      case exception: Throwable => (None, Some(exception))
+    }
+
+    val deleteException: Option[Throwable] = Option(resource).flatMap { resource =>
+      try {
+        resource.delete()
+        None
+      }
+      catch {
+        case exception: Throwable => Some(exception)
+      }
+    }
+
+    (exception, deleteException) match {
+      case (None, None) => result.get
+      case (Some(ex), None) => throw ex
+      case (None, Some(ex)) => throw ex
+      case (Some(ex), Some(deleteEx)) => (ex, deleteEx) match {
+        case (e, NonFatal(nonfatal)) =>
+          // Put the potentially fatal one first.
+          e.addSuppressed(nonfatal)
+          throw e
+        case (NonFatal(nonfatal), e) =>
+          // Put the potentially fatal one first.
+          e.addSuppressed(nonfatal)
+          throw e
+        case (e, deleteE) =>
+          // On tie, put exception before deleteException.
+          e.addSuppressed(deleteE)
+          throw e
+      }
+    }
+  }
+
+  // Allow for alternative syntax deleteable.autoDelete { deleteable => ... }
+  implicit class AutoDeleter[Resource <: Deleter.Deleteable](resource: Resource) {
+
+    def autoDelete[Result](function: Resource => Result): Result = Deleter.autoDelete(resource)(function)
+  }
+}

--- a/main/src/main/scala/org/clulab/fatdynet/utils/Header.scala
+++ b/main/src/main/scala/org/clulab/fatdynet/utils/Header.scala
@@ -1,0 +1,7 @@
+package org.clulab.fatdynet.utils
+
+class Header(val line: String, val lineNo: Int) {
+  val Array(objectType, objectName, dimension, _, _) = line.split(" ")
+  // Skip leading { and trailing }
+  val dims = dimension.substring(1, dimension.length - 1).split(",").map(_.toInt)
+}

--- a/main/src/main/scala/org/clulab/fatdynet/utils/Loader.scala
+++ b/main/src/main/scala/org/clulab/fatdynet/utils/Loader.scala
@@ -1,0 +1,425 @@
+package org.clulab.fatdynet.utils
+
+import java.util.regex.Pattern
+
+import edu.cmu.dynet.{
+  Dim,
+  LookupParameter,
+  ModelLoader,
+  ModelSaver,
+  Parameter,
+  ParameterCollection,
+
+  FastLstmBuilder,
+  LstmBuilder,
+  CompactVanillaLSTMBuilder,
+  CoupledLstmBuilder,
+  VanillaLstmBuilder,
+
+  // TreeLSTMBuilder, // abstract
+    UnidirectionalTreeLSTMBuilder,
+    BidirectionalTreeLSTMBuilder,
+
+  RnnBuilder, // abstract
+  SimpleRnnBuilder,
+
+  GruBuilder
+}
+import org.clulab.fatdynet.utils.Closer.AutoCloser
+
+import scala.collection.mutable
+import scala.io.Source
+
+/**
+  * See https://dynet.readthedocs.io/en/latest/python_saving_tutorial.html
+  */
+abstract class Loader(path: String, namespace: String) {
+
+  def namespaceFilter(objectName: String): Boolean = objectName.startsWith(namespace)
+
+  def parameterFilter(objectType: String, objectName: String): Boolean =
+      (objectType == "#Parameter#" || objectType == "#LookupParameter#") && !objectName.matches(".*/_[0-9]+$")
+
+  def modelFilter(objectType: String, objectName: String): Boolean
+  def newBuilder(modelLoader: ModelLoader, model: ParameterCollection): Option[RnnBuilder]
+
+  protected def readParameters(modelLoader: ModelLoader, objectType: String, objectName: String, dims: Array[Int],
+      parameters: mutable.Map[String, Parameter], lookupParameters: mutable.Map[String, LookupParameter]): Boolean = {
+    objectType match {
+      case "#Parameter#" =>
+        val pc = new ParameterCollection()
+        val param = pc.addParameters(Dim(dims))
+        modelLoader.populateParameter(param, key = objectName)
+        parameters(objectName) = param
+        true
+      case "#LookupParameter#" =>
+        val pc = new ParameterCollection()
+        val param = pc.addLookupParameters(dims.last, Dim(dims.dropRight(1)))
+        modelLoader.populateLookupParameter(param, key = objectName)
+        lookupParameters(objectName) = param
+        true
+      case _ => false
+    }
+  }
+
+  protected def readModel(modelLoader: ModelLoader, objectType: String, objectName: String, dims: Array[Int]): Boolean
+
+  protected def readLine(lineno: Int, line: String, modelLoader: ModelLoader, parameters: mutable.Map[String, Parameter],
+      lookupParameters: mutable.Map[String, LookupParameter], useParameters: Boolean, useBuilder: Boolean): Unit = {
+    val Array(objectType, objectName, dimension, _, _) = line.split(" ")
+    // Skip leading { and trailing }
+    val dims = dimension.substring(1, dimension.length - 1).split(",").map(_.toInt)
+
+    if (namespaceFilter(objectName)) {
+      if (modelFilter(objectType, objectName)) {
+        if (useBuilder)
+          if (!readModel(modelLoader, objectType, objectName, dims))
+            throw new RuntimeException(s"Found unrecognized object type '$objectType' while reading model in line $lineno: '$line'")
+      }
+      else if (parameterFilter(objectType, objectName)) {
+        if (useParameters)
+          if (!readParameters(modelLoader, objectType, objectName, dims, parameters, lookupParameters))
+            throw new RuntimeException(s"Found unrecognized object type '$objectType' while reading parameter in line $lineno: '$line'")
+      }
+      else
+        throw new RuntimeException(s"Encountered unrecognized object type '$objectType' while reading line $lineno: '$line'")
+    }
+  }
+
+  protected def load(useParameters: Boolean, useBuilder: Boolean):
+      (Map[String, Parameter], Map[String, LookupParameter], Option[RnnBuilder], ParameterCollection) = {
+    new Loader.ClosableModelLoader(path).autoClose { modelLoader =>
+      Source.fromFile(path).autoClose { source =>
+        val parameters = mutable.Map[String, Parameter]()
+        val lookupParameters = mutable.Map[String, LookupParameter]()
+
+        source
+            .getLines
+            //.zipWithIndex
+            .filter(line => line.startsWith("#"))
+            .foreach(line => readLine(5, line, modelLoader, parameters, lookupParameters, useParameters, useBuilder))
+
+        val model = new ParameterCollection
+        val optionBuilder = if (useBuilder) newBuilder(modelLoader, model) else None
+
+        (parameters.toMap, lookupParameters.toMap, optionBuilder, model)
+      }
+    }
+  }
+
+  def loadParameters: (Map[String, Parameter], Map[String, LookupParameter]) = {
+    val (parameters, lookupParameters, _, _) = load(useParameters = true, useBuilder = false)
+    (parameters, lookupParameters)
+  }
+
+  def loadBuilder: (Option[RnnBuilder], ParameterCollection) = {
+    val (_, _, builder, model) = load(useParameters = false, useBuilder = true)
+    (builder, model)
+  }
+
+  def loadParametersAndBuilder: (Map[String, Parameter], Map[String, LookupParameter], Option[RnnBuilder], ParameterCollection) = {
+    val (parameters, lookupParameters, builder, model) = load(useParameters = true, useBuilder = true)
+    (parameters, lookupParameters, builder, model)
+  }
+}
+
+class ParameterLoader(path: String, namespace: String) extends Loader(path, namespace) {
+
+  def modelFilter(objectType: String, objectName: String): Boolean = !parameterFilter(objectType, objectName)
+
+  protected def readModel(modelLoader: ModelLoader, objectType: String, objectName: String, dims: Array[Int]): Boolean = true
+
+  def newBuilder(modelLoader: ModelLoader, model: ParameterCollection): Option[RnnBuilder] = None
+}
+
+abstract class SimpleLoader(path: String, namespace: String) extends Loader(path, namespace) {
+  protected val pattern: Pattern
+  protected var count: Int = 0
+  protected var inputDim: Int = -1
+  protected var hiddenDim: Int = -1
+  protected var name: String = ""
+
+  def modelFilter(objectType: String, objectName: String): Boolean =
+      objectType == "#Parameter#" && pattern.matcher(objectName).matches
+
+  protected def readModelSingleLine(modelLoader: ModelLoader, objectType: String, objectName: String, dims: Array[Int]): Boolean = {
+    val matcher = pattern.matcher(objectName)
+
+    if (matcher.matches) {
+      if (count == 0) {
+        inputDim = dims.last
+        hiddenDim = dims.head
+        name = matcher.group(1)
+      }
+      else
+        require(matcher.group(1) == name)
+      count += 1
+      true
+    }
+    else
+      false
+  }
+
+  protected def readModelDoubleLine(modelLoader: ModelLoader, objectType: String, objectName: String, dims: Array[Int]): Boolean = {
+    val matcher = pattern.matcher(objectName)
+
+    if (matcher.matches) {
+      if (count == 0) {
+        inputDim = dims.last
+        name = matcher.group(1)
+      }
+      else {
+        require(matcher.group(1) == name)
+        if (count == 1)
+          hiddenDim = dims.last
+      }
+      count += 1
+      true
+    }
+    else
+      false
+  }
+
+  protected def populate(builder: RnnBuilder, modelLoader: ModelLoader, model: ParameterCollection): Option[RnnBuilder] = {
+    modelLoader.populateModel(model, name)
+    Some(builder)
+  }
+}
+
+abstract class ComplexLoader(path: String, namespace: String) extends SimpleLoader(path, namespace) {
+  protected val lnLstmPattern: Pattern = Loader.lnLstmPattern
+  protected var lnLstmCount = 0
+
+  override def modelFilter(objectType: String, objectName: String): Boolean =
+    objectType == "#Parameter#" && (pattern.matcher(objectName).matches || lnLstmPattern.matcher(objectName).matches)
+
+  protected def readModel(modelLoader: ModelLoader, objectType: String, objectName: String, dims: Array[Int]): Boolean = {
+    val matcher = pattern.matcher(objectName)
+    val lnLstmMatcher = lnLstmPattern.matcher(objectName)
+
+    if (matcher.matches) {
+      if (count == 0) {
+        inputDim = dims.last
+        name = matcher.group(1)
+      }
+      else {
+        require(matcher.group(1) == name)
+        if (count == 1)
+          hiddenDim = dims.last
+      }
+      count += 1
+      true
+    }
+    else if (count > 0 && lnLstmMatcher.matches && lnLstmMatcher.group(1) == name) {
+      lnLstmCount += 1
+      true
+    }
+    else
+      false
+  }
+}
+
+class FastLstmLoader(path: String, namespace: String) extends SimpleLoader(path, namespace) {
+  protected val pattern: Pattern = Loader.fastLstmLoaderPattern
+
+  protected def readModel(modelLoader: ModelLoader, objectType: String, objectName: String, dims: Array[Int]): Boolean =
+      readModelSingleLine(modelLoader, objectType, objectName, dims)
+
+  def newBuilder(modelLoader: ModelLoader, model: ParameterCollection): Option[RnnBuilder] =
+      if (count > 0 && count % 11 == 0)
+        populate(new FastLstmBuilder(count / 11, inputDim, hiddenDim, model), modelLoader, model)
+      else
+        None
+}
+
+class LstmLoader(path: String, namespace: String) extends ComplexLoader(path, namespace) {
+  protected val pattern: Pattern = Loader.lstmLoaderPattern
+
+  def newBuilder(modelLoader: ModelLoader, model: ParameterCollection): Option[RnnBuilder] =
+      if (count > 0 && count % 3 == 0 && (lnLstmCount == 0 || lnLstmCount == count * 2))
+        populate(new LstmBuilder(count / 3, inputDim, hiddenDim, model, lnLstmCount > 0), modelLoader, model)
+      else
+        None
+}
+
+class CompactVanillaLstmLoader(path: String, namespace: String) extends SimpleLoader(path, namespace) {
+  protected val pattern: Pattern = Loader.compactVanillaLstmPattern
+
+  protected def readModel(modelLoader: ModelLoader, objectType: String, objectName: String, dims: Array[Int]): Boolean =
+      readModelDoubleLine(modelLoader, objectType, objectName, dims)
+
+  def newBuilder(modelLoader: ModelLoader, model: ParameterCollection): Option[RnnBuilder] =
+      if (count > 0 && count % 3 == 0)
+        populate(new CompactVanillaLSTMBuilder(count / 3, inputDim, hiddenDim, model), modelLoader, model)
+      else
+        None
+}
+
+class CoupledLstmLoader(path: String, namespace: String) extends SimpleLoader(path, namespace) {
+  protected val pattern: Pattern = Loader.coupledLstmPattern
+
+  protected def readModel(modelLoader: ModelLoader, objectType: String, objectName: String, dims: Array[Int]): Boolean =
+      readModelSingleLine(modelLoader, objectType, objectName, dims)
+
+  def newBuilder(modelLoader: ModelLoader, model: ParameterCollection): Option[RnnBuilder] =
+      if (count > 0 && count % 11 == 0)
+        populate(new CoupledLstmBuilder(count / 11, inputDim, hiddenDim, model), modelLoader, model)
+      else
+        None
+}
+
+class VanillaLstmLoader(path: String, namespace: String) extends ComplexLoader(path, namespace) {
+  protected val pattern: Pattern = Loader.vanillaLstmPattern
+
+  def newBuilder(modelLoader: ModelLoader, model: ParameterCollection): Option[RnnBuilder] =
+      if (count > 0 && count % 3 == 0 && (lnLstmCount == 0 || lnLstmCount == count * 2))
+        populate(new VanillaLstmBuilder(count / 3, inputDim, hiddenDim, model, lnLstmCount > 0), modelLoader, model)
+      else
+        None
+}
+
+class UnidirectionalTreeLstmLoader(path: String, namespace: String) extends SimpleLoader(path, namespace) {
+  protected val pattern: Pattern = Loader.unidirectionalTreeLstmPattern
+
+  protected def readModel(modelLoader: ModelLoader, objectType: String, objectName: String, dims: Array[Int]): Boolean =
+    readModelDoubleLine(modelLoader, objectType, objectName, dims)
+
+  def newBuilder(modelLoader: ModelLoader, model: ParameterCollection): Option[RnnBuilder] =
+      if (count > 0 && count % 3 == 0)
+        populate(new UnidirectionalTreeLSTMBuilder(count / 3, inputDim, hiddenDim, model), modelLoader, model)
+      else
+        None
+}
+
+class BidirectionalTreeLstmLoader(path: String, namespace: String) extends SimpleLoader(path, namespace) {
+  protected val pattern: Pattern = Loader.bidirectionalTreeLstmPattern
+
+  protected def readModel(modelLoader: ModelLoader, objectType: String, objectName: String, dims: Array[Int]): Boolean =
+      readModelSingleLine(modelLoader, objectType, objectName, dims)
+
+  def newBuilder(modelLoader: ModelLoader, model: ParameterCollection): Option[RnnBuilder] =
+      if (count > 0 && count % 6 == 0)
+        populate(new BidirectionalTreeLSTMBuilder(count / 6, inputDim, hiddenDim / 2, model), modelLoader, model)
+      else
+        None
+}
+
+class SimpleRnnLoader(path: String, namespace: String) extends SimpleLoader(path, namespace) {
+  protected val pattern: Pattern = Loader.simpleRnnPattern
+  protected var singleDimCount = 0
+
+  protected def readModel(modelLoader: ModelLoader, objectType: String, objectName: String, dims: Array[Int]): Boolean = {
+    val matcher = pattern.matcher(objectName)
+
+    if (matcher.matches) {
+      if (count == 0) {
+        inputDim = dims.last
+        hiddenDim = dims.head
+        name = matcher.group(1)
+      }
+      else {
+        require(matcher.group(1) == name)
+        if (dims.length == 1)
+          singleDimCount += 1
+      }
+      count += 1
+      true
+    }
+    else
+      false
+  }
+
+  def newBuilder(modelLoader: ModelLoader, model: ParameterCollection): Option[RnnBuilder] = {
+    val ratio = count / singleDimCount
+    val supportLags = ratio == 4
+
+    if (count > 0 && count % singleDimCount == 0 && (ratio == 3 || ratio == 4))
+      populate(new SimpleRnnBuilder(count / ratio, inputDim, hiddenDim, model, supportLags), modelLoader, model)
+    else
+      None
+  }
+}
+
+class GruLoader(path: String, namespace: String) extends SimpleLoader(path, namespace) {
+  protected val pattern: Pattern = Loader.gruPattern
+
+  protected def readModel(modelLoader: ModelLoader, objectType: String, objectName: String, dims: Array[Int]): Boolean =
+      readModelSingleLine(modelLoader, objectType, objectName, dims)
+
+  def newBuilder(modelLoader: ModelLoader, model: ParameterCollection): Option[RnnBuilder] =
+      if (count > 0 && count % 9 == 0)
+        populate(new GruBuilder(count / 9, inputDim, hiddenDim, model), modelLoader, model)
+      else
+        None
+}
+
+object Loader {
+  lazy val fastLstmLoaderPattern: Pattern = "(.*)/fast-lstm-builder/_[0-9]+$".r.pattern
+  lazy val lstmLoaderPattern: Pattern = "(.*)/vanilla-lstm-builder/_[0-9]+$".r.pattern
+  lazy val compactVanillaLstmPattern: Pattern = "(.*)/compact-vanilla-lstm-builder/_[0-9]+$".r.pattern
+  lazy val coupledLstmPattern: Pattern = "(.*)/lstm-builder/_[0-9]+$".r.pattern
+  lazy val vanillaLstmPattern: Pattern = "(.*)/vanilla-lstm-builder/_[0-9]+$".r.pattern
+  lazy val unidirectionalTreeLstmPattern: Pattern = "(.*)/unidirectional-tree-lstm-builder/vanilla-lstm-builder/_[0-9]+$".r.pattern
+  lazy val bidirectionalTreeLstmPattern: Pattern = "(.*)/bidirectional-tree-lstm-builder/vanilla-lstm-builder(_1)?/_[0-9]+$".r.pattern
+  lazy val simpleRnnPattern: Pattern = "(.*)/simple-rnn-builder/_[0-9]+$".r.pattern
+  lazy val gruPattern: Pattern = "(.*)/gru-builder/_[0-9]+$".r.pattern
+
+  lazy val lnLstmPattern: Pattern = "(.*)/_[0-9]+$".r.pattern
+
+  class ClosableModelLoader(filename: String) extends ModelLoader(filename) {
+    def close(): Unit = done
+  }
+
+  class ClosableModelSaver(filename: String) extends ModelSaver(filename) {
+    def close(): Unit = done
+  }
+
+  def loadParameters(path: String, namespace: String = ""): (Map[String, Parameter], Map[String, LookupParameter]) = {
+    new ParameterLoader(path, namespace).loadParameters
+  }
+
+  def loadFastLstm(path: String, namespace: String = ""): (Option[FastLstmBuilder], Option[ParameterCollection], Map[String, Parameter], Map[String, LookupParameter]) = {
+    val (parameters, lookupParameters, someBuilder: Option[RnnBuilder], model) = new FastLstmLoader(path, namespace).loadParametersAndBuilder
+    (someBuilder.map(_.asInstanceOf[FastLstmBuilder]), Some(model), parameters, lookupParameters)
+  }
+
+  def loadLstm(path: String, namespace: String = ""): (Option[LstmBuilder], Option[ParameterCollection], Map[String, Parameter], Map[String, LookupParameter]) = {
+    val (parameters, lookupParameters, someBuilder: Option[RnnBuilder], model) = new LstmLoader(path, namespace).loadParametersAndBuilder
+    (someBuilder.map(_.asInstanceOf[LstmBuilder]), Some(model), parameters, lookupParameters)
+  }
+
+  def loadCompactVanillaLstm(path: String, namespace: String = ""): (Option[CompactVanillaLSTMBuilder], Option[ParameterCollection], Map[String, Parameter], Map[String, LookupParameter]) = {
+    val (parameters, lookupParameters, someBuilder: Option[RnnBuilder], model) = new CompactVanillaLstmLoader(path, namespace).loadParametersAndBuilder
+    (someBuilder.map(_.asInstanceOf[CompactVanillaLSTMBuilder]), Some(model), parameters, lookupParameters)
+  }
+
+  def loadCoupledLstm(path: String, namespace: String = ""): (Option[CoupledLstmBuilder], Option[ParameterCollection], Map[String, Parameter], Map[String, LookupParameter]) = {
+    val (parameters, lookupParameters, someBuilder: Option[RnnBuilder], model) = new CoupledLstmLoader(path, namespace).loadParametersAndBuilder
+    (someBuilder.map(_.asInstanceOf[CoupledLstmBuilder]), Some(model), parameters, lookupParameters)
+  }
+
+  def loadVanillaLstm(path: String, namespace: String = ""): (Option[VanillaLstmBuilder], Option[ParameterCollection], Map[String, Parameter], Map[String, LookupParameter]) = {
+    val (parameters, lookupParameters, someBuilder: Option[RnnBuilder], model) = new VanillaLstmLoader(path, namespace).loadParametersAndBuilder
+    (someBuilder.map(_.asInstanceOf[VanillaLstmBuilder]), Some(model), parameters, lookupParameters)
+  }
+
+  def loadUnidirectionalTreeLstm(path: String, namespace: String = ""): (Option[UnidirectionalTreeLSTMBuilder], Option[ParameterCollection], Map[String, Parameter], Map[String, LookupParameter]) = {
+    val (parameters, lookupParameters, someBuilder: Option[RnnBuilder], model) = new UnidirectionalTreeLstmLoader(path, namespace).loadParametersAndBuilder
+    (someBuilder.map(_.asInstanceOf[UnidirectionalTreeLSTMBuilder]), Some(model), parameters, lookupParameters)
+  }
+
+  def loadBidirectionalTreeLstm(path: String, namespace: String = ""): (Option[BidirectionalTreeLSTMBuilder], Option[ParameterCollection], Map[String, Parameter], Map[String, LookupParameter]) = {
+    val (parameters, lookupParameters, someBuilder: Option[RnnBuilder], model) = new BidirectionalTreeLstmLoader(path, namespace).loadParametersAndBuilder
+    (someBuilder.map(_.asInstanceOf[BidirectionalTreeLSTMBuilder]), Some(model), parameters, lookupParameters)
+  }
+
+  def loadSimpleRnn(path: String, namespace: String = ""): (Option[SimpleRnnBuilder], Option[ParameterCollection], Map[String, Parameter], Map[String, LookupParameter]) = {
+    val (parameters, lookupParameters, someBuilder: Option[RnnBuilder], model) = new SimpleRnnLoader(path, namespace).loadParametersAndBuilder
+    (someBuilder.map(_.asInstanceOf[SimpleRnnBuilder]), Some(model), parameters, lookupParameters)
+  }
+
+  def loadGru(path: String, namespace: String = ""): (Option[GruBuilder], Option[ParameterCollection], Map[String, Parameter], Map[String, LookupParameter]) = {
+    val (parameters, lookupParameters, someBuilder: Option[RnnBuilder], model) = new GruLoader(path, namespace).loadParametersAndBuilder
+    (someBuilder.map(_.asInstanceOf[GruBuilder]), Some(model), parameters, lookupParameters)
+  }
+}

--- a/main/src/main/scala/org/clulab/fatdynet/utils/Saver.scala
+++ b/main/src/main/scala/org/clulab/fatdynet/utils/Saver.scala
@@ -1,0 +1,10 @@
+package org.clulab.fatdynet.utils
+
+import edu.cmu.dynet._
+
+object Saver {
+
+  class ClosableModelSaver(filename: String) extends ModelSaver(filename) {
+    def close(): Unit = done
+  }
+}

--- a/main/src/main/scala/org/clulab/fatdynet/utils/Transducer.scala
+++ b/main/src/main/scala/org/clulab/fatdynet/utils/Transducer.scala
@@ -1,0 +1,11 @@
+package org.clulab.fatdynet.utils
+
+import edu.cmu.dynet._
+
+object Transducer {
+
+  def transduce(builder: RnnBuilder, inputs: Seq[Expression]): Seq[Expression] = {
+    builder.startNewSequence()
+    inputs.map(builder.addInput)
+  }
+}


### PR DESCRIPTION
Please do not merge.  This shows how RNN.scala would work with the new version of fatdynet.  There is a PR for that at https://github.com/clulab/fatdynet/pull/8.  Imagine that load(dynetFilename:String, x2iFilename: String) was working with a model trained and saved from Python and couldn't reuse the Scala code.