### PR TITLE
Fix calculateHashCode to use general trait rather than class name

### DIFF
--- a/odin/src/main/scala/org/clulab/odin/Mention.scala
+++ b/odin/src/main/scala/org/clulab/odin/Mention.scala
@@ -170,7 +170,7 @@ trait Mention extends Equals with Ordered[Mention] with Serializable {
   protected lazy val cachedHashCode = calculateHashCode
 
   protected def calculateHashCode: Int = {
-    val h0 = stringHash(getClass.getName)
+    val h0 = stringHash("org.clulab.odin.Mention")
     val h1 = mix(h0, labels.hashCode)
     val h2 = mix(h1, tokenInterval.hashCode)
     val h3 = mix(h2, sentence.hashCode)


### PR DESCRIPTION
If class names are compared instead, reach crashes in MentionFilter.synPathContainsTrigger.  It is getting an unexpected mention there which has a synPath of None.  I'm not sure whether it should just be more careful there or whether the hash code is solely to blame.  This fixes the breaking problem, though.