### PR TITLE
Supporting  `@trigger:Label` notation for triggers

### DIFF
--- a/odin/src/main/scala/org/clulab/odin/impl/Extractor.scala
+++ b/odin/src/main/scala/org/clulab/odin/impl/Extractor.scala
@@ -51,7 +51,7 @@ class TokenExtractor(
     (groupsTrigger, mentionsTrigger) match {
       case (Some(groupTriggerKey), Some(mentionTriggerKey)) =>
         // Can't have both notations
-        throw new RuntimeException("Can't specify a trigger in as both named capture and named mention")
+        throw new RuntimeException("Can't specify a trigger as both named capture and named mention")
       case (Some(groupTriggerKey), None) =>
         // having several triggers in the same rule is not supported
         // the first will be used and the rest ignored


### PR DESCRIPTION
Added test to verify -- previously failed (as expected), now passes.
IDK if this syntax is efficient / in keeping with odin stuff but thought it would at least get the convo started...
if merged, I think it...

closes #321 