### PR TITLE
add weighted embd methods

### DIFF
--- a/main/src/main/scala/org/clulab/embeddings/word2vec/CompactWord2Vec.scala
+++ b/main/src/main/scala/org/clulab/embeddings/word2vec/CompactWord2Vec.scala
@@ -136,8 +136,8 @@ class CompactWord2Vec(buildType: CompactWord2Vec.BuildType) {
   def makeCompositeVectorWeighted(text: Iterable[String], weights:Iterable[Float]): CompactWord2Vec.ArrayType = {
     val total = new CompactWord2Vec.ArrayType(columns)
 
-    for (idx <- 0 until text.size){
-      map.get(text(idx)).foreach { index => addWeighted(total, index, weights(idx)) }
+    (text, weights).zipped.foreach { (word, weight) =>
+      map.get(word).foreach { index => addWeighted(total, index, weight) }
     }
 
     norm(total)

--- a/main/src/main/scala/org/clulab/embeddings/word2vec/CompactWord2Vec.scala
+++ b/main/src/main/scala/org/clulab/embeddings/word2vec/CompactWord2Vec.scala
@@ -136,9 +136,10 @@ class CompactWord2Vec(buildType: CompactWord2Vec.BuildType) {
   def makeCompositeVectorWeighted(text: Iterable[String], weights:Iterable[Float]): CompactWord2Vec.ArrayType = {
     val total = new CompactWord2Vec.ArrayType(columns)
 
-    (text, weights).zipped.foreach { (word, weight) =>
-      map.get(word).foreach { index => addWeighted(total, index, weight) }
+    for (idx <- 0 until text.size){
+      map.get(text(idx)).foreach { index => addWeighted(total, index, weights(idx)) }
     }
+
     norm(total)
   }
 

--- a/main/src/main/scala/org/clulab/embeddings/word2vec/CompactWord2Vec.scala
+++ b/main/src/main/scala/org/clulab/embeddings/word2vec/CompactWord2Vec.scala
@@ -90,6 +90,16 @@ class CompactWord2Vec(buildType: CompactWord2Vec.BuildType) {
     }
   }
 
+  protected def addWeighted(dest: CompactWord2Vec.ArrayType, srcRow: Int, weight:Float): Unit = {
+    val srcOffset = srcRow * columns
+    var i = 0 // optimization
+
+    while (i < columns) {
+      dest(i) += array(srcOffset + i)*weight
+      i += 1
+    }
+  }
+
   def isOutOfVocabulary(word: String): Boolean = !map.contains(Word2VecUtils.sanitizeWord(word))
 
   // Normalize this vector to length 1, in place.
@@ -119,6 +129,15 @@ class CompactWord2Vec(buildType: CompactWord2Vec.BuildType) {
 
     text.foreach { word =>
       map.get(word).foreach { index => add(total, index) }
+    }
+    norm(total)
+  }
+
+  def makeCompositeVectorWeighted(text: Iterable[String], weights:Iterable[Float]): CompactWord2Vec.ArrayType = {
+    val total = new CompactWord2Vec.ArrayType(columns)
+
+    (text, weights).zipped.foreach { (word, weight) =>
+      map.get(word).foreach { index => addWeighted(total, index, weight) }
     }
     norm(total)
   }


### PR DESCRIPTION
1, Added two functions in the CompactWord2Vec file: addWeighted and makeCompositeVectorWeighted. They allow giving different weights to the tokens when composing the embedding. 
2, The local publish version is "8.0.2-SNAPSHOT". If you modify this, the "procVer" value in eidos build.sbt should also be changed. 