### PR TITLE
Add reusable menu components

### DIFF
--- a/corenlp/src/main/scala/org/clulab/processors/ProcessorShell.scala
+++ b/corenlp/src/main/scala/org/clulab/processors/ProcessorShell.scala
@@ -1,14 +1,17 @@
 package org.clulab.processors
 
-import scala.collection.immutable.ListMap
-import org.clulab.processors.corenlp.CoreNLPProcessor
-import org.clulab.processors.fastnlp.{FastNLPProcessor, FastNLPProcessorWithSemanticRoles}
-import java.io.{File, PrintWriter}
+import java.io.PrintWriter
 
-import jline.console.ConsoleReader
-import jline.console.history.FileHistory
 import org.clulab.dynet.Utils
 import org.clulab.processors.clu.CluProcessor
+import org.clulab.processors.corenlp.CoreNLPProcessor
+import org.clulab.processors.fastnlp.{FastNLPProcessor, FastNLPProcessorWithSemanticRoles}
+import org.clulab.utils.CliReader
+import org.clulab.utils.DefaultMenuItem
+import org.clulab.utils.ExitMenuItem
+import org.clulab.utils.HelpMenuItem
+import org.clulab.utils.MainMenuItem
+import org.clulab.utils.Menu
 
 /**
   * A simple interactive shell
@@ -17,80 +20,51 @@ import org.clulab.processors.clu.CluProcessor
   * Last Modified: Fix compiler warning: remove redundant match case clause.
  */
 object ProcessorShell extends App {
-
-  val history = new FileHistory(new File(System.getProperty("user.home"), ".processorshellhistory"))
-  sys addShutdownHook {
-    history.flush() // flush file before exiting
-  }
-
-  val reader = new ConsoleReader
-  reader.setHistory(history)
-
-  val commands = ListMap(
-    ":help" -> "show commands",
-    ":core" -> "use CoreNLPProcessor",
-    ":fast" -> "use FastNLPProcessor",
-    ":clu" -> "use CluProcessor",
-    ":exit" -> "exit system"
-  )
-
-  // create the processor
   lazy val core: Processor = new CoreNLPProcessor() // this uses the slower constituent parser
   lazy val fast: Processor = new FastNLPProcessorWithSemanticRoles() // this uses the faster dependency parser
   lazy val clu: Processor = new CluProcessor()
 
-  var proc = core
-  reader.setPrompt("(core)>>> ")
-  println("\nWelcome to the ProcessorShell!")
-  printCommands()
+  var proc = core // The initial proc does not get initialized.
+  val corePrompt = "(core)>>> "
 
-  var running = true
+  val lineReader = new CliReader(corePrompt, "user.home", ".processorshellhistory")
   val printWriter = new PrintWriter(System.out)
 
-  while (running) {
-    reader.readLine match {
-      case ":help" =>
-        printCommands()
-
-      case ":core" =>
-        reader.setPrompt("(core)>>> ")
-        println("Preparing CoreNLPProcessor...\n")
-        proc = core
-        proc.annotate("initialize me!")
-
-      case ":fast" =>
-        reader.setPrompt("(fast)>>> ")
-        println("Preparing FastNLPProcessor...\n")
-        proc = fast
-        proc.annotate("initialize me!")
-
-      case ":clu" =>
-        reader.setPrompt("(clu)>>> ")
-        println("Preparing CluProcessor...\n")
-        Utils.initializeDyNet()
-        proc = clu
-        proc.annotate("initialize me!")
-
-      case ":exit" | null =>
-        running = false
-
-      case text =>
-        val doc = proc.annotate(text)
-        doc.prettyPrint(printWriter)
-        printWriter.flush()
-    }
+  def prepareProcessor(prompt: String, message: String, processor: Processor): Boolean = {
+    lineReader.setPrompt(prompt)
+    println(message)
+    proc = processor
+    proc.annotate("initialize me!")
+    true
   }
 
-  // manual terminal cleanup
-  reader.getTerminal.restore()
-  reader.shutdown()
+  def prepareCore(menu: Menu, text: String): Boolean =
+    prepareProcessor(corePrompt, "Preparing CoreNLPProcessor...", core)
 
+  def prepareFast(menu: Menu, text: String): Boolean =
+    prepareProcessor("(fast)>>> ", "Preparing FastNLPProcessor...", fast)
 
-  /** summarize available commands */
-  def printCommands(): Unit = {
-    println("\nCOMMANDS:")
-    for ((cmd, msg) <- commands)
-      println(s"\t$cmd\t=> $msg")
-    println()
+  def prepareClu(menu: Menu, text: String): Boolean = {
+    Utils.initializeDyNet()
+    prepareProcessor("(clu)>>> ", "Preparing CluProcessor...", clu)
   }
+
+  def annotate(menu: Menu, text: String): Boolean = {
+    val doc = proc.annotate(text)
+    doc.prettyPrint(printWriter)
+    printWriter.flush()
+    true
+  }
+
+  val mainMenuItems = Seq(
+    new HelpMenuItem(":help", "show commands"),
+    new MainMenuItem(":core", "use CoreNLPProcessor", prepareCore),
+    new MainMenuItem(":fast", "use FastNLPProcessor", prepareFast),
+    new MainMenuItem(":clu", "use CluProcessor", prepareClu),
+    new ExitMenuItem(":exit", "exit system")
+  )
+  val defaultMenuItem = new DefaultMenuItem(annotate)
+  val menu = new Menu("Welcome to the ProcessorShell!", lineReader, mainMenuItems, defaultMenuItem)
+
+  menu.run()
 }

--- a/main/src/main/scala/org/clulab/utils/LineReader.scala
+++ b/main/src/main/scala/org/clulab/utils/LineReader.scala
@@ -1,0 +1,55 @@
+package org.clulab.utils
+
+import java.io.File
+
+/**
+ * Line reader to use in different environments.  The CliReader works on the command line
+ * and with sbt and supports history.  However, it doesn't work well in the IntelliJ
+ * or Eclipse IDEs (as least not with Windows).  For those, use the IdeReader.  To switch
+ * between the two, add a command line argument to get the IdeReader rather than changing
+ * the code.
+ */
+
+abstract class LineReader {
+  def readLine(): String
+  def readLineOpt(): Option[String]
+  def setPrompt(prompt: String): Unit
+}
+
+class CliReader(prompt: String, parentProperty: String, child: String) extends LineReader {
+  import jline.console.ConsoleReader
+  import jline.console.history.FileHistory
+
+  val reader = new ConsoleReader()
+  val history = new FileHistory(new File(System.getProperty(parentProperty), child))
+
+  reader.setPrompt(prompt)
+  reader.setHistory(history)
+  sys addShutdownHook {
+    reader.getTerminal.restore()
+    reader.shutdown()
+    history.flush() // flush file before exiting
+  }
+
+  override def readLine(): String = reader.readLine
+
+  override def readLineOpt(): Option[String] = Option(readLine())
+
+  override def setPrompt(prompt: String): Unit = reader.setPrompt(prompt)
+}
+
+class IdeReader(protected var prompt: String) extends LineReader {
+  import java.util.Scanner
+
+  protected val reader = new Scanner(System.in)
+
+  override def readLine(): String = {
+    print(prompt)
+    Console.flush()
+    reader.nextLine
+  }
+
+  override def readLineOpt(): Option[String] = Option(readLine())
+
+  override def setPrompt(prompt: String): Unit = this.prompt = prompt
+}

--- a/main/src/main/scala/org/clulab/utils/Menu.scala
+++ b/main/src/main/scala/org/clulab/utils/Menu.scala
@@ -1,0 +1,54 @@
+package org.clulab.utils
+
+class MenuItem(val command: MenuItem.Command) {
+
+  def run(menu: Menu, key: String): Boolean = command(menu, key)
+}
+
+object MenuItem {
+  type Command = (Menu, String) => Boolean
+  val helpCommand: Command = (menu: Menu, _: String) => { menu.printCommands(); true }
+  val exitCommand: Command = (_: Menu, _: String) => false
+  val defaultCommand: Command = (_: Menu, input: String) => { println(s"Unknown command: $input"); true }
+  val eofCommand: Command = (_: Menu, _: String) => { println(); println(); false }
+  val defaultMenuItem: DefaultMenuItem = new DefaultMenuItem(defaultCommand)
+}
+
+class MainMenuItem(val key: String, val hint: String, command: MenuItem.Command) extends MenuItem(command)
+
+class HelpMenuItem(key: String, hint: String, command: MenuItem.Command = MenuItem.helpCommand) extends MainMenuItem(key, hint, command)
+
+class ExitMenuItem(key: String, hint: String, command: MenuItem.Command = MenuItem.exitCommand) extends MainMenuItem(key, hint, command)
+
+class DefaultMenuItem(command: MenuItem.Command = MenuItem.defaultCommand) extends MenuItem(command)
+
+class Menu(greeting: String, lineReader: LineReader, mainMenuItems: Seq[MainMenuItem], defaultMenuItem: DefaultMenuItem = MenuItem.defaultMenuItem) {
+  val maxKeyLength: Int = mainMenuItems.foldLeft(0) { (maxKeyLength: Int, mainMenuItem: MainMenuItem) => Math.max(maxKeyLength, mainMenuItem.key.length) }
+  val indent: String = "    "
+
+  def printCommands(): Unit = {
+    println("COMMANDS:")
+    mainMenuItems.foreach { mainMenuItem =>
+      val padding = " " * (maxKeyLength - mainMenuItem.key.length)
+      println(s"$indent${mainMenuItem.key}$padding => ${mainMenuItem.hint}")
+    }
+  }
+
+  def processMenu: Boolean = {
+    println()
+    lineReader.readLineOpt().map { line =>
+      println()
+      mainMenuItems
+          .find(_.key == line)
+          .map(_.command(this, line))
+          .getOrElse(defaultMenuItem.command(this, line))
+    }.getOrElse(MenuItem.eofCommand(this, ""))
+  }
+
+  def run(): Unit = {
+    println(s"\n$greeting\n")
+    printCommands()
+    while (processMenu) { }
+    println(s"Bye!\n")
+  }
+}


### PR DESCRIPTION
There are at least four copies of the shell code in circulation: processors, reach, eidos, eidosdottir.  It was time to reuse some code.  This is being copied over from eidos and then eidos and reach will use it.  There are already PRs prepared for them.