### PR TITLE
Add some manual memory management by closing DyNet objects when finished

### DIFF
--- a/corenlp/src/main/scala/org/clulab/processors/examples/InfiniteParallelProcessorExample.scala
+++ b/corenlp/src/main/scala/org/clulab/processors/examples/InfiniteParallelProcessorExample.scala
@@ -75,7 +75,10 @@ object InfiniteParallelProcessorExample {
     val timer = new Timer(s"$threads threads processing ${parFiles.size} files")
     timer.start()
 
-    while (true) {
+    var done = false
+
+    // In the debugger you can change done to true in order to stop looping and check memory.
+    while (!done) {
       processFiles(parFiles, processorProvider.newOrReusedProcessor)
     }
 
@@ -103,6 +106,6 @@ object InfiniteParallelProcessorExample {
       "2",
       "false"
     ))
-    Utils.shutdown()
+    Utils.shutdown(true)
   }
 }

--- a/corenlp/src/test/scala/org/clulab/processors/TestTokenizers.scala
+++ b/corenlp/src/test/scala/org/clulab/processors/TestTokenizers.scala
@@ -61,12 +61,16 @@ class TestTokenizers extends FlatSpec with Matchers {
     shallow.mkDocument("initialize me")
 
     var start = System.currentTimeMillis()
+    // Just one time doesn't seem to be accurate enough.
+    1.to(10).foreach { _ => shallow.mkDocument(text, keepText = false) }
     val coreDoc = shallow.mkDocument(text, keepText = false)
     var end = System.currentTimeMillis()
     val coreTime = end - start
     printSents(coreDoc.sentences)
 
     start = System.currentTimeMillis()
+    // Just one time doesn't seem to be accurate enough.
+    1.to(10).foreach { _ => clu.mkDocument(text, keepText = false) }
     val cluDoc = clu.mkDocument(text, keepText = false)
     end = System.currentTimeMillis()
     val cluTime = end - start

--- a/main/build.sbt
+++ b/main/build.sbt
@@ -21,7 +21,7 @@ libraryDependencies ++= {
     "org.scala-lang.modules"     %% "scala-parser-combinators" % "1.0.4",
     "com.io7m.xom"                % "xom"                      % "1.2.10",
     // for machine learning
-    "org.clulab"                 %% "fatdynet"                 % "0.3.1", // "0-cuda.2.6-SNAPSHOT"
+    "org.clulab"                 %% "fatdynet"                 % "0.3.2", // "0-cuda.2.6-SNAPSHOT"
     "de.bwaldvogel"               % "liblinear"                % "2.30",
     "tw.edu.ntu.csie"             % "libsvm"                   % "3.23",
     // NLP tools used by CluProcessor

--- a/main/src/main/scala/org/clulab/utils/BeforeAndAfter.scala
+++ b/main/src/main/scala/org/clulab/utils/BeforeAndAfter.scala
@@ -1,0 +1,16 @@
+package org.clulab.utils
+
+trait BeforeAndAfter {
+  def before(): Unit
+  def after(): Unit
+
+  def perform[T](f: => T): T = {
+    before()
+    try {
+      f
+    }
+    finally {
+      after()
+    }
+  }
+}


### PR DESCRIPTION
To CluProcessor add a BeforeAndAfter to manage the temporary attachment.  After removal of the attachment, close the DyNet objects so that C++ memory is freed right away.  Update to new version of FatDynet which includes the close functionality.