### PR TITLE
get Mention.text from raw not words

### DIFF
--- a/main/src/main/scala/org/clulab/odin/Mention.scala
+++ b/main/src/main/scala/org/clulab/odin/Mention.scala
@@ -87,6 +87,9 @@ trait Mention extends Equals with Ordered[Mention] with Serializable {
   /** returns true if the StringMatcher matches any of the mention labels */
   def matches(matcher: StringMatcher): Boolean = labels exists matcher.matches
 
+  /** returns all raw (original, no processing applied) tokens in mention */
+  def raw: Seq[String] = sentenceObj.raw.slice(start, end)
+
   /** returns all tokens in mention */
   def words: Seq[String] = sentenceObj.words.slice(start, end)
 
@@ -140,10 +143,10 @@ trait Mention extends Equals with Ordered[Mention] with Serializable {
     case Some(txt) => txt.slice(startOffset, endOffset)
     case None =>
       // try to reconstruct the sentence using the character offsets
-      val bits = words.head +: tokenInterval.drop(1).map { i =>
+      val bits = raw.head +: tokenInterval.drop(1).map { i =>
         val spaces = " " * (sentenceObj.startOffsets(i) - sentenceObj.endOffsets(i - 1))
-        val word = sentenceObj.words(i)
-        spaces + word
+        val rawWord = sentenceObj.raw(i)
+        spaces + rawWord
       }
       bits.mkString
   }

--- a/main/src/test/scala/org/clulab/odin/TestMention.scala
+++ b/main/src/test/scala/org/clulab/odin/TestMention.scala
@@ -1,0 +1,30 @@
+package org.clulab.odin
+
+import org.clulab.TestUtils.jsonStringToDocument
+import org.scalatest.{FlatSpec, Matchers}
+
+class TestMention extends FlatSpec with Matchers {
+
+  // motivated by changes to the words field that replaced `'m` with `am`
+  "mention.text" should "properly reconstruct the original span" in {
+    // I'm going to dance
+    val json = """{"sentences":[{"words":["I","am","going","to","dance","."],"startOffsets":[0,1,4,10,13,18],"endOffsets":[1,3,9,12,18,19],"raw":["I","'m","going","to","dance","."],"tags":["PRP","VBP","VBG","TO","VB","."],"lemmas":["I","be","go","to","dance","."],"entities":["O","O","O","O","O","O"],"norms":["O","O","O","O","O","O"],"chunks":["B-NP","B-VP","I-VP","I-VP","I-VP","O"],"graphs":{"universal-enhanced":{"edges":[{"source":2,"destination":0,"relation":"nsubj"},{"source":2,"destination":1,"relation":"aux"},{"source":2,"destination":4,"relation":"xcomp"},{"source":2,"destination":5,"relation":"punct"},{"source":4,"destination":0,"relation":"nsubj:xsubj"},{"source":4,"destination":3,"relation":"mark"}],"roots":[2]},"universal-basic":{"edges":[{"source":2,"destination":0,"relation":"nsubj"},{"source":2,"destination":1,"relation":"aux"},{"source":2,"destination":4,"relation":"xcomp"},{"source":2,"destination":5,"relation":"punct"},{"source":4,"destination":3,"relation":"mark"}],"roots":[2]}}}]}"""
+    val doc = jsonStringToDocument(json)
+
+    val rule =
+      """
+        |rules:
+        | - name: test
+        |   type: token
+        |   label: TestMention
+        |   pattern: |
+        |     [lemma=I] []* [lemma=dance]
+        |""".stripMargin
+
+    val ee = ExtractorEngine(rule)
+    val mentions = ee.extractFrom(doc)
+    mentions should have length(1)
+    mentions.head.text shouldBe "I'm going to dance"
+  }
+
+}


### PR DESCRIPTION
There was an issue I ran into using odin, where the mention.text didn't match the original (specifically, a span like "I'm going to ..." became "Iam doing to..." because of the way the mention.text was created.  This change creates the mention text from the raw.

if a diff functionality is desired, please let me know and I can adjust.

fyi @marcovzla 