### PR TITLE
Added more numeric date formats with symbol

### DIFF
--- a/main/src/main/resources/org/clulab/numeric/dates.yml
+++ b/main/src/main/resources/org/clulab/numeric/dates.yml
@@ -53,7 +53,7 @@ rules:
     pattern: |
       [word=/^(1\d\d\d|20\d\d)(:|\/|\-)(0?[1-9]|1[012])(:|\/|\-)(0?[1-9]|[12]\d|3[01])$/]
 
-  # Rule for DD-MM-YYYY (accepts -, :, / as separators)
+  # Rule for DD-MM-YYYY (accepts -, :, /, as separators)
   - name: date-dd-mm-yyyy
     label: Date
     priority: ${ rulepriority }
@@ -63,4 +63,42 @@ rules:
     pattern: |
       [word=/^(0?[1-9]|[12]\d|3[01])(:|\/|\-)(0?[1-9]|1[012])(:|\/|\-)(1\d\d\d|20\d\d)$/]
 
+  # Rule for YY-MM-DD (accepts -, :, /, as separators)
+  - name: date-yy-mm-dd
+    label: Date
+    priority: ${ rulepriority }
+    type: token
+    example: "It was 21-06-16"
+    action: mkDateMentionYyMmDd
+    pattern: |
+      [word=/^(\d\d)(:|\/|\-)(0?[1-9]|1[012])(:|\/|\-)(0?[1-9]|[12]\d|3[01])$/]
 
+  # Rule for YY-MM (accepts -, :, /, as separators)
+  - name: date-yy-mm
+    label: Date
+    priority: ${ rulepriority }
+    type: token
+    example: "It was 21.06."
+    action: mkDateMentionYyMm
+    pattern: |
+       [word=/^(\d\d)(:|\/|\-)(0?[1-9]|1[012])$/]
+
+  # Rule for MM-YYYY (accepts -, :, /, as separators)
+  - name: date-mm-yyyy
+    label: Date
+    priority: ${ rulepriority }
+    type: token
+    example: "It was 06.2021. "
+    action: mkDateMentionMmYyyy
+    pattern: |
+      [word=/^(0?[1-9]|1[012])(:|\/|\-)(1\d\d\d|2\d\d\d)$/]
+
+  # Rule for YYYY-MM (accepts -, :, /, as separators)
+  - name: date-yyyy-mm
+    label: Date
+    priority: ${ rulepriority }
+    type: token
+    example: "It was 2021/06. "
+    action: mkDateMentionYyyyMm
+    pattern: |
+      [word=/^(1\d\d\d|2\d\d\d)(:|\/|\-)(0?[1-9]|1[012])$/]

--- a/main/src/main/scala/org/clulab/numeric/actions/NumericActions.scala
+++ b/main/src/main/scala/org/clulab/numeric/actions/NumericActions.scala
@@ -25,6 +25,26 @@ class NumericActions extends Actions {
     mentions.map(_.toDateMentionDdMmYyyy)
   }
 
+  /** Constructs a DateMention from the mm-yyyy single token */
+  def mkDateMentionMmYyyy(mentions: Seq[Mention], state: State): Seq[Mention] = {
+    mentions.map(_.toDateMentionMmYyyy)
+  }
+
+  /** Constructs a DateMention from the yyyy-mm single token */
+  def mkDateMentionYyyyMm(mentions: Seq[Mention], state: State): Seq[Mention] = {
+    mentions.map(_.toDateMentionYyyyMm)
+  }
+
+  /** Constructs a DateMention from the yy-mm single token */
+  def mkDateMentionYyMm(mentions: Seq[Mention], state: State): Seq[Mention] = {
+    mentions.map(_.toDateMentionYyMm)
+  }
+
+  /** Constructs a DateMention from the yy-mm single token */
+  def mkDateMentionYyMmDd(mentions: Seq[Mention], state: State): Seq[Mention] = {
+    mentions.map(_.toDateMentionYyMmDd)
+  }
+
   //
   // global actions below this points
   //

--- a/main/src/main/scala/org/clulab/numeric/mentions/package.scala
+++ b/main/src/main/scala/org/clulab/numeric/mentions/package.scala
@@ -47,7 +47,6 @@ package object mentions {
       case m =>
         throw new RuntimeException(s"ERROR: cannot convert mention of type ${m.getClass.toString} to DateMention!")
     }
-
     def toDateMentionDdMmYyyy: DateMention =  mention match {
       case m: DateMention => m
 
@@ -67,15 +66,108 @@ package object mentions {
       case m =>
         throw new RuntimeException(s"ERROR: cannot convert mention of type ${m.getClass.toString} to DateMention!")
     }
+    def toDateMentionYyMmDd: DateMention =  mention match {
+      case m: DateMention => m
+
+      case m: TextBoundMention =>
+        val (year, month, day) = parseYyMmDd(m.words.head)
+        new DateMention(
+          m.labels,
+          m.tokenInterval,
+          m.sentence,
+          m.document,
+          m.keep,
+          m.foundBy,
+          m.attachments,
+          Some(Seq(day)), Some(Seq(month)), Some(Seq(year))
+        )
+
+      case m =>
+        throw new RuntimeException(s"ERROR: cannot convert mention of type ${m.getClass.toString} to DateMention!")
+    }
+    def toDateMentionMmYyyy: DateMention = mention match {
+      case m: DateMention => m
+
+      case m: TextBoundMention =>
+        val (year, month, day) = parseMmYyyy(m.words.head)
+        new DateMention(
+          m.labels,
+          m.tokenInterval,
+          m.sentence,
+          m.document,
+          m.keep,
+          m.foundBy,
+          m.attachments,
+          Some(Seq(day)), Some(Seq(month)), Some(Seq(year))
+        )
+
+      case m =>
+        throw new RuntimeException(s"Error: cannot convert mention of type ${m.getClass.toString} to DateMention!")
+    }
+    def toDateMentionYyyyMm: DateMention = mention match {
+      case m: DateMention => m
+
+      case m: TextBoundMention =>
+        val (year, month, day) = parseYyyyMm(m.words.head)
+        new DateMention(
+          m.labels,
+          m.tokenInterval,
+          m.sentence,
+          m.document,
+          m.keep,
+          m.foundBy,
+          m.attachments,
+          Some(Seq(day)), Some(Seq(month)), Some(Seq(year))
+        )
+
+      case m =>
+        throw new RuntimeException(s"Error: cannot convert mention of type ${m.getClass.toString} to DateMention!")
+    }
+    def toDateMentionYyMm: DateMention = mention match {
+      case m: DateMention => m
+
+      case m: TextBoundMention =>
+        val (year, month, day) = parseYyMm(m.words.head)
+        new DateMention(
+          m.labels,
+          m.tokenInterval,
+          m.sentence,
+          m.document,
+          m.keep,
+          m.foundBy,
+          m.attachments,
+          Some(Seq(day)), Some(Seq(month)), Some(Seq(year))
+        )
+
+      case m =>
+        throw new RuntimeException(s"Error: cannot convert mention of type ${m.getClass.toString} to DateMention!")
+    }
   }
 
   // this can be more relaxed since the correct date format was previously checked by the Odin grammar
   private val DATE_DD_DD_DD: Pattern = Pattern.compile("(\\d+)\\D(\\d+)\\D(\\d+)")
 
+  // this can be more relaxed since the correct date format was previously checked by the Odin grammar
+  // this is necessary for date formats such as MM-YYYY or YYYY-MM or YY-MM
+  private val DATE_DD_DD: Pattern = Pattern.compile("(\\d+)\\D(\\d+)")
+
   private def parseYyyyMmDd(v: String): (String, String, String) = {
     val m = DATE_DD_DD_DD.matcher(v)
     if(m.matches()) {
       val year = m.group(1)
+      val month = m.group(2)
+      val day = m.group(3)
+
+      Tuple3(year, month, day)
+    } else {
+      throw new RuntimeException(s"ERROR: cannot extract year/month/day from date $v!")
+    }
+  }
+
+  private def parseYyMmDd(v: String): (String, String, String) = {
+    val m = DATE_DD_DD_DD.matcher(v)
+    if(m.matches()) {
+      val year = "XX" + m.group(1)
       val month = m.group(2)
       val day = m.group(3)
 
@@ -91,6 +183,46 @@ package object mentions {
       val day = m.group(1)
       val month = m.group(2)
       val year = m.group(3)
+
+      Tuple3(year, month, day)
+    } else {
+      throw new RuntimeException(s"ERROR: cannot extract year/month/day from date $v!")
+    }
+  }
+
+  private def parseMmYyyy(v:String): (String, String, String) = {
+    val m = DATE_DD_DD.matcher(v)
+    if(m.matches()) {
+      val day = "XX"
+      val month = m.group(1)
+      val year = m.group(2)
+
+      Tuple3(year, month, day)
+    } else {
+      throw new RuntimeException(s"ERROR: cannot extract year/month/day from date $v!")
+    }
+  }
+
+
+  private def parseYyyyMm(v:String): (String, String, String) = {
+    val m = DATE_DD_DD.matcher(v)
+    if(m.matches()) {
+      val day = "XX"
+      val year = m.group(1)
+      val month = m.group(2)
+
+      Tuple3(year, month, day)
+    } else {
+      throw new RuntimeException(s"ERROR: cannot extract year/month/day from date $v!")
+    }
+  }
+
+  private def parseYyMm(v:String): (String, String, String) = {
+    val m = DATE_DD_DD.matcher(v)
+    if(m.matches()) {
+      val day = "XX"
+      val year = "XX" + m.group(1)
+      val month = m.group(2)
 
       Tuple3(year, month, day)
     } else {

--- a/main/src/test/scala/org/clulab/numeric/TestDateRecognition.scala
+++ b/main/src/test/scala/org/clulab/numeric/TestDateRecognition.scala
@@ -39,6 +39,49 @@ class TestDateRecognition extends FlatSpec with Matchers {
     ensure("It is 12:05:2000", Interval(2, 3), "DATE", "2000-05-12")
     ensure("It is 12-05-2000", Interval(2, 3), "DATE", "2000-05-12")
   }
+
+  // Timex.fromXml("<TIMEX3 tid=\"t3\" value=\"1988-02-17\" type=\"DATE\">1988-02-17</TIMEX3>"),
+  // Timex.fromXml("<TIMEX3 tid=\"t4\" value=\"XX10-02-19\" type=\"DATE\">19.02.10</TIMEX3>"),
+  // Timex.fromXml("<TIMEX3 tid=\"t5\" value=\"2010-02-19\" type=\"DATE\">19.02.2010</TIMEX3>")
+  it should "recognize numeric dates 2" in {
+    // these tests should be captured by yyyy-mm-dd
+    ensure(sentence= "ISO date is 1988-02-17.", Interval(3, 4), goldEntity= "DATE", goldNorm= "1988-02-17")
+    ensure(sentence= "1988-02-17.", Interval(0, 1), goldEntity= "DATE", goldNorm= "1988-02-17")
+    ensure(sentence= "1988/02/17.", Interval(0, 1), goldEntity= "DATE", goldNorm= "1988-02-17")
+
+    // Any confusion between European and American date format. We go with American one.
+    ensure(sentence= "ISO date is 1988-02-03.", Interval(3, 4), goldEntity= "DATE", goldNorm= "1988-02-03")
+    ensure(sentence= "ISO date is 1988/02/03.", Interval(3, 4), goldEntity= "DATE", goldNorm= "1988-02-03")
+    ensure(sentence= "1988/02/03.", Interval(0, 1), goldEntity= "DATE", goldNorm= "1988-02-03")
+
+  }
+
+//  it should "recognize numeric dates in yy-mm-dd" in  {
+//    ensure(sentence= "88/02/15.", Interval(0, 1), goldEntity= "DATE", goldNorm= "XX88-02-15")
+//    ensure(sentence= "ISO date is 88/02/15.", Interval(3, 4), goldEntity= "DATE", goldNorm= "XX88-02-15")
+//  }
+//
+//  it should "recognize numeric dates in mm-yyyy" in  {
+//    // These tests should be captured by rule mm-yyyy
+//    ensure(sentence= "02-1988.", Interval(0, 1), goldEntity= "DATE", goldNorm= "1988-02-XX")
+//    ensure(sentence= "ISO date is 02/1988.", Interval(3, 4), goldEntity= "DATE", goldNorm= "1988-02-XX")
+//    ensure(sentence= "02/1988.", Interval(0, 1), goldEntity= "DATE", goldNorm= "1988-02-XX")
+//    ensure(sentence= "ISO date is 02/1988.", Interval(3, 4), goldEntity= "DATE", goldNorm= "1988-02-XX")
+//    ensure(sentence= "02/1988.", Interval(0, 1), goldEntity= "DATE", goldNorm= "1988-02-XX")
+//  }
+//
+//  it should "recognize numeric dates in yyyy-mm" in {
+//    // These tests are captured by rule yyyy-mm
+//    ensure(sentence= "ISO date is 1988-02.", Interval(3, 4), goldEntity= "DATE", goldNorm= "1988-02-XX")
+//    ensure(sentence= "1988-02.", Interval(0, 1), goldEntity= "DATE", goldNorm= "1988-02-XX")
+//    ensure(sentence= "ISO date is 1988/02.", Interval(3, 4), goldEntity= "DATE", goldNorm= "1988-02-XX")
+//    ensure(sentence= "1988/02.", Interval(0, 1), goldEntity= "DATE", goldNorm= "1988-02-XX")
+//  }
+
+//  it should "recognize numeric dates in yy-mm" in {
+//    ensure(sentence= "19/02.", Interval(0, 1), goldEntity= "DATE", goldNorm= "XX19-02-XX")
+//  }
+
   // End unit tests for date recognition.
 
   //


### PR DESCRIPTION
@MihaiSurdeanu 

I added multiple more tests for all the rules we discussed. 

One more thing I want to ask is that I tried to add 4 more rules as follows:

1) MM/YYYY
2) YYYY/MM
3) YY/MM/DD
4) YY/MM

These rules come from the STUtime Stanford repository. I follow this procedure:
1. add to dates.yml, for each rule, I create the action mkDateMention corresponding.
2. For each mkDateMention action , I create a mkDateMention function inside the NumericActions.scala
3. For each mkDateMention in NumericActions.scala, I create a toDateMention function and a parser.

However, it looks like these new rules are not recognized by the odin. Could you have a look at one rule, let's say yyyy-mm, and go through this process to see if it is correct? I also created tests for that rule, which you can uncomment in the TestDateRecognition.scala. 

