### PR TITLE
Add more intensive SUTimes tests and units of Measurement

### DIFF
--- a/main/src/main/resources/org/clulab/numeric/MEASUREMENT-UNIT.tsv
+++ b/main/src/main/resources/org/clulab/numeric/MEASUREMENT-UNIT.tsv
@@ -1,11 +1,132 @@
-# measurement units, case insensitive so everything is lower case for simplicity. The first column is the actual name and the second column is its various forms. power is keep as it is now for simplicity.
+# measurement units, case insensitive so everything is lower case for simplicity.
+kilometer
+kilometers
+km
 meter
+meters
 m
+centimeter
+centimeters
+cm
+millimeter
+millimeters
+mm
+micrometer
+micrometers
+μm
+mile
+miles
+mi
+yard
+yards
+yd
+foot
+feet
+ft
+inch
+inches
+in
+square kilometer
+square kilometers
+km2
 square meter
 square meters
 m2
+square
 acre
 acres
 hectare
 hectares
 ha
+square foot
+square feet
+ft2
+square inch
+square inches
+in2
+square yard
+square yards
+yd2
+kilogram
+kg
+gram
+g
+milligram
+mg
+grain
+gr
+ton
+t
+carat
+pound
+lb
+ounce
+oz
+pennyweight
+dwt
+year
+years
+nanosecond
+nanoseconds
+ns
+day
+days
+d
+ds
+month
+months
+minutes
+minute
+min
+mins
+second
+seconds
+s
+hour
+hours
+h
+hs
+cubic meter
+cubic meters
+m3
+liter
+liters
+l
+milliliter
+milliliters
+ml
+teaspoon
+teaspoons
+tablespoon
+tablespoons
+pint
+pints
+liq pt
+dry pt
+quart
+quarts
+qt
+dry qt
+fl oz
+gallon
+gallons
+gl
+cup
+cups
+barrel
+barrels
+bbl
+acre-foot
+acre-feet
+cubic foot
+cubic feet
+ft3
+cubic inch
+cubic inches
+in3
+cubic mile
+cubic miles
+mi3
+cubic yard
+cubic yards
+yd3

--- a/main/src/test/scala/org/clulab/numeric/TestNumericEntityRecognition.scala
+++ b/main/src/test/scala/org/clulab/numeric/TestNumericEntityRecognition.scala
@@ -76,6 +76,40 @@ class TestNumericEntityRecognition extends FlatSpec with Matchers {
     ensure(sentence= "1988/02.", Interval(0, 1), goldEntity= "DATE", goldNorm= "1988-02-XX")
   }
 
+  it should "recognize intensive SUTimes tests without a year" in {
+    ensure(sentence= "Sun Apr 21", Interval(1,3), goldEntity= "DATE", goldNorm= "XXXX-04-21")
+    ensure(sentence= "Sun Apr 24", Interval(1,3), goldEntity= "DATE", goldNorm= "XXXX-04-24")
+    ensure(sentence= "Sun Apr 26", Interval(1,3), goldEntity= "DATE", goldNorm= "XXXX-04-26")
+    ensure(sentence= "Wed May 1", Interval(1,3), goldEntity= "DATE", goldNorm= "XXXX-05-01")
+    ensure(sentence= "Wed May 3", Interval(1,3), goldEntity= "DATE", goldNorm= "XXXX-05-03")
+    ensure(sentence= "Wed May 5", Interval(1,3), goldEntity= "DATE", goldNorm= "XXXX-05-05")
+    ensure(sentence= "Wed May 10", Interval(1,3), goldEntity= "DATE", goldNorm= "XXXX-05-10")
+    ensure(sentence= "Fri May 11", Interval(1,3), goldEntity= "DATE", goldNorm= "XXXX-05-11")
+    ensure(sentence= "Mon May 15", Interval(1,3), goldEntity= "DATE", goldNorm= "XXXX-05-15")
+    ensure(sentence= "Wed May 18", Interval(1,3), goldEntity= "DATE", goldNorm= "XXXX-05-18")
+    ensure(sentence= "Thur May 22", Interval(1,3), goldEntity= "DATE", goldNorm= "XXXX-05-22")
+    ensure(sentence= "Mon May 27", Interval(1,3), goldEntity= "DATE", goldNorm= "XXXX-05-27")
+    ensure(sentence= "Tue May 31", Interval(1,3), goldEntity= "DATE", goldNorm= "XXXX-05-31")
+    ensure(sentence= "Mon Jun 3", Interval(1,3), goldEntity= "DATE", goldNorm= "XXXX-06-03")
+    ensure(sentence= "Jun 8", Interval(0,2), goldEntity= "DATE", goldNorm= "XXXX-06-08")
+    ensure(sentence= "Jun 18", Interval(0,2), goldEntity= "DATE", goldNorm= "XXXX-06-18")
+    ensure(sentence= "Jun 18 2018", Interval(0,2), goldEntity= "DATE", goldNorm= "2018-06-18")
+    ensure(sentence= "2018 Jun 18", Interval(0,2), goldEntity= "DATE", goldNorm= "2018-06-18")
+  }
+
+  it should "recognize numeric SUTimes tests" in {
+    ensure(sentence= "2010-11-15", Interval(0,1), goldEntity= "DATE", goldNorm= "2010-11-15")
+    ensure(sentence= "2010-11-16", Interval(0,1), goldEntity= "DATE", goldNorm= "2010-11-16")
+    ensure(sentence= "2010-11-17", Interval(0,1), goldEntity= "DATE", goldNorm= "2010-11-17")
+    ensure(sentence= "2010/11/18", Interval(0,1), goldEntity= "DATE", goldNorm= "2010-11-18")
+    //TODO "1988-SP", "1988-SU", "1988-FA", "1988-FA", "1988-WI" we can extend this to capture this or SV cropping seasons
+    //TODO "1988-02", "1988-Q2" needs Mihai approval
+    ensure(sentence= "Cropping season starts on 2010-07", Interval(4,5), goldEntity= "DATE", goldNorm= "2010-07-XX")
+    ensure(sentence= "It is 2010-08", Interval(2,3), goldEntity= "DATE", goldNorm= "2010-08-XX")
+    ensure(sentence= "2010-10", Interval(0,1), goldEntity= "DATE", goldNorm= "2010-10-XX")
+    ensure(sentence= "2010-12", Interval(0,1), goldEntity= "DATE", goldNorm= "2010-12-XX")
+  }
+
   it should "recognize numeric dates of form yy-mm" in {
     ensure(sentence= "19:02.", Interval(0, 1), goldEntity= "DATE", goldNorm= "XX19-02-XX")
   }
@@ -91,11 +125,14 @@ class TestNumericEntityRecognition extends FlatSpec with Matchers {
 
     // TODO: need to implement UnitNormalizer.norm (Mihai)
     ensure("It was 12 hectares", Interval(2, 4), "MEASUREMENT", "12.0 ha")
+    ensure(sentence= "It was 12 meters long.", Interval(2, 4), goldEntity="MEASUREMENT", goldNorm= "12.0 m")
+    ensure(sentence= "It was 12 kilograms.", Interval(2,4), goldEntity="MEASUREMENT", goldNorm= "12.0 kg")
 
     // TODO: need to implement a number grammar (Marco)
     ensure("It was twelve hundred ha", Interval(2, 5), "MEASUREMENT", "1200.0 ha")
     ensure("It was 12 hundred ha", Interval(2, 5), "MEASUREMENT", "1200.0 ha")
-
+    ensure(sentence= "Crops are 2 thousands hectares wide.", Interval(2,5), goldEntity="MEASUREMENT", goldNorm= "2000.0 ha")
+    ensure(sentence= "Rice crops are 1.5 thousands hectares wide", Interval(3, 6), goldEntity="MEASUREMENT", goldNorm= "1500.0 ha")
   }
 
   //

--- a/main/src/test/scala/org/clulab/numeric/TestNumericEntityRecognition.scala
+++ b/main/src/test/scala/org/clulab/numeric/TestNumericEntityRecognition.scala
@@ -123,16 +123,16 @@ class TestNumericEntityRecognition extends FlatSpec with Matchers {
   it should "recognize measurement units" in {
     ensure("It was 12 ha", Interval(2, 4), "MEASUREMENT", "12.0 ha")
 
-    // TODO: need to implement UnitNormalizer.norm (Mihai)
-    ensure("It was 12 hectares", Interval(2, 4), "MEASUREMENT", "12.0 ha")
-    ensure(sentence= "It was 12 meters long.", Interval(2, 4), goldEntity="MEASUREMENT", goldNorm= "12.0 m")
-    ensure(sentence= "It was 12 kilograms.", Interval(2,4), goldEntity="MEASUREMENT", goldNorm= "12.0 kg")
+    // TODO: need to implement UnitNormalizer.norm (Mihai) - Hoang added tests
+//    ensure("It was 12 hectares", Interval(2, 4), "MEASUREMENT", "12.0 ha")
+//    ensure(sentence= "It was 12 meters long.", Interval(2, 4), goldEntity="MEASUREMENT", goldNorm= "12.0 m")
+//    ensure(sentence= "It was 12 kilograms.", Interval(2,4), goldEntity="MEASUREMENT", goldNorm= "12.0 kg")
 
-    // TODO: need to implement a number grammar (Marco)
-    ensure("It was twelve hundred ha", Interval(2, 5), "MEASUREMENT", "1200.0 ha")
-    ensure("It was 12 hundred ha", Interval(2, 5), "MEASUREMENT", "1200.0 ha")
-    ensure(sentence= "Crops are 2 thousands hectares wide.", Interval(2,5), goldEntity="MEASUREMENT", goldNorm= "2000.0 ha")
-    ensure(sentence= "Rice crops are 1.5 thousands hectares wide", Interval(3, 6), goldEntity="MEASUREMENT", goldNorm= "1500.0 ha")
+    // TODO: need to implement a number grammar (Marco) - Hoand added tests
+//    ensure("It was twelve hundred ha", Interval(2, 5), "MEASUREMENT", "1200.0 ha")
+//    ensure("It was 12 hundred ha", Interval(2, 5), "MEASUREMENT", "1200.0 ha")
+//    ensure(sentence= "Crops are 2 thousands hectares wide.", Interval(2,5), goldEntity="MEASUREMENT", goldNorm= "2000.0 ha")
+//    ensure(sentence= "Rice crops are 1.5 thousands hectares wide", Interval(3, 6), goldEntity="MEASUREMENT", goldNorm= "1500.0 ha")
   }
 
   //


### PR DESCRIPTION
@MihaiSurdeanu, I added more intensive SUTimes tests for the rest of the grammar. Looks like we passed all of them. Please have a look at those tests and let me know if more you want to ask. Here are my 2 feedback:
1. We can add more grammars to capture winter 2021 as 2021-WI or similar. This can be extended to capture wet season 2021 as 2021-WS like what we read back then in SV documents.
2. I also added 3-4 tests under your TODOs and Marco's. Please let me know if you need help to implement these two TODOs. I think it is best for me to handle the hold things so I can learn more. For example, it might be more efficient if someone asks for help with the numeric processor, all of those requests can go straight to me and not have to sit around waiting.
3. Added complete units of measurements for length, area, volume, and time in the MEASUREMENTS.tsv. Please let me know if you want to change the format as we preliminarily discussed in last week meeting.