### PR TITLE
refactored to make more editable by downstream users if desired

### DIFF
--- a/main/src/main/scala/org/clulab/odin/impl/MarkdownGeneration.scala
+++ b/main/src/main/scala/org/clulab/odin/impl/MarkdownGeneration.scala
@@ -1,8 +1,156 @@
 package org.clulab.odin.impl
 
+import org.clulab.odin.impl.MarkdownGeneration._
 import org.clulab.odin.impl.RuleReader.{DefaultAction, Rule}
 
 import scala.collection.mutable.ArrayBuffer
+
+case class RuleSchema(
+  name: String,
+  extractorType: String,
+  labels: Seq[String],
+  priority: String,
+  action: Option[String],
+  keep: Boolean,
+  additional: Map[String, String],
+  arguments: Seq[ArgumentSchema]
+) {
+  def toMarkdown: String = {
+    val preamble = List(
+      "--------", // hline
+      "",
+      s"#### rule: _${name}_",
+      "",
+      s"attribute | value",
+      "-----  |   ---- "
+    )
+
+    val table = ArrayBuffer[String](
+      s"type |  ${extractorType}",
+      s"labels    | ${labelsString(labels)}",
+      s"priority  | ${priority}",
+      s"keep      | ${booleanString(keep)}"
+    )
+    if (action.isDefined) table.append(s"action | `Action` | `${action}` ")
+
+    // additional -- these are for cross-sentence rules
+    additional.foreach{ case (key, value) => table.append(s"$key  | $value") }
+
+    table.append("")
+
+    // args
+    val argumentLines = if (arguments.isEmpty) {
+      List(
+        "",
+        "_No arguments_"
+      )
+    } else {
+      List(
+        "",
+        "**argument name** | **label(s)** | **quantifier** | **required?**",
+        ":---- | :---- | :---- | :----"
+      ) ++ arguments.map(_.toMarkdown)
+    }
+
+    val lines = preamble ++ table ++ argumentLines ++ Seq("", "&nbsp;", "")
+    lines.mkString("\n")
+  }
+}
+
+case class ExtractionSchema(
+   name: String,
+   rules: Seq[String],
+   labels: Seq[String],
+   priorities: Seq[String],
+   actions: Seq[String],
+   keep: Seq[Boolean],
+   argumentsPerRule: Seq[Seq[ArgumentSchema]]
+) {
+  val argsByName = argumentsPerRule.flatten.groupBy(_.name)
+  val aggregatedArgs = aggregateArgs()
+
+  def toMarkdown(minimal: Boolean = false): String = {
+
+    val table = ArrayBuffer[String](
+      "----------------------------------",
+      "",
+      s"###  ${name}",
+      "",
+      s"|Attribute        |  Value | ",
+      s"| :--------       | :---- |",
+      s"|label hierarchy  | ${labelsString(labels)} "
+    )
+    if (!minimal) {
+      table.append(s"|rules            | ${listString(rules.map(r => s"""_${r}_"""))} ")
+      table.append(s"|priorities       | ${listString(priorities)}")
+    }
+    table.append(s"|keep             | ${booleanString(keep)} ")
+
+    if (actions.nonEmpty && !minimal) table.append(s"|actions | ${backtickedString(actions)}")
+
+    // arguments
+    if (argsByName.nonEmpty) {
+      table.appendAll(
+        List(
+          "",
+          "_Arguments_",
+          "",
+          "|name        | **label(s)**  | **quantifier(s)** | **required?**|",
+          "| :--------  | :----         | :----             | :---- "
+        )
+      )
+      val argLines = for {
+        (name, (labels, possibleQuantifiers, optionalities)) <- aggregatedArgs
+      } yield s"| _${name}_ | ${labels} | ${possibleQuantifiers} | ${optionalities}"
+      table.appendAll(argLines)
+    }
+    else {
+      table.appendAll(List("", "_No arguments_"))
+    }
+    table.append("")
+    table.mkString("\n")
+  }
+
+  def aggregateArgs(): Map[String, (String, String, String)] = {
+    for {
+      (name, argSchemas) <- argsByName
+    } yield (name, aggregateArgs(name, argSchemas))
+  }
+  def aggregateArgs(name: String, argSchemas: Seq[ArgumentSchema]): (String, String, String) = {
+    val labels = labelsString(argSchemas.map(_.label).distinct)
+    val possibleQuantifiers = listString(argSchemas.map(_.quantifier))
+    val requirednesses = {
+      val requiredValues = argSchemas.map(_.required)
+      // Another way an argument can be not required is if it's not extracted in all rules
+      // for Mentions of this type.
+      // TODO: test this logic!!
+      val inAllRules = argumentsPerRule.forall {
+        rule => // for this rule, there is an argument with this name
+          // and it's required
+          rule.exists(arg => arg.name == name && arg.required)
+      }
+      booleanString(requiredValues ++ Seq(inAllRules))
+    }
+    (labels, possibleQuantifiers, requirednesses)
+  }
+
+}
+
+case class ArgumentSchema(
+  name: String,
+  label: String,
+  quantifier: String,
+  required: Boolean
+) {
+  // each argument is a row in an argument table
+  def toMarkdown: String =
+    s" ${name} | " +
+    s"`${label}` | " +
+    s"${quantifier} | " +
+    s"${booleanString(required)} "
+}
+
+
 
 object MarkdownGeneration {
 
@@ -16,71 +164,60 @@ object MarkdownGeneration {
     * @param extractor
     * @return markdown representation
     */
-  def toMarkdown(rule: Rule, extractor: Extractor): String = {
-    val preamble = List(
-      "--------", // hline
-      "",
-      s"#### rule: _${extractor.name}_",
-      "",
-      s"attribute | value",
-      "-----  |   ---- "
-    )
-
-    val lines = extractor match {
-      case x: CrossSentenceExtractor => crossSentenceExtractorAsMarkdown(rule, x)
-      case x: TokenExtractor => tokenExtractorAsMarkdown(rule, x)
-      case x: GraphExtractor => graphExtractorAsMarkdown(rule, x)
-      case _ => List()
+  def toRuleSchema(rule: Rule, extractor: Extractor): RuleSchema = {
+    extractor match {
+      case x: CrossSentenceExtractor => crossSentenceRuleSchema(rule, x)
+      case x: TokenExtractor => tokenExtractorRuleSchema(rule, x)
+      case x: GraphExtractor => graphExtractorRuleSchema(rule, x)
+      case _ => ???
     }
-    val list = preamble ++ lines ++ Seq("", "&nbsp;", "")
-    list.mkString("\n")
   }
 
 
-  def crossSentenceExtractorAsMarkdown(r: Rule, x: CrossSentenceExtractor): List[String] = {
-    val table = ArrayBuffer[String](
-      "type |  `CrossSentenceExtractor`",
-      s"labels    | ${labelsString(x.labels)}",
-      s"priority  | ${priorityString(x.priority)}",
-      s"keep      | ${booleanString(x.keep)}"
+  def crossSentenceRuleSchema(r: Rule, x: CrossSentenceExtractor): RuleSchema = {
+    RuleSchema(
+      name = r.name,
+      extractorType = "CrossSentenceExtractor",
+      labels = x.labels,
+      priority = priorityString(x.priority),
+      action = if (r.action != DefaultAction) Some(r.action) else None,
+      keep = x.keep,
+      additional = Map(
+        "leftWindow" -> x.leftWindow.toString,
+        "rightWindow" -> x.rightWindow.toString,
+        "anchorRole" -> x.anchorRole,
+        "neighborRole" -> x.neighborRole
+      ),
+      Seq.empty
     )
-    if (r.action != DefaultAction) table.append(s"action | `Action` | `${r.action}` ")
-    table.appendAll(
-      List(
-        s"leftWindow | ${x.leftWindow}",
-        s"rightWindow | ${x.rightWindow}",
-        s"anchorRole | ${x.anchorRole}",
-        s"neighborRole | ${x.neighborPattern}"
-      )
-    )
-    table.toList
   }
 
-  def tokenExtractorAsMarkdown(r: Rule, x: TokenExtractor): List[String] = {
-    val table = ArrayBuffer[String](
-      "type | `TokenExtractor`",
-      s"labels    | ${labelsString(x.labels)}",
-      s"priority  | ${priorityString(x.priority)}",
-      s"keep      | ${booleanString(x.keep)}"
+  def tokenExtractorRuleSchema(r: Rule, x: TokenExtractor): RuleSchema = {
+    RuleSchema(
+      name = r.name,
+      extractorType = "TokenExtractor",
+      labels = x.labels,
+      priority = priorityString(x.priority),
+      action = if (r.action != DefaultAction) Some(r.action) else None,
+      keep = x.keep,
+      additional = Map.empty,
+      arguments = Seq.empty
     )
-    if (r.action != DefaultAction) table.append(s"action | `${r.action}` ")
-    table.append("")
-    table.toList
   }
 
   /** With GraphExtractors, the patterns support arguments and config variables too,
     * so here we display those as well */
-  def graphExtractorAsMarkdown(r: Rule, x: GraphExtractor): List[String] = {
-    val argumentLines = argsToMarkdown(x.pattern.arguments)
-    val table = ArrayBuffer[String](
-      s"type   | `GraphExtractor` (${x.config.graph})",
-      s"labels        |  ${labelsString(x.labels)}",
-      s"priority      |  ${priorityString(x.priority)}",
-      s"keep          |  ${booleanString(x.keep)}"
+  def graphExtractorRuleSchema(r: Rule, x: GraphExtractor): RuleSchema = {
+    RuleSchema(
+      name = r.name,
+      extractorType = "GraphExtractor",
+      labels = x.labels,
+      priority = priorityString(x.priority),
+      action = if (r.action != DefaultAction) Some(r.action) else None,
+      keep = x.keep,
+      additional = Map.empty,
+      arguments = toArgSchema(x.pattern.arguments)
     )
-    if (r.action != DefaultAction) table.append(s"action | `${r.action}` ")
-    table.append("")
-    (table ++ argumentLines).toList
   }
 
   // Arguments
@@ -90,18 +227,8 @@ object MarkdownGeneration {
     * @param args ArgumentPatterns for the Rule
     * @return markdown table strings
     */
-  def argsToMarkdown(args: Seq[ArgumentPattern]): List[String] = {
-    if (args.isEmpty) List(
-      "",
-      "_No arguments_"
-    )
-    else {
-      List(
-        "",
-        "**argument name** | **label(s)** | **quantifier** | **required?**",
-        ":---- | :---- | :---- | :----"
-      ) ++ args.map(argToMarkdown)
-    }
+  def toArgSchema(args: Seq[ArgumentPattern]): Seq[ArgumentSchema] = {
+    args.map(toArgSchema)
   }
 
   /**
@@ -110,11 +237,13 @@ object MarkdownGeneration {
     * @param a
     * @return markdown table string
     */
-  def argToMarkdown(a: ArgumentPattern): String = {
-    s" ${a.name} | " +
-      s"`${a.label}` | " +
-      s"${quantifierString(a.quantifier)} | " +
-      s"${booleanString(a.required)} "
+  def toArgSchema(a: ArgumentPattern): ArgumentSchema = {
+    ArgumentSchema(
+      name = a.name,
+      label = a.label,
+      quantifier = quantifierString(a.quantifier),
+      required = a.required
+    )
   }
 
   /**
@@ -149,61 +278,35 @@ object MarkdownGeneration {
   //      Methods for aggregated view
   // ------------------------------------------
 
-  def toMarkdown(label: String, pairs: Seq[(Rule, Extractor)]): Seq[String] = {
+  /**
+    *
+    * @param label the internal taxonomy label that all mentions produced
+    *              by these rules conform to
+    * @param pairs the (Rule, Extractor) pairs for all rules that
+    *              extract mentions with label == `label`
+    * @return sequence of ExtractionSchema
+    */
+  def toExtractionSchema(label: String, pairs: Seq[(Rule, Extractor)]): ExtractionSchema = {
     val (rules, extractors) = pairs.unzip
     assert(pairs.nonEmpty) // Should not happen
-    val allRuleNames = listString(rules.map(rule => s"""_${rule.name}_"""))
-    val allPriorities = priorityString(extractors.map(_.priority))
-    val labels = extractors.head.labels
-    // All should have the same labels because they come from the taxonomy
-    assert(labels.length == extractors.flatMap(_.labels).distinct.length)
-    val allKeep = booleanString(extractors.map(_.keep))
-    val allActions = backtickedString(
-      rules
-        .map(_.action)
-        .filterNot(_ == DefaultAction)
-    )
 
-    val table = ArrayBuffer[String](
-      "----------------------------------",
-      "",
-      s"###  ${label}",
-      "",
-      s"|Attribute        |  Value | ",
-      s"| :--------       | :---- |",
-      s"|rules            | ${allRuleNames} ",
-      s"|label hierarchy  | ${labelsString(labels)} ",
-      s"|priorities       | ${allPriorities}",
-      s"|keep             | ${allKeep} "
-    )
-    if (allActions.nonEmpty) table.append(s"|actions | ${allActions}")
+    val arguments = extractors
+      .collect{ case gp: GraphExtractor => gp.pattern.arguments}
+      .map(toArgSchema)
 
-    val argPatterns = extractors.collect{ case gp: GraphExtractor => gp.pattern.arguments}.flatten
-    val argsByName = argPatterns.groupBy(_.name)
-    if (argsByName.nonEmpty) {
-      table.appendAll(
-        List(
-          "",
-          "_Arguments_",
-          "",
-          "|name        | **label(s)**  | **quantifier(s)** | **required?**|",
-          "| :--------  | :----         | :----             | :---- "
-        )
-      )
-      val argLines = for {
-        (name, patterns) <- argsByName
-        labels = labelsString(patterns.map(_.label).distinct)
-        possibleQuantifiers = quantifierString(patterns.map(_.quantifier))
-        optionalities = booleanString(patterns.map(_.required))
-      } yield s"| _${name}_ | ${labels} | ${possibleQuantifiers} | ${optionalities}"
-      table.appendAll(argLines)
-    }
-    else {
-      table.appendAll(List("", "_No arguments_"))
-    }
-    table.append("")
-    table.toList
+    ExtractionSchema(
+      name = label,
+      rules = rules.map(_.name),
+      // All should have the same labels because they come from the taxonomy
+      // assert(labels.length == extractors.flatMap(_.labels).distinct.length)
+      labels = extractors.head.labels,
+      priorities = extractors.map(e => priorityString(e.priority)),
+      actions = rules.map(_.action).filterNot(_ == DefaultAction),
+      keep = extractors.map(_.keep),
+      argumentsPerRule = arguments
+    )
   }
+
 
   def listString(ss: Seq[String]): String = {
     val distinct = ss.distinct.sorted
@@ -214,8 +317,6 @@ object MarkdownGeneration {
     }
   }
 
-  def quantifierString(qq: Seq[ArgumentQuantifier]): String =
-    listString(qq.map(quantifierString))
   def quantifierString(q: ArgumentQuantifier): String = {
     q match {
       case NullQuantifier => "_none_"
@@ -232,8 +333,6 @@ object MarkdownGeneration {
     }
   }
 
-  def priorityString(pp: Seq[Priority]): String =
-    listString(pp.map(priorityString))
   def priorityString(p: Priority): String = {
     p match {
       case e: ExactPriority => s"`${e.value.toString}`"

--- a/main/src/test/scala/org/clulab/odin/TestMarkdownGeneration.scala
+++ b/main/src/test/scala/org/clulab/odin/TestMarkdownGeneration.scala
@@ -18,12 +18,78 @@ class TestMarkdownGeneration extends FlatSpec with Matchers {
 
     val master = FileUtils.getTextFromResource("/org/clulab/odin/grammars/embeddings.yml")
     noException shouldBe thrownBy{
-      rr.exportExtractionSchemasFromMaster(master, s"$tempDir/extractions.md")
+      rr.exportExtractionSchemas(master, s"$tempDir/extractions.md")
     }
     noException shouldBe thrownBy{
-      rr.exportRuleSchemasFromMaster(master, s"$tempDir/rules.md")
+      rr.exportRuleSchemas(master, s"$tempDir/rules.md")
     }
 
   }
 
+  it should "properly aggregate argument requiredness" in {
+    val rules =
+      """
+        |rules:
+        | - name: Rule1
+        |   label: TestMention
+        |   keep: true
+        |   pattern: |
+        |     trigger = eat
+        |     agent: Entity = >nsubj []
+        |     theme: Entity = >dobj []
+        |     alwaysOpt: Entity? = >abc []
+        |
+        | - name: Rule2
+        |   label: TestMention
+        |   keep: true
+        |   pattern: |
+        |     trigger = eat
+        |     agent: Entity? = >nsubj []
+        |     theme: Entity = >dobj []
+        |     alwaysOpt: Entity? = >abc []
+        |
+        | - name: Rule3
+        |   label: TestMention
+        |   keep: true
+        |   pattern: |
+        |     trigger = eat
+        |     agent: Entity? = >nsubj []
+        |     theme: Entity = >dobj []
+        |     other: Entity = >dobj >amod []
+        |     alwaysOpt: Entity? = >abc []
+        |""".stripMargin
+
+    val rr = new RuleReader(new Actions, StandardCharsets.UTF_8)
+    val extractionsSchemas = rr.extractionSchemaObjects(rules)
+    extractionsSchemas should have length (1)
+
+    val schema = extractionsSchemas.head
+    val aggregated = schema.aggregateArgs()
+    // agent
+    val (aLabs, aQuants, aReqs) = aggregated("agent")
+    aLabs should include("Entity")
+    aQuants should include("?")
+    aQuants should include("_none_")
+    aReqs should include("true")
+    aReqs should include("false")
+    val (tLabs, tQuants, tReqs) = aggregated("theme")
+    tLabs should include("Entity")
+    tQuants should include("_none_")
+    tQuants should not include("?")
+    tReqs should include("true")
+    tReqs should not include("false")
+    val (oLabs, oQuants, oReqs) = aggregated("other")
+    oLabs should include("Entity")
+    oQuants should include("_none_")
+    oQuants should not include("?")
+    oReqs should include("true")
+    oReqs should include("false")
+    val (aoLabs, aoQuants, aoReqs) = aggregated("alwaysOpt")
+    aoLabs should include("Entity")
+    aoQuants should include("?")
+    aoQuants should not include("_none_")
+    aoReqs should not include("true")
+    aoReqs should include("false")
+
+  }
 }


### PR DESCRIPTION
Basically there are three entry points for each "view" -- one to get the schema objects, in case you want to mess with the format a lot externally (god help you), one for the string contents of the md file, and one to actually export a md file to a specific path.

@adarshp I also added a "minimal" boolean (to the `toMarkdown` method on the ExtractionSchema as well as the entry point api for extraction schemas, seemed not relevant to the rule schemas) that may do most of what you want, but if not you can always get the objects and write your own code.