### PR TITLE
Calculate roots automatically

### DIFF
--- a/main/src/main/scala/org/clulab/processors/clu/CluProcessor.scala
+++ b/main/src/main/scala/org/clulab/processors/clu/CluProcessor.scala
@@ -205,9 +205,7 @@ class CluProcessor (val config: Config = ConfigFactory.load("cluprocessor")) ext
     for(i <- headsAndLabels.indices) {
       val head = headsAndLabels(i)._1
       val label = headsAndLabels(i)._2
-      if(head == -1) { // found a root
-        roots += i
-      } else {
+      if (head >= 0) {
         val edge = Edge[String](head, i, label)
         edges.append(edge)
       }
@@ -269,7 +267,7 @@ class CluProcessor (val config: Config = ConfigFactory.load("cluprocessor")) ext
     }
     */
 
-    new DirectedGraph[String](edges.toList, roots.toSet)
+    new DirectedGraph[String](edges.toList, Set.empty)
   }
 
   def srlSentence(sent: Sentence,
@@ -294,10 +292,7 @@ class CluProcessor (val config: Config = ConfigFactory.load("cluprocessor")) ext
           .filter { case (argLabel, _) => argLabel != "O" }
           .map { case (argLabel, argIndex) => Edge[String](pred, argIndex, argLabel) }
     }
-    val sources = edges.map(_.source).toSet
-    val destinations = edges.map(_.destination).toSet
-    val roots = sources -- destinations
-    new DirectedGraph[String](edges.toList, roots, Some(words.length))
+    new DirectedGraph[String](edges.toList, Set.empty, Some(words.length))
   }
 
   private def getEmbeddings(doc: Document): ConstEmbeddingParameters =

--- a/main/src/main/scala/org/clulab/struct/DirectedGraph.scala
+++ b/main/src/main/scala/org/clulab/struct/DirectedGraph.scala
@@ -17,6 +17,13 @@ case class DirectedGraph[E](edges: List[Edge[E]],
                             roots: collection.immutable.Set[Int],
                             preferredSize: Option[Int] = None) extends Serializable {
 
+  /* Use for debugging.  roots in the constructor would need to be a var.
+  val calculatedRoots = DirectedGraph.calculateRoots(edges)
+  if (calculatedRoots != roots) {
+    println("The roots of the directed graph are not as expected!")
+    roots = calculatedRoots
+  } */
+
   val outgoingEdges: Array[Array[(Int, E)]] = mkOutgoing(edges, roots, preferredSize)
   val incomingEdges: Array[Array[(Int, E)]] = mkIncoming(edges, roots, preferredSize)
 
@@ -290,6 +297,14 @@ class DirectedGraphEdgeIterator[E](val graph:DirectedGraph[E]) extends Iterator[
 }
 
 object DirectedGraph {
+
+  def calculateRoots[E](edges: List[Edge[E]]): Set[Int] = {
+    val sources = edges.map(_.source).toSet
+    val destinations = edges.map(_.destination).toSet
+    val roots = sources -- destinations
+
+    roots
+  }
 
   def triplesToEdges[E](triples: List[(Int, Int, E)]): List[Edge[E]] = for {
     triple <- triples

--- a/main/src/main/scala/org/clulab/struct/DirectedGraphIndex.scala
+++ b/main/src/main/scala/org/clulab/struct/DirectedGraphIndex.scala
@@ -19,8 +19,8 @@ class DirectedGraphIndex[E](
   def this(sentenceLength:Int) {
     this(sentenceLength,
       new mutable.HashSet[Int],
-      DirectedGraphIndex.mkOutgoing(sentenceLength),
-      DirectedGraphIndex.mkIncoming(sentenceLength),
+      DirectedGraphIndex.mkOutgoing[E](sentenceLength),
+      DirectedGraphIndex.mkIncoming[E](sentenceLength),
       new mutable.HashMap[E, mutable.HashSet[(Int, Int)]]()
     )
   }
@@ -45,13 +45,8 @@ class DirectedGraphIndex[E](
 
   protected def updateRoots(): Unit = {
     roots.clear()
-    roots ++= DirectedGraph.calculateRoots(mkEdges())
+    roots ++= DirectedGraph.calculateRoots(mkEdges(), size)
   }
-
-  // Warning: This "root" isn't necessarily one that would be calculated.
-  // It has hopefully already been added as a side-effect of the
-  // addition or removal of an edge.
-  def addRoot(index:Int) { roots += index }
 
   def findByName(label:E): Seq[Edge[E]] = {
     val edges = new ListBuffer[Edge[E]]

--- a/main/src/main/scala/org/clulab/utils/DependencyUtils.scala
+++ b/main/src/main/scala/org/clulab/utils/DependencyUtils.scala
@@ -232,12 +232,11 @@ object DependencyUtils {
   }
 
   def mergeGraphs[T](dg1: DirectedGraph[T], dg2: DirectedGraph[T]): DirectedGraph[T] = {
-    val roots = dg1.roots ++ dg1.roots
-    val edges = new mutable.HashSet[Edge[T]]
-    edges ++= dg1.edges
-    edges ++= dg2.edges
+    // Roots cannot simply be combined.
+    // val roots = dg1.suggestedRoots ++ dg1.suggestedRoots
+    val edges = dg1.edges ++ dg2.edges
 
-    new DirectedGraph[T](edges.toList, roots)
+    new DirectedGraph(edges, Set.empty)
   }
 }
 

--- a/main/src/test/scala/org/clulab/struct/TestDirectedGraph.scala
+++ b/main/src/test/scala/org/clulab/struct/TestDirectedGraph.scala
@@ -1,0 +1,84 @@
+package org.clulab.struct
+
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
+
+class TestDirectedGraph extends FlatSpec with Matchers {
+
+  behavior of "DirectedGraph"
+
+  def newEdge(source: Int, destination: Int): Edge[String] = {
+    val relation = s""
+
+    Edge(source, destination, relation)
+  }
+
+  it should "process a loop with a source" in {
+    val edges = List(
+      newEdge(0, 1),
+      newEdge(1, 2),
+      newEdge(2, 1)
+    )
+    val roots = Set(0)
+    val directedGraph = new DirectedGraph(edges, roots)
+
+    directedGraph.size should be (3)
+    directedGraph.roots should be (Set(0))
+  }
+
+  it should "process a loop without a source" in {
+    val edges = List(
+      newEdge(0, 1),
+      newEdge(1, 2),
+      newEdge(2, 0)
+    )
+    val roots = Set(0)
+    val directedGraph = new DirectedGraph(edges, roots)
+
+    directedGraph.size should be (3)
+    directedGraph.roots should be (Set(0))
+  }
+
+  it should "add lone roots" in {
+    val edges = List(
+      newEdge(1, 2),
+      newEdge(2, 3),
+      newEdge(3, 1)
+    )
+    val roots = Set(0, 1, 4)
+    val directedGraph = new DirectedGraph(edges, roots, Some(5))
+
+    directedGraph.size should be (5)
+    directedGraph.roots should be (Set(0, 1, 4))
+  }
+
+  it should "handle disjoint loops" in {
+    val edges = List(
+      newEdge(0, 1),
+      newEdge(1, 2),
+      newEdge(2, 0),
+
+      newEdge(3, 4),
+      newEdge(4, 5),
+      newEdge(5, 3)
+    )
+    val roots = Set(0, 3)
+    val directedGraph = new DirectedGraph(edges, roots)
+
+    directedGraph.size should be (6)
+    directedGraph.roots should be (Set(0, 3))
+  }
+
+  it should "not use a leading destination as a root" in {
+    val edges = List(
+      newEdge(1, 0),
+      newEdge(1, 2),
+      newEdge(2, 1)
+    )
+    val roots = Set(1)
+    val directedGraph = new DirectedGraph(edges, roots)
+
+    directedGraph.size should be (3)
+    directedGraph.roots should be (Set(1))
+  }
+}


### PR DESCRIPTION
This still has roots passed in, usually as an empty Seq, for testing.  It will be removed shortly.  Several tests in clulab.utils.TestDependencyUtils are failing.  The ones I looked at should be failing given the new definition of root.  The old definition may have been slightly different.  It looks like lone vertices, with no incoming or outgoing edges, were not always considered to be roots before.  They are now.  I'm not sure what to do about the tests.