### PR TITLE
Clean tokens when parsing numeric expressions.

### DIFF
--- a/main/src/main/resources/org/clulab/numeric/number.yml
+++ b/main/src/main/resources/org/clulab/numeric/number.yml
@@ -28,7 +28,15 @@ rules:
       (ten | eleven | twelve | thirteen | fourteen | fifteen | sixteen | seventeen | eighteen | nineteen |
       # or numbers 20-99
       twenty @WordDigit? | thirty @WordDigit? | fourty @WordDigit? | fifty @WordDigit? |
-      sixty @WordDigit? | seventy @WordDigit? | eighty @WordDigit? | ninety @WordDigit?)
+      sixty @WordDigit? | seventy @WordDigit? | eighty @WordDigit? | ninety @WordDigit? |
+      "twenty-one" | "twenty-two" | "twenty-three" | "twenty-four" | "twenty-five" | "twenty-six" | "twenty-seven" | "twenty-eight" | "twenty-nine" |
+      "thirty-one" | "thirty-two" | "thirty-three" | "thirty-four" | "thirty-five" | "thirty-six" | "thirty-seven" | "thirty-eight" | "thirty-nine" |
+      "forty-one" | "forty-two" | "forty-three" | "forty-four" | "forty-five" | "forty-six" | "forty-seven" | "forty-eight" | "forty-nine" |
+      "fifty-one" | "fifty-two" | "fifty-three" | "fifty-four" | "fifty-five" | "fifty-six" | "fifty-seven" | "fifty-eight" | "fifty-nine" |
+      "sixty-one" | "sixty-two" | "sixty-three" | "sixty-four" | "sixty-five" | "sixty-six" | "sixty-seven" | "sixty-eight" | "sixty-nine" |
+      "seventy-one" | "seventy-two" | "seventy-three" | "seventy-four" | "seventy-five" | "seventy-six" | "seventy-seven" | "seventy-eight" | "seventy-nine" |
+      "eighty-one" | "eighty-two" | "eighty-three" | "eighty-four" | "eighty-five" | "eighty-six" | "eighty-seven" | "eighty-eight" | "eighty-nine" |
+      "ninety-one" | "ninety-two" | "ninety-three" | "ninety-four" | "ninety-five" | "ninety-six" | "ninety-seven" | "ninety-eight" | "ninety-nine")
       /^hundreds?$/ @WordTens?
 
   - name: word_quadrillions
@@ -36,42 +44,42 @@ rules:
     priority: 8
     type: token
     pattern: |
-      (@WordHundreds /^quadrillions?$/)? @WordTrillions
+      @WordHundreds /^quadrillions?$/ | (@WordHundreds /^quadrillions?$/)? @WordTrillions
 
   - name: word_trillions
     label: WordTrillions
     priority: 7
     type: token
     pattern: |
-      (@WordHundreds /^trillions?$/)? @WordBillions
+      @WordHundreds /^trillions?$/ | (@WordHundreds /^trillions?$/)? @WordBillions
 
   - name: word_billions
     label: WordBillions
     priority: 6
     type: token
     pattern: |
-      (@WordHundreds /^billions?$/)? @WordMillions
+      @WordHundreds /^billions?$/ | (@WordHundreds /^billions?$/)? @WordMillions
 
   - name: word_millions
     label: WordMillions
     priority: 5
     type: token
     pattern: |
-      (@WordHundreds /^millions?$/)? @WordThousands
+      @WordHundreds /^millions?$/ | (@WordHundreds /^millions?$/)? @WordThousands
 
   - name: word_thousands
     label: WordThousands
     priority: 4
     type: token
     pattern: |
-      (@WordHundreds /^thousands?$/)? @WordHundreds
+      @WordHundreds /^thousands?$/ | (@WordHundreds /^thousands?$/)? @WordHundreds
 
   - name: word_hundreds
     label: WordHundreds
     priority: 3
     type: token
     pattern: |
-      (@WordDigit /^hundreds?$/)? @WordTens
+      @WordDigit /^hundreds?$/ | (@WordDigit /^hundreds?$/)? @WordTens
 
   - name: word_tens
     label: WordTens
@@ -84,7 +92,15 @@ rules:
       ten | eleven | twelve | thirteen | fourteen | fifteen | sixteen | seventeen | eighteen | nineteen |
       # or numbers 20-99
       twenty @WordDigit? | thirty @WordDigit? | fourty @WordDigit? | fifty @WordDigit? |
-      sixty @WordDigit? | seventy @WordDigit? | eighty @WordDigit? | ninety @WordDigit?
+      sixty @WordDigit? | seventy @WordDigit? | eighty @WordDigit? | ninety @WordDigit? |
+      "twenty-one" | "twenty-two" | "twenty-three" | "twenty-four" | "twenty-five" | "twenty-six" | "twenty-seven" | "twenty-eight" | "twenty-nine" |
+      "thirty-one" | "thirty-two" | "thirty-three" | "thirty-four" | "thirty-five" | "thirty-six" | "thirty-seven" | "thirty-eight" | "thirty-nine" |
+      "forty-one" | "forty-two" | "forty-three" | "forty-four" | "forty-five" | "forty-six" | "forty-seven" | "forty-eight" | "forty-nine" |
+      "fifty-one" | "fifty-two" | "fifty-three" | "fifty-four" | "fifty-five" | "fifty-six" | "fifty-seven" | "fifty-eight" | "fifty-nine" |
+      "sixty-one" | "sixty-two" | "sixty-three" | "sixty-four" | "sixty-five" | "sixty-six" | "sixty-seven" | "sixty-eight" | "sixty-nine" |
+      "seventy-one" | "seventy-two" | "seventy-three" | "seventy-four" | "seventy-five" | "seventy-six" | "seventy-seven" | "seventy-eight" | "seventy-nine" |
+      "eighty-one" | "eighty-two" | "eighty-three" | "eighty-four" | "eighty-five" | "eighty-six" | "eighty-seven" | "eighty-eight" | "eighty-nine" |
+      "ninety-one" | "ninety-two" | "ninety-three" | "ninety-four" | "ninety-five" | "ninety-six" | "ninety-seven" | "ninety-eight" | "ninety-nine"
 
   - name: word_digits
     label: WordDigit

--- a/main/src/main/scala/org/clulab/numeric/NumberParser.scala
+++ b/main/src/main/scala/org/clulab/numeric/NumberParser.scala
@@ -20,8 +20,8 @@ object NumberParser {
           if (word.endsWith("s")) {
             word = word.dropRight(1)
           }
-		  // split on dashes
-          word.split("-")
+          // split on dashes
+          hyphenated.getOrElse(word, Array(word))
         }
         parseWords(cleanWords) orElse parseNumeric(cleanWords)
     }
@@ -135,6 +135,88 @@ object NumberParser {
     "billion"     -> 1e9,
     "trillion"    -> 1e12,
     "quadrillion" -> 1e15
+  )
+
+  val hyphenated = Map(
+    "twenty-one" -> Array("twenty", "one"),
+    "twenty-two" -> Array("twenty", "two"),
+    "twenty-three" -> Array("twenty", "three"),
+    "twenty-four" -> Array("twenty", "four"),
+    "twenty-five" -> Array("twenty", "five"),
+    "twenty-six" -> Array("twenty", "six"),
+    "twenty-seven" -> Array("twenty", "seven"),
+    "twenty-eight" -> Array("twenty", "eight"),
+    "twenty-nine" -> Array("twenty", "nine"),
+
+    "thirty-one" -> Array("thirty", "one"),
+    "thirty-two" -> Array("thirty", "two"),
+    "thirty-three" -> Array("thirty", "three"),
+    "thirty-four" -> Array("thirty", "four"),
+    "thirty-five" -> Array("thirty", "five"),
+    "thirty-six" -> Array("thirty", "six"),
+    "thirty-seven" -> Array("thirty", "seven"),
+    "thirty-eight" -> Array("thirty", "eight"),
+    "thirty-nine" -> Array("thirty", "nine"),
+
+    "forty-one" -> Array("forty", "one"),
+    "forty-two" -> Array("forty", "two"),
+    "forty-three" -> Array("forty", "three"),
+    "forty-four" -> Array("forty", "four"),
+    "forty-five" -> Array("forty", "five"),
+    "forty-six" -> Array("forty", "six"),
+    "forty-seven" -> Array("forty", "seven"),
+    "forty-eight" -> Array("forty", "eight"),
+    "forty-nine" -> Array("forty", "nine"),
+
+    "fifty-one" -> Array("fifty", "one"),
+    "fifty-two" -> Array("fifty", "two"),
+    "fifty-three" -> Array("fifty", "three"),
+    "fifty-four" -> Array("fifty", "four"),
+    "fifty-five" -> Array("fifty", "five"),
+    "fifty-six" -> Array("fifty", "six"),
+    "fifty-seven" -> Array("fifty", "seven"),
+    "fifty-eight" -> Array("fifty", "eight"),
+    "fifty-nine" -> Array("fifty", "nine"),
+
+    "sixty-one" -> Array("sixty", "one"),
+    "sixty-two" -> Array("sixty", "two"),
+    "sixty-three" -> Array("sixty", "three"),
+    "sixty-four" -> Array("sixty", "four"),
+    "sixty-five" -> Array("sixty", "five"),
+    "sixty-six" -> Array("sixty", "six"),
+    "sixty-seven" -> Array("sixty", "seven"),
+    "sixty-eight" -> Array("sixty", "eight"),
+    "sixty-nine" -> Array("sixty", "nine"),
+
+    "seventy-one" -> Array("seventy", "one"),
+    "seventy-two" -> Array("seventy", "two"),
+    "seventy-three" -> Array("seventy", "three"),
+    "seventy-four" -> Array("seventy", "four"),
+    "seventy-five" -> Array("seventy", "five"),
+    "seventy-six" -> Array("seventy", "six"),
+    "seventy-seven" -> Array("seventy", "seven"),
+    "seventy-eight" -> Array("seventy", "eight"),
+    "seventy-nine" -> Array("seventy", "nine"),
+
+    "eighty-one" -> Array("eighty", "one"),
+    "eighty-two" -> Array("eighty", "two"),
+    "eighty-three" -> Array("eighty", "three"),
+    "eighty-four" -> Array("eighty", "four"),
+    "eighty-five" -> Array("eighty", "five"),
+    "eighty-six" -> Array("eighty", "six"),
+    "eighty-seven" -> Array("eighty", "seven"),
+    "eighty-eight" -> Array("eighty", "eight"),
+    "eighty-nine" -> Array("eighty", "nine"),
+
+    "ninety-one" -> Array("ninety", "one"),
+    "ninety-two" -> Array("ninety", "two"),
+    "ninety-three" -> Array("ninety", "three"),
+    "ninety-four" -> Array("ninety", "four"),
+    "ninety-five" -> Array("ninety", "five"),
+    "ninety-six" -> Array("ninety", "six"),
+    "ninety-seven" -> Array("ninety", "seven"),
+    "ninety-eight" -> Array("ninety", "eight"),
+    "ninety-nine" -> Array("ninety", "nine"),
   )
 
 }

--- a/main/src/main/scala/org/clulab/numeric/NumberParser.scala
+++ b/main/src/main/scala/org/clulab/numeric/NumberParser.scala
@@ -149,7 +149,7 @@ object NumberParser {
     "sixty-one", "sixty-two", "sixty-three", "sixty-four", "sixty-five", "sixty-six", "sixty-seven", "sixty-eight", "sixty-nine",
     "seventy-one", "seventy-two", "seventy-three", "seventy-four", "seventy-five", "seventy-six", "seventy-seven", "seventy-eight", "seventy-nine",
     "eighty-one", "eighty-two", "eighty-three", "eighty-four", "eighty-five", "eighty-six", "eighty-seven", "eighty-eight", "eighty-nine",
-    "ninety-one", "ninety-two", "ninety-three", "ninety-four", "ninety-five", "ninety-six", "ninety-seven", "ninety-eight", "ninety-nine",
+    "ninety-one", "ninety-two", "ninety-three", "ninety-four", "ninety-five", "ninety-six", "ninety-seven", "ninety-eight", "ninety-nine"
   )
 
 }

--- a/main/src/main/scala/org/clulab/numeric/NumberParser.scala
+++ b/main/src/main/scala/org/clulab/numeric/NumberParser.scala
@@ -21,7 +21,11 @@ object NumberParser {
             word = word.dropRight(1)
           }
           // split on dashes
-          hyphenated.getOrElse(word, Array(word))
+          if (hyphenated.contains(word)) {
+              word.split("-")
+          } else {
+              Array(word)
+          }
         }
         parseWords(cleanWords) orElse parseNumeric(cleanWords)
     }
@@ -137,86 +141,15 @@ object NumberParser {
     "quadrillion" -> 1e15
   )
 
-  val hyphenated = Map(
-    "twenty-one" -> Array("twenty", "one"),
-    "twenty-two" -> Array("twenty", "two"),
-    "twenty-three" -> Array("twenty", "three"),
-    "twenty-four" -> Array("twenty", "four"),
-    "twenty-five" -> Array("twenty", "five"),
-    "twenty-six" -> Array("twenty", "six"),
-    "twenty-seven" -> Array("twenty", "seven"),
-    "twenty-eight" -> Array("twenty", "eight"),
-    "twenty-nine" -> Array("twenty", "nine"),
-
-    "thirty-one" -> Array("thirty", "one"),
-    "thirty-two" -> Array("thirty", "two"),
-    "thirty-three" -> Array("thirty", "three"),
-    "thirty-four" -> Array("thirty", "four"),
-    "thirty-five" -> Array("thirty", "five"),
-    "thirty-six" -> Array("thirty", "six"),
-    "thirty-seven" -> Array("thirty", "seven"),
-    "thirty-eight" -> Array("thirty", "eight"),
-    "thirty-nine" -> Array("thirty", "nine"),
-
-    "forty-one" -> Array("forty", "one"),
-    "forty-two" -> Array("forty", "two"),
-    "forty-three" -> Array("forty", "three"),
-    "forty-four" -> Array("forty", "four"),
-    "forty-five" -> Array("forty", "five"),
-    "forty-six" -> Array("forty", "six"),
-    "forty-seven" -> Array("forty", "seven"),
-    "forty-eight" -> Array("forty", "eight"),
-    "forty-nine" -> Array("forty", "nine"),
-
-    "fifty-one" -> Array("fifty", "one"),
-    "fifty-two" -> Array("fifty", "two"),
-    "fifty-three" -> Array("fifty", "three"),
-    "fifty-four" -> Array("fifty", "four"),
-    "fifty-five" -> Array("fifty", "five"),
-    "fifty-six" -> Array("fifty", "six"),
-    "fifty-seven" -> Array("fifty", "seven"),
-    "fifty-eight" -> Array("fifty", "eight"),
-    "fifty-nine" -> Array("fifty", "nine"),
-
-    "sixty-one" -> Array("sixty", "one"),
-    "sixty-two" -> Array("sixty", "two"),
-    "sixty-three" -> Array("sixty", "three"),
-    "sixty-four" -> Array("sixty", "four"),
-    "sixty-five" -> Array("sixty", "five"),
-    "sixty-six" -> Array("sixty", "six"),
-    "sixty-seven" -> Array("sixty", "seven"),
-    "sixty-eight" -> Array("sixty", "eight"),
-    "sixty-nine" -> Array("sixty", "nine"),
-
-    "seventy-one" -> Array("seventy", "one"),
-    "seventy-two" -> Array("seventy", "two"),
-    "seventy-three" -> Array("seventy", "three"),
-    "seventy-four" -> Array("seventy", "four"),
-    "seventy-five" -> Array("seventy", "five"),
-    "seventy-six" -> Array("seventy", "six"),
-    "seventy-seven" -> Array("seventy", "seven"),
-    "seventy-eight" -> Array("seventy", "eight"),
-    "seventy-nine" -> Array("seventy", "nine"),
-
-    "eighty-one" -> Array("eighty", "one"),
-    "eighty-two" -> Array("eighty", "two"),
-    "eighty-three" -> Array("eighty", "three"),
-    "eighty-four" -> Array("eighty", "four"),
-    "eighty-five" -> Array("eighty", "five"),
-    "eighty-six" -> Array("eighty", "six"),
-    "eighty-seven" -> Array("eighty", "seven"),
-    "eighty-eight" -> Array("eighty", "eight"),
-    "eighty-nine" -> Array("eighty", "nine"),
-
-    "ninety-one" -> Array("ninety", "one"),
-    "ninety-two" -> Array("ninety", "two"),
-    "ninety-three" -> Array("ninety", "three"),
-    "ninety-four" -> Array("ninety", "four"),
-    "ninety-five" -> Array("ninety", "five"),
-    "ninety-six" -> Array("ninety", "six"),
-    "ninety-seven" -> Array("ninety", "seven"),
-    "ninety-eight" -> Array("ninety", "eight"),
-    "ninety-nine" -> Array("ninety", "nine"),
+  val hyphenated = Set(
+    "twenty-one", "twenty-two", "twenty-three", "twenty-four", "twenty-five", "twenty-six", "twenty-seven", "twenty-eight", "twenty-nine",
+    "thirty-one", "thirty-two", "thirty-three", "thirty-four", "thirty-five", "thirty-six", "thirty-seven", "thirty-eight", "thirty-nine",
+    "forty-one", "forty-two", "forty-three", "forty-four", "forty-five", "forty-six", "forty-seven", "forty-eight", "forty-nine",
+    "fifty-one", "fifty-two", "fifty-three", "fifty-four", "fifty-five", "fifty-six", "fifty-seven", "fifty-eight", "fifty-nine",
+    "sixty-one", "sixty-two", "sixty-three", "sixty-four", "sixty-five", "sixty-six", "sixty-seven", "sixty-eight", "sixty-nine",
+    "seventy-one", "seventy-two", "seventy-three", "seventy-four", "seventy-five", "seventy-six", "seventy-seven", "seventy-eight", "seventy-nine",
+    "eighty-one", "eighty-two", "eighty-three", "eighty-four", "eighty-five", "eighty-six", "eighty-seven", "eighty-eight", "eighty-nine",
+    "ninety-one", "ninety-two", "ninety-three", "ninety-four", "ninety-five", "ninety-six", "ninety-seven", "ninety-eight", "ninety-nine",
   )
 
 }

--- a/main/src/main/scala/org/clulab/numeric/NumberParser.scala
+++ b/main/src/main/scala/org/clulab/numeric/NumberParser.scala
@@ -11,11 +11,18 @@ object NumberParser {
     words match {
       case Seq() => None
       case words =>
-	    // remove 's' from words like "thousands"
-	    val cleanWords = words.map { w =>
-		  if (w.endsWith("s")) w.dropRight(1) else w
-	    }
-	    parseWords(cleanWords) orElse parseNumeric(cleanWords)
+        val cleanWords = words.map { w =>
+          // lowercase
+          var word = w.toLowerCase()
+          // remove commas from numbers like 100,000
+          word = word.replace(",", "")
+          // remove 's' from words like "thousands"
+          if (word.endsWith("s")) {
+            word = word.dropRight(1)
+          }
+          word
+        }
+        parseWords(cleanWords) orElse parseNumeric(cleanWords)
     }
   }
 

--- a/main/src/main/scala/org/clulab/numeric/NumberParser.scala
+++ b/main/src/main/scala/org/clulab/numeric/NumberParser.scala
@@ -11,7 +11,7 @@ object NumberParser {
     words match {
       case Seq() => None
       case words =>
-        val cleanWords = words.map { w =>
+        val cleanWords = words.flatMap { w =>
           // lowercase
           var word = w.toLowerCase()
           // remove commas from numbers like 100,000
@@ -20,7 +20,8 @@ object NumberParser {
           if (word.endsWith("s")) {
             word = word.dropRight(1)
           }
-          word
+		  // split on dashes
+          word.split("-")
         }
         parseWords(cleanWords) orElse parseNumeric(cleanWords)
     }

--- a/main/src/test/scala/org/clulab/numeric/TestNumberParser.scala
+++ b/main/src/test/scala/org/clulab/numeric/TestNumberParser.scala
@@ -52,6 +52,10 @@ class TestNumberParser extends FlatSpec with Matchers {
 		NumberParser.parse("thousands".split(" ")) shouldEqual Some(1000)
 		NumberParser.parse("2 thousand".split(" ")) shouldEqual Some(2000)
 		NumberParser.parse("2 thousands".split(" ")) shouldEqual Some(2000)
+		NumberParser.parse("100 thousand".split(" ")) shouldEqual Some(100000)
+		NumberParser.parse("one hundred thousand".split(" ")) shouldEqual Some(100000)
+		NumberParser.parse("ONE HUNDRED THOUSAND".split(" ")) shouldEqual Some(100000)
+		NumberParser.parse("100,000".split(" ")) shouldEqual Some(100000)
 	}
 
 }

--- a/main/src/test/scala/org/clulab/numeric/TestNumericEntityRecognition.scala
+++ b/main/src/test/scala/org/clulab/numeric/TestNumericEntityRecognition.scala
@@ -133,6 +133,14 @@ class TestNumericEntityRecognition extends FlatSpec with Matchers {
     ensure("It was 12 hundred ha", Interval(2, 5), "MEASUREMENT", "1200.0 ha")
     ensure(sentence= "Crops are 2 thousands ha wide.", Interval(2,5), goldEntity="MEASUREMENT", goldNorm= "2000.0 ha")
     ensure(sentence= "Rice crops are 1.5 thousands ha wide", Interval(3, 6), goldEntity="MEASUREMENT", goldNorm= "1500.0 ha")
+    ensure(sentence= "Rice crops are 1 ha wide", Interval(3, 5), goldEntity="MEASUREMENT", goldNorm= "1.0 ha")
+    ensure(sentence= "Rice crops are one ha wide", Interval(3, 5), goldEntity="MEASUREMENT", goldNorm= "1.0 ha")
+    ensure(sentence= "Rice crops are ten ha wide", Interval(3, 5), goldEntity="MEASUREMENT", goldNorm= "10.0 ha")
+    ensure(sentence= "Rice crops are twenty five ha wide", Interval(3, 5), goldEntity="MEASUREMENT", goldNorm= "25.0 ha")
+    ensure(sentence= "Rice crops are twenty-five ha wide", Interval(3, 5), goldEntity="MEASUREMENT", goldNorm= "25.0 ha")
+    ensure(sentence= "Rice crops are one hundred ha wide", Interval(3, 5), goldEntity="MEASUREMENT", goldNorm= "100.0 ha")
+    ensure(sentence= "Rice crops are one thousand ha wide", Interval(3, 6), goldEntity="MEASUREMENT", goldNorm= "1000.0 ha")
+    ensure(sentence= "Rice crops are one hundred thousand ha wide", Interval(3, 6), goldEntity="MEASUREMENT", goldNorm= "100000.0 ha")
   }
 
   //


### PR DESCRIPTION
Converts to lowercase and remove commas.
Fixes an issue mentioned in #530