### PR TITLE
load rules from filesystem if we can find them

### DIFF
--- a/main/src/main/scala/org/clulab/odin/ExtractorEngine.scala
+++ b/main/src/main/scala/org/clulab/odin/ExtractorEngine.scala
@@ -76,14 +76,16 @@ object ExtractorEngine {
    *  @param globalAction an action that will be applied to the extracted
    *                      mentions at the end of each iteration
    *  @param charset encoding to use for reading files
+   *  @param path path to use if rules should be loaded from filesystem
    */
   def apply(
       rules: String,
       actions: Actions = new Actions,
       globalAction: odin.Action = identityAction,
-      charset: Charset = UTF_8
+      charset: Charset = UTF_8,
+      path: Option[File] = None
   ): ExtractorEngine = {
-    val reader = new RuleReader(actions, charset)
+    val reader = new RuleReader(actions, charset, path)
     val extractors = reader.read(rules)
     new ExtractorEngine(extractors, globalAction)
   }

--- a/main/src/main/scala/org/clulab/odin/impl/RuleReader.scala
+++ b/main/src/main/scala/org/clulab/odin/impl/RuleReader.scala
@@ -4,8 +4,10 @@ import java.io.File
 import java.net.URL
 import java.util.{Collection, Map => JMap}
 import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
 
 import org.apache.commons.text.StrSubstitutor
+import org.apache.commons.io.FileUtils.readFileToString
 
 import scala.collection.JavaConverters._
 import scala.io.{Codec, Source}
@@ -18,7 +20,7 @@ import org.clulab.utils.Closer._
 
 
 
-class RuleReader(val actions: Actions, val charset: Charset) {
+class RuleReader(val actions: Actions, val charset: Charset, val rulepath: Option[File] = None) {
 
   import RuleReader._
 
@@ -230,23 +232,39 @@ class RuleReader(val actions: Actions, val charset: Charset) {
   def readOrImportVars(data: Any): Map[String, String] = data match {
     case vars: JMap[_, _] => vars.asScala.map{ case (k,v) => k.toString -> processVar(v) }.toMap
     case path: String =>
-      val url = mkURL(path)
-      val source = Source.fromURL(url)
-      val input = source.mkString
-      source.close()
+      val input = readFileOrResource(path)
       val yaml = new Yaml(new Constructor(classOf[JMap[String, Any]]))
       val vars = yaml.load(input).asInstanceOf[JMap[String, Any]]
       vars.asScala.mapValues(v => processVar(v)).toMap
+  }
+
+  /**
+    * Tries to read the path as a file first. If it fails, then it tries
+    * to read from the jar resources.
+    *
+    * @param s
+    * @return
+    */
+  def readFileOrResource(s: String): String = {
+    rulepath match {
+      case Some(path) =>
+        val filepath = if (s.startsWith("/")) s.drop(1) else s
+        val f = new File(path, filepath)
+        readFileToString(f, StandardCharsets.UTF_8)
+      case None =>
+        val url = mkURL(s)
+        val source = Source.fromURL(url)
+        val data = source.mkString
+        source.close()
+        data
+    }
   }
 
   // reads a taxonomy from data, where data may be either a forest or a file path
   private def readTaxonomy(data: Any): Taxonomy = data match {
     case t: Collection[_] => Taxonomy(t.asInstanceOf[Collection[Any]])
     case path: String =>
-      val url = mkURL(path)
-      val source = Source.fromURL(url)
-      val input = source.mkString
-      source.close()
+      val input = readFileOrResource(path)
       val yaml = new Yaml(new Constructor(classOf[Collection[Any]]))
       val data = yaml.load(input).asInstanceOf[Collection[Any]]
       Taxonomy(data)
@@ -273,10 +291,7 @@ class RuleReader(val actions: Actions, val charset: Charset) {
       val res = replaceVars(p, config.variables)
       res
     }
-    val url = mkURL(path)
-    val source = Source.fromURL(url)
-    val input = source.mkString // slurp
-    source.close()
+    val input = readFileOrResource(path)
     // read rules and vars from file
     val (jRules: Collection[JMap[String, Any]], localVars: Map[String, String]) = try {
       // try to read file with rules and optional vars by trying to read a JMap

--- a/main/src/main/scala/org/clulab/utils/Shell.scala
+++ b/main/src/main/scala/org/clulab/utils/Shell.scala
@@ -8,8 +8,24 @@ abstract class Shell {
    * if that needs to happen after shell() is called.  Otherwise,
    * such initialization can happen in the subclass constructor. */
   def initialize(): Unit = ()
+
   /** The actual work, including printing out the output */
   def work(text: String): Unit
+
+  /** Override me to reload rules */
+  def reload(): Unit = {
+    println("reloading not supported")
+  }
+
+  def reload(menu: Menu, text: String): Boolean = {
+    try {
+      reload()
+    }
+    catch {
+      case e: Throwable => println(s"error reloading: ${e.getMessage}")
+    }
+    true
+  }
 
   def shell() {
 
@@ -31,6 +47,7 @@ abstract class Shell {
     val lineReader = new CliReader("(shell)>>> ", "user.home", ".shellhistory")
     val mainMenuItems = Seq(
       new HelpMenuItem(":help", "show commands"),
+      new MainMenuItem(":reload", "reload rules from filesystem", reload),
       new ExitMenuItem(":exit", "exit system")
     )
     val defaultMenuItem = new DefaultMenuItem(workSafely)
@@ -38,4 +55,5 @@ abstract class Shell {
 
     menu.run()
   }
+
 }


### PR DESCRIPTION
With this pr, the `RuleReader` tries to interpret paths as files first and then as resources in the jar. This is useful for reloading rules without rebuilding.

It also adds a `:reload` option to the shell menu that can be implemented downstream.