### PR TITLE
Enable processor reloading in shells

### DIFF
--- a/corenlp/src/main/scala/org/clulab/processors/ProcessorJsonShell.scala
+++ b/corenlp/src/main/scala/org/clulab/processors/ProcessorJsonShell.scala
@@ -1,73 +1,20 @@
 package org.clulab.processors
 
-import org.clulab.dynet.Utils
-import org.clulab.processors.clu.CluProcessor
-import org.clulab.processors.corenlp.CoreNLPProcessor
-import org.clulab.processors.fastnlp.FastNLPProcessorWithSemanticRoles
 import org.clulab.serialization.json4StopGraph.JSONSerializer
-import org.clulab.utils.CliReader
-import org.clulab.utils.DefaultMenuItem
-import org.clulab.utils.ExitMenuItem
-import org.clulab.utils.HelpMenuItem
-import org.clulab.utils.MainMenuItem
 import org.clulab.utils.Menu
 
-import java.io.PrintWriter
-
-/**
-  * A simple interactive shell
-  * User: mihais
-  * Date: 3/13/14
-  * Last Modified: Fix compiler warning: remove redundant match case clause.
- */
-object ProcessorJsonShell extends App {
-  lazy val core: Processor = new CoreNLPProcessor() // this uses the slower constituent parser
-  lazy val fast: Processor = new FastNLPProcessorWithSemanticRoles() // this uses the faster dependency parser
-  lazy val clu: Processor = new CluProcessor()
-
-  Utils.initializeDyNet()
-
-  var proc = clu // The initial proc does not get initialized.
-  val cluCorePrompt = "(clu)>>> "
-
-  val lineReader = new CliReader(cluCorePrompt, "user.home", ".processorshellhistory")
-  val printWriter = new PrintWriter(System.out)
+class ProcessorJsonShell extends ProcessorShell {
   val serializer = new JSONSerializer(printWriter)
 
-  def prepareProcessor(prompt: String, message: String, processor: Processor): Boolean = {
-    lineReader.setPrompt(prompt)
-    println(message)
-    proc = processor
-    proc.annotate("initialize me!")
-    true
-  }
-
-  def prepareCore(menu: Menu, text: String): Boolean =
-    prepareProcessor("(core)>>>", "Preparing CoreNLPProcessor...", core)
-
-  def prepareFast(menu: Menu, text: String): Boolean =
-    prepareProcessor("(fast)>>> ", "Preparing FastNLPProcessor...", fast)
-
-  def prepareClu(menu: Menu, text: String): Boolean = {
-    prepareProcessor("(clu)>>> ", "Preparing CluProcessor...", clu)
-  }
-
-  def annotate(menu: Menu, text: String): Boolean = {
-    val doc = proc.annotate(text)
+  override def work(text: String): Unit = {
+    val doc = proc.get.annotate(text)
     serializer.serialize(doc)
     printWriter.flush()
-    true
   }
 
-  val mainMenuItems = Seq(
-    new HelpMenuItem(":help", "show commands"),
-    new MainMenuItem(":core", "use CoreNLPProcessor", prepareCore),
-    new MainMenuItem(":fast", "use FastNLPProcessor", prepareFast),
-    new MainMenuItem(":clu", "use CluProcessor", prepareClu),
-    new ExitMenuItem(":exit", "exit system")
-  )
-  val defaultMenuItem = new DefaultMenuItem(annotate)
-  val menu = new Menu("Welcome to the ProcessorJsonShell!", lineReader, mainMenuItems, defaultMenuItem)
+  override def mkMenu(): Menu = super.mkMenu.withGreeting("Welcome to the ProcessorJsonShell!")
+}
 
-  menu.run()
+object ProcessorJsonShell extends App {
+  new ProcessorJsonShell().shell()
 }

--- a/corenlp/src/main/scala/org/clulab/processors/ProcessorShell.scala
+++ b/corenlp/src/main/scala/org/clulab/processors/ProcessorShell.scala
@@ -12,6 +12,7 @@ import org.clulab.utils.ReloadableProcessor
 import org.clulab.utils.ReloadableShell
 import org.clulab.utils.SafeDefaultMenuItem
 import org.clulab.utils.SafeMainMenuItem
+import org.clulab.utils.Shell
 
 import java.io.PrintWriter
 
@@ -21,7 +22,7 @@ import java.io.PrintWriter
   * Date: 3/13/14
   * Last Modified: Fix compiler warning: remove redundant match case clause.
   */
-class ProcessorShell extends ReloadableShell {
+class ProcessorShell extends Shell {
   Utils.initializeDyNet()
 
   val core = new PromptedReloadableProcessor("(core)>>> ", () => new CoreNLPProcessor()) // this uses the slower constituent parser
@@ -53,6 +54,7 @@ class ProcessorShell extends ReloadableShell {
     printWriter.flush()
   }
 
+  // We inherit now just from Shell, so no reloading is performed.
   def reload(): Unit = {
     println("The processor is reloading...")
     proc.reload()
@@ -64,7 +66,7 @@ class ProcessorShell extends ReloadableShell {
       new SafeMainMenuItem(":core", "use CoreNLPProcessor", prepareCore),
       new SafeMainMenuItem(":fast", "use FastNLPProcessor", prepareFast),
       new SafeMainMenuItem(":clu", "use CluProcessor", prepareClu),
-      new SafeMainMenuItem(":reload", "reload rules for current processor from filesystem", reload),
+      // new SafeMainMenuItem(":reload", "reload rules for current processor from filesystem", reload),
       new ExitMenuItem(":exit", "exit system")
     )
     val defaultMenuItem = new SafeDefaultMenuItem(work)

--- a/corenlp/src/main/scala/org/clulab/processors/ProcessorShell.scala
+++ b/corenlp/src/main/scala/org/clulab/processors/ProcessorShell.scala
@@ -1,70 +1,81 @@
 package org.clulab.processors
 
-import java.io.PrintWriter
 import org.clulab.dynet.Utils
 import org.clulab.processors.clu.CluProcessor
 import org.clulab.processors.corenlp.CoreNLPProcessor
 import org.clulab.processors.fastnlp.FastNLPProcessorWithSemanticRoles
 import org.clulab.utils.CliReader
-import org.clulab.utils.DefaultMenuItem
 import org.clulab.utils.ExitMenuItem
 import org.clulab.utils.HelpMenuItem
-import org.clulab.utils.MainMenuItem
 import org.clulab.utils.Menu
+import org.clulab.utils.ReloadableProcessor
+import org.clulab.utils.ReloadableShell
+import org.clulab.utils.SafeDefaultMenuItem
+import org.clulab.utils.SafeMainMenuItem
+
+import java.io.PrintWriter
 
 /**
   * A simple interactive shell
   * User: mihais
   * Date: 3/13/14
   * Last Modified: Fix compiler warning: remove redundant match case clause.
- */
-object ProcessorShell extends App {
-  lazy val core: Processor = new CoreNLPProcessor() // this uses the slower constituent parser
-  lazy val fast: Processor = new FastNLPProcessorWithSemanticRoles() // this uses the faster dependency parser
-  lazy val clu: Processor = new CluProcessor()
-
+  */
+class ProcessorShell extends ReloadableShell {
   Utils.initializeDyNet()
 
-  var proc = clu // The initial proc does not get initialized.
-  val cluCorePrompt = "(clu)>>> "
+  val core = new PromptedReloadableProcessor("(core)>>> ", () => new CoreNLPProcessor()) // this uses the slower constituent parser
+  val fast = new PromptedReloadableProcessor("(fast)>>> ", () => new FastNLPProcessorWithSemanticRoles()) // this uses the faster dependency parser
+  val clu = new PromptedReloadableProcessor("(clu)>>> ", () => new CluProcessor(), true)
 
-  val lineReader = new CliReader(cluCorePrompt, "user.home", ".processorshellhistory")
+  var proc = clu // Note that the initial proc does not get initialized.
+
+  val lineReader = new CliReader(proc.prompt, "user.home", ".processorshellhistory")
   val printWriter = new PrintWriter(System.out)
 
-  def prepareProcessor(prompt: String, message: String, processor: Processor): Boolean = {
-    lineReader.setPrompt(prompt)
+  def prepareProcessor(message: String, promptedReloadableProcessor: PromptedReloadableProcessor): Unit = {
+    lineReader.setPrompt(promptedReloadableProcessor.prompt)
     println(message)
-    proc = processor
-    proc.annotate("initialize me!")
-    true
+    proc = promptedReloadableProcessor
+    proc.reload()
+    proc.get.annotate("initialize me!")
   }
 
-  def prepareCore(menu: Menu, text: String): Boolean =
-    prepareProcessor("(core)>>>", "Preparing CoreNLPProcessor...", core)
+  def prepareCore(): Unit = prepareProcessor("Preparing CoreNLPProcessor...", core)
 
-  def prepareFast(menu: Menu, text: String): Boolean =
-    prepareProcessor("(fast)>>> ", "Preparing FastNLPProcessor...", fast)
+  def prepareFast(): Unit = prepareProcessor("Preparing FastNLPProcessor...", fast)
 
-  def prepareClu(menu: Menu, text: String): Boolean = {
-    prepareProcessor("(clu)>>> ", "Preparing CluProcessor...", clu)
-  }
+  def prepareClu(): Unit = prepareProcessor("Preparing CluProcessor...", clu)
 
-  def annotate(menu: Menu, text: String): Boolean = {
-    val doc = proc.annotate(text)
+  override def work(text: String): Unit = {
+    val doc = proc.get.annotate(text)
     doc.prettyPrint(printWriter)
     printWriter.flush()
-    true
   }
 
-  val mainMenuItems = Seq(
-    new HelpMenuItem(":help", "show commands"),
-    new MainMenuItem(":core", "use CoreNLPProcessor", prepareCore),
-    new MainMenuItem(":fast", "use FastNLPProcessor", prepareFast),
-    new MainMenuItem(":clu", "use CluProcessor", prepareClu),
-    new ExitMenuItem(":exit", "exit system")
-  )
-  val defaultMenuItem = new DefaultMenuItem(annotate)
-  val menu = new Menu("Welcome to the ProcessorShell!", lineReader, mainMenuItems, defaultMenuItem)
+  def reload(): Unit = {
+    println("The processor is reloading...")
+    proc.reload()
+  }
 
-  menu.run()
+  override def mkMenu(): Menu = {
+    val mainMenuItems = Seq(
+      new HelpMenuItem(":help", "show commands"),
+      new SafeMainMenuItem(":core", "use CoreNLPProcessor", prepareCore),
+      new SafeMainMenuItem(":fast", "use FastNLPProcessor", prepareFast),
+      new SafeMainMenuItem(":clu", "use CluProcessor", prepareClu),
+      new SafeMainMenuItem(":reload", "reload rules for current processor from filesystem", reload),
+      new ExitMenuItem(":exit", "exit system")
+    )
+    val defaultMenuItem = new SafeDefaultMenuItem(work)
+
+    new Menu("Welcome to the ProcessorShell!", lineReader, mainMenuItems, defaultMenuItem)
+  }
 }
+
+object ProcessorShell extends App {
+  new ProcessorShell().shell()
+}
+
+class PromptedReloadableProcessor(val prompt: String, constructor: () => Processor, impatient: Boolean = true)
+    extends ReloadableProcessor(constructor, impatient)

--- a/main/src/main/scala/org/clulab/numeric/NumericEntityRecognizer.scala
+++ b/main/src/main/scala/org/clulab/numeric/NumericEntityRecognizer.scala
@@ -1,6 +1,5 @@
 package org.clulab.numeric
 
-import org.apache.commons.io.FileUtils.readFileToString
 import org.clulab.numeric.actions.NumericActions
 import org.clulab.odin.{ExtractorEngine, Mention}
 import org.clulab.processors.Document
@@ -9,7 +8,6 @@ import org.clulab.struct.TrueEntityValidator
 import org.clulab.utils.FileUtils
 
 import java.io.File
-import java.nio.charset.StandardCharsets
 import scala.collection.mutable.ArrayBuffer
 
 class NumericEntityRecognizer protected (val lexiconNer: LexiconNER, val actions: NumericActions,
@@ -61,6 +59,7 @@ class NumericEntityRecognizer protected (val lexiconNer: LexiconNER, val actions
 }
 
 object NumericEntityRecognizer {
+  val rulesPath = "/org/clulab/numeric/master.yml"
 
   // this matches essential dictionaries such as month names
   def mkLexiconNer: LexiconNER = LexiconNER(
@@ -78,15 +77,13 @@ object NumericEntityRecognizer {
 
   // this matches the grammars for both atomic and compositional entities
   def mkExtractor(actions: NumericActions): ExtractorEngine = {
-    val rules = FileUtils.getTextFromResource("/org/clulab/numeric/master.yml")
+    val rules = FileUtils.getTextFromResource(rulesPath)
     ExtractorEngine(rules, actions, actions.cleanupAction)
   }
 
   def mkExtractor(actions: NumericActions, ruleDir: File): ExtractorEngine = {
-    // Some code here is copied from RuleReader.scala.
-    val filepath = "org/clulab/numeric/master.yml"
-    val f = new File(ruleDir, filepath)
-    val rules = FileUtils.getTextFromFile(f)
+    val ruleFile = new File(ruleDir, rulesPath.drop(1)) // copied from RuleReader.scala
+    val rules = FileUtils.getTextFromFile(ruleFile)
 
     ExtractorEngine(rules, actions, actions.cleanupAction, ruleDir = Some(ruleDir))
   }

--- a/main/src/main/scala/org/clulab/numeric/NumericEntityRecognizer.scala
+++ b/main/src/main/scala/org/clulab/numeric/NumericEntityRecognizer.scala
@@ -1,5 +1,6 @@
 package org.clulab.numeric
 
+import org.apache.commons.io.FileUtils.readFileToString
 import org.clulab.numeric.actions.NumericActions
 import org.clulab.odin.{ExtractorEngine, Mention}
 import org.clulab.processors.Document
@@ -7,13 +8,15 @@ import org.clulab.sequences.LexiconNER
 import org.clulab.struct.TrueEntityValidator
 import org.clulab.utils.FileUtils
 
+import java.io.File
+import java.nio.charset.StandardCharsets
 import scala.collection.mutable.ArrayBuffer
 
 class NumericEntityRecognizer protected (val lexiconNer: LexiconNER, val actions: NumericActions,
     val extractor: ExtractorEngine) {
 
-  def reloaded(path: String): NumericEntityRecognizer = {
-    val extractorEngine = NumericEntityRecognizer.mkExtractor(actions, path) // Update just this part.
+  def reloaded(ruleDir: File): NumericEntityRecognizer = {
+    val extractorEngine = NumericEntityRecognizer.mkExtractor(actions, ruleDir) // Update just this part.
     new NumericEntityRecognizer(lexiconNer, actions, extractorEngine)
   }
 
@@ -79,9 +82,13 @@ object NumericEntityRecognizer {
     ExtractorEngine(rules, actions, actions.cleanupAction)
   }
 
-  def mkExtractor(actions: NumericActions, path: String): ExtractorEngine = {
-    val rules = FileUtils.getTextFromFile(path)
-    ExtractorEngine(rules, actions, actions.cleanupAction)
+  def mkExtractor(actions: NumericActions, ruleDir: File): ExtractorEngine = {
+    // Some code here is copied from RuleReader.scala.
+    val filepath = "org/clulab/numeric/master.yml"
+    val f = new File(ruleDir, filepath)
+    val rules = FileUtils.getTextFromFile(f)
+
+    ExtractorEngine(rules, actions, actions.cleanupAction, ruleDir = Some(ruleDir))
   }
 
   def apply(): NumericEntityRecognizer = {

--- a/main/src/main/scala/org/clulab/numeric/NumericEntityRecognizerShell.scala
+++ b/main/src/main/scala/org/clulab/numeric/NumericEntityRecognizerShell.scala
@@ -17,7 +17,7 @@ class ReloadableNumericProcessor(ruleDirOpt: Option[String]) extends ReloadableP
         .numericEntityRecognizer
         .reloaded(new File(ruleDirOpt.get))
 
-    processorOpt = Some(cluProcessor.reloaded(numericEntityRecognizer))
+    processorOpt = Some(cluProcessor.copy(numericEntityRecognizerOptOpt = Some(Some(numericEntityRecognizer))))
   }
 }
 

--- a/main/src/main/scala/org/clulab/numeric/NumericEntityRecognizerShell.scala
+++ b/main/src/main/scala/org/clulab/numeric/NumericEntityRecognizerShell.scala
@@ -2,30 +2,48 @@ package org.clulab.numeric
 
 import org.clulab.dynet.Utils
 import org.clulab.processors.clu.CluProcessor
-import org.clulab.utils.ReloadableProcessor
 import org.clulab.utils.ReloadableShell
 
-class NumericEntityRecognizerShell extends ReloadableShell {
+class ReloadableNer(protected var ner: NumericEntityRecognizer) {
+
+  def get: NumericEntityRecognizer = ner
+
+  def reload(path: String): Unit = ner = ner.reloaded(path)
+}
+
+class NumericEntityRecognizerShell(pathOpt: Option[String]) extends ReloadableShell {
   Utils.initializeDyNet()
 
-  val proc = new ReloadableProcessor(() => new CluProcessor(), true)
-  val ner = new NumericEntityRecognizer()
+  val proc = new CluProcessor()
+  var ner = new ReloadableNer(NumericEntityRecognizer())
 
   /** The actual work, including printing out the output */
   def work(text: String): Unit = {
-    val doc = proc.get.annotate(text)
-    val mentions = ner.extractFrom(doc)
+    val doc = proc.annotate(text)
+    val mentions = ner.get.extractFrom(doc)
 
     setLabelsAndNorms(doc, mentions)
     displayMentions(mentions, doc)
   }
 
   def reload(): Unit = {
-    println("The processor is reloading...")
-    proc.reload()
+    if (pathOpt.isDefined) {
+      println("The numeric entity recognizer is reloading...")
+      try {
+        ner.reload(pathOpt.get)
+      }
+      catch {
+        case throwable: Throwable =>
+          println(s"Rules could not be reloaded from ${pathOpt.get}!")
+          throwable.printStackTrace
+      }
+    }
+    else
+      println("No file was specified, possibly on the command line, from which to read rules!")
   }
 }
 
 object NumericEntityRecognizerShell extends App {
-  new NumericEntityRecognizerShell().shell()
+  // args(0) can optionally be a path from which to reload rules.
+  new NumericEntityRecognizerShell(args.lift(0)).shell()
 }

--- a/main/src/main/scala/org/clulab/numeric/NumericEntityRecognizerShell.scala
+++ b/main/src/main/scala/org/clulab/numeric/NumericEntityRecognizerShell.scala
@@ -2,26 +2,30 @@ package org.clulab.numeric
 
 import org.clulab.dynet.Utils
 import org.clulab.processors.clu.CluProcessor
-import org.clulab.utils.Shell
+import org.clulab.utils.ReloadableProcessor
+import org.clulab.utils.ReloadableShell
 
-class NumericEntityRecognizerShell extends Shell {
-  val proc = new CluProcessor()
+class NumericEntityRecognizerShell extends ReloadableShell {
+  Utils.initializeDyNet()
+
+  val proc = new ReloadableProcessor(() => new CluProcessor(), true)
   val ner = new NumericEntityRecognizer()
 
   /** The actual work, including printing out the output */
-  override def work(text: String): Unit = {
-    val doc = proc.annotate(text)
-
+  def work(text: String): Unit = {
+    val doc = proc.get.annotate(text)
     val mentions = ner.extractFrom(doc)
 
     setLabelsAndNorms(doc, mentions)
-
     displayMentions(mentions, doc)
+  }
+
+  def reload(): Unit = {
+    println("The processor is reloading...")
+    proc.reload()
   }
 }
 
 object NumericEntityRecognizerShell extends App {
-  Utils.initializeDyNet()
-  val sh = new NumericEntityRecognizerShell()
-  sh.shell()
+  new NumericEntityRecognizerShell().shell()
 }

--- a/main/src/main/scala/org/clulab/numeric/NumericEntityRecognizerShell.scala
+++ b/main/src/main/scala/org/clulab/numeric/NumericEntityRecognizerShell.scala
@@ -48,7 +48,7 @@ class NumericEntityRecognizerShell(ruleDirOpt: Option[String]) extends Reloadabl
       }
     }
     else
-      println("No directory was specified, possibly on the command line, from which to read rules!")
+      println("No directory was specified, possibly on the command line, from which to reload rules!")
   }
 }
 

--- a/main/src/main/scala/org/clulab/odin/ExtractorEngine.scala
+++ b/main/src/main/scala/org/clulab/odin/ExtractorEngine.scala
@@ -76,16 +76,16 @@ object ExtractorEngine {
    *  @param globalAction an action that will be applied to the extracted
    *                      mentions at the end of each iteration
    *  @param charset encoding to use for reading files
-   *  @param path path to use if rules should be loaded from filesystem
+   *  @param ruleDir base directory to use if rules should be loaded from filesystem
    */
   def apply(
       rules: String,
       actions: Actions = new Actions,
       globalAction: odin.Action = identityAction,
       charset: Charset = UTF_8,
-      path: Option[File] = None
+      ruleDir: Option[File] = None
   ): ExtractorEngine = {
-    val reader = new RuleReader(actions, charset, path)
+    val reader = new RuleReader(actions, charset, ruleDir)
     val extractors = reader.read(rules)
     new ExtractorEngine(extractors, globalAction)
   }

--- a/main/src/main/scala/org/clulab/odin/impl/RuleReader.scala
+++ b/main/src/main/scala/org/clulab/odin/impl/RuleReader.scala
@@ -20,7 +20,7 @@ import org.clulab.utils.Closer._
 
 
 
-class RuleReader(val actions: Actions, val charset: Charset, val rulepath: Option[File] = None) {
+class RuleReader(val actions: Actions, val charset: Charset, val ruleDir: Option[File] = None) {
 
   import RuleReader._
 
@@ -246,7 +246,7 @@ class RuleReader(val actions: Actions, val charset: Charset, val rulepath: Optio
     * @return
     */
   def readFileOrResource(s: String): String = {
-    rulepath match {
+    ruleDir match {
       case Some(path) =>
         val filepath = if (s.startsWith("/")) s.drop(1) else s
         val f = new File(path, filepath)

--- a/main/src/main/scala/org/clulab/processors/Processor.scala
+++ b/main/src/main/scala/org/clulab/processors/Processor.scala
@@ -100,6 +100,15 @@ trait Processor {
     doc.clear()
     doc
   }
+
+  /**
+    * Make the quickest possible copy of this processor with anything that might have
+    * changed on disk or in the environment updated in the returned processor.  The
+    * current processor should be left unchanged.  Most processors have nothing to
+    * update, so the default implementation is to return the original.
+    */
+  // This is not yet used.
+  // def reloaded: Processor = this
 }
 
 

--- a/main/src/main/scala/org/clulab/processors/Processor.scala
+++ b/main/src/main/scala/org/clulab/processors/Processor.scala
@@ -100,17 +100,7 @@ trait Processor {
     doc.clear()
     doc
   }
-
-  /**
-    * Make the quickest possible copy of this processor with anything that might have
-    * changed on disk or in the environment updated in the returned processor.  The
-    * current processor should be left unchanged.  Most processors have nothing to
-    * update, so the default implementation is to return the original.
-    */
-  // This is not yet used.
-  // def reloaded: Processor = this
 }
-
 
 object Processor {
   /**

--- a/main/src/main/scala/org/clulab/processors/clu/CluProcessor.scala
+++ b/main/src/main/scala/org/clulab/processors/clu/CluProcessor.scala
@@ -66,7 +66,7 @@ class CluProcessor (val config: Config = ConfigFactory.load("cluprocessor"),
   }
 
   // recognizes numeric entities using Odin rules
-  lazy val numericEntityRecognizer = new NumericEntityRecognizer
+  lazy val numericEntityRecognizer = NumericEntityRecognizer()
 
   // one of the multi-task learning (MTL) models, which covers: SRL (arguments)
   lazy val mtlSrla: Metal = getArgString(s"$prefix.language", Some("EN")) match {

--- a/main/src/main/scala/org/clulab/processors/clu/CluProcessor.scala
+++ b/main/src/main/scala/org/clulab/processors/clu/CluProcessor.scala
@@ -42,22 +42,37 @@ class CluProcessor protected (
     optionalNER: Option[LexiconNER] = None
   ) = this(config, optionalNER, None, None, None, None, None, None, None, None)
 
-  override def getConf: Config = config
-
-  def reloaded(numericEntityRecognier: NumericEntityRecognizer): CluProcessor = {
+  // The strategy here is to use Some(value) to indicate that the copied CluProcessor
+  // should use the provided value when the copy is made.  Use None to reuse the value
+  // in the current CluProcessor.  Since everything defaults to None, default behavior
+  // results in a copy of the original with nothing replaced.
+  def copy(
+    configOpt: Option[Config] = None,
+    optionalNEROpt: Option[Option[LexiconNER]] = None,
+    numericEntityRecognizerOptOpt: Option[Option[NumericEntityRecognizer]] = None,
+    internStringsOptOpt: Option[Option[Boolean]] = None,
+    localTokenizerOptOpt: Option[Option[Tokenizer]] = None,
+    lemmatizerOptOpt: Option[Option[Lemmatizer]] = None,
+    mtlPosChunkSrlpOptOpt: Option[Option[Metal]] = None,
+    mtlNerOptOpt: Option[Option[Metal]] = None,
+    mtlSrlaOptOpt: Option[Option[Metal]] = None,
+    mtlDepsOptOpt: Option[Option[Metal]] = None
+  ): CluProcessor = {
     new CluProcessor(
-      config,
-      optionalNER,
-      Some(numericEntityRecognizer), // This is the only one that is really reloaded then.
-      Some(internStrings),
-      Some(localTokenizer),
-      Some(lemmatizer),
-      Some(mtlPosChunkSrlp),
-      Some(mtlNer),
-      Some(mtlSrla),
-      Some(mtlDeps)
+      configOpt.getOrElse(this.config),
+      optionalNEROpt.getOrElse(this.optionalNER),
+      numericEntityRecognizerOptOpt.getOrElse(this.numericEntityRecognizerOpt),
+      internStringsOptOpt.getOrElse(this.internStringsOpt),
+      localTokenizerOptOpt.getOrElse(this.localTokenizerOpt),
+      lemmatizerOptOpt.getOrElse(this.lemmatizerOpt),
+      mtlPosChunkSrlpOptOpt.getOrElse(this.mtlPosChunkSrlpOpt),
+      mtlNerOptOpt.getOrElse(this.mtlNerOpt),
+      mtlSrlaOptOpt.getOrElse(this.mtlSrlaOpt),
+      mtlDepsOptOpt.getOrElse(this.mtlDepsOpt)
     )
   }
+
+  override def getConf: Config = config
 
   // should we intern strings or not?
   val internStrings:Boolean = internStringsOpt.getOrElse(

--- a/main/src/main/scala/org/clulab/processors/clu/CluProcessor.scala
+++ b/main/src/main/scala/org/clulab/processors/clu/CluProcessor.scala
@@ -22,57 +22,102 @@ import org.clulab.utils.BeforeAndAfter
   *   lemmatization (Morpha, copied in our repo to minimize dependencies),
   *   POS tagging, NER, chunking, dependency parsing - using our MTL architecture (dep parsing coming soon)
   */
-class CluProcessor (val config: Config = ConfigFactory.load("cluprocessor"),
-                    val optionalNER: Option[LexiconNER] = None) extends Processor with Configured {
+// This protected constructor is used especially for reloading.
+class CluProcessor protected (
+  val config: Config,
+  val optionalNER: Option[LexiconNER],
+  numericEntityRecognizerOpt: Option[NumericEntityRecognizer],
+  internStringsOpt: Option[Boolean],
+  localTokenizerOpt: Option[Tokenizer],
+  lemmatizerOpt: Option[Lemmatizer],
+  mtlPosChunkSrlpOpt: Option[Metal],
+  mtlNerOpt: Option[Metal],
+  mtlSrlaOpt: Option[Metal],
+  mtlDepsOpt: Option[Metal]
+) extends Processor with Configured {
+
+  // standard, abbreviated constructor
+  def this(
+    config: Config = ConfigFactory.load("cluprocessor"),
+    optionalNER: Option[LexiconNER] = None
+  ) = this(config, optionalNER, None, None, None, None, None, None, None, None)
 
   override def getConf: Config = config
 
+  def reloaded(numericEntityRecognier: NumericEntityRecognizer): CluProcessor = {
+    new CluProcessor(
+      config,
+      optionalNER,
+      Some(numericEntityRecognizer), // This is the only one that is really reloaded then.
+      Some(internStrings),
+      Some(localTokenizer),
+      Some(lemmatizer),
+      Some(mtlPosChunkSrlp),
+      Some(mtlNer),
+      Some(mtlSrla),
+      Some(mtlDeps)
+    )
+  }
+
   // should we intern strings or not?
-  val internStrings:Boolean = getArgBoolean(s"$prefix.internStrings", Some(false))
+  val internStrings:Boolean = internStringsOpt.getOrElse(
+    getArgBoolean(s"$prefix.internStrings", Some(false))
+  )
 
   // This strange construction is designed to allow subclasses access to the value of the tokenizer while
   // at the same time allowing them to override the value.
   // val tokenizer: Tokenizer = new ModifiedTokenizer(super.tokenizer)
   // does not work in a subclass because super.tokenizer is invalid.  Instead it needs to be something like
   // val tokenizer: Tokenizer = new ModifiedTokenizer(localTokenizer)
-  protected lazy val localTokenizer: Tokenizer = getArgString(s"$prefix.language", Some("EN")) match {
-    case "PT" => new OpenDomainPortugueseTokenizer
-    case "ES" => new OpenDomainSpanishTokenizer
-    case _ => new OpenDomainEnglishTokenizer
+  protected lazy val localTokenizer: Tokenizer = localTokenizerOpt.getOrElse {
+    getArgString(s"$prefix.language", Some("EN")) match {
+      case "PT" => new OpenDomainPortugueseTokenizer
+      case "ES" => new OpenDomainSpanishTokenizer
+      case _ => new OpenDomainEnglishTokenizer
+    }
   }
 
   // the actual tokenizer
   lazy val tokenizer: Tokenizer = localTokenizer
 
   // the lemmatizer
-  lazy val lemmatizer: Lemmatizer = getArgString(s"$prefix.language", Some("EN")) match {
-    case "PT" => new PortugueseLemmatizer
-    case "ES" => new SpanishLemmatizer
-    case _ => new EnglishLemmatizer
+  lazy val lemmatizer: Lemmatizer = lemmatizerOpt.getOrElse {
+    getArgString(s"$prefix.language", Some("EN")) match {
+      case "PT" => new PortugueseLemmatizer
+      case "ES" => new SpanishLemmatizer
+      case _ => new EnglishLemmatizer
+    }
   }
 
   // one of the multi-task learning (MTL) models, which covers: POS, chunking, and SRL (predicates)
-  lazy val mtlPosChunkSrlp: Metal = getArgString(s"$prefix.language", Some("EN")) match {
-    case "PT" => throw new RuntimeException("PT model not trained yet") // Add PT
-    case "ES" => throw new RuntimeException("ES model not trained yet") // Add ES
-    case _ => Metal(getArgString(s"$prefix.mtl-pos-chunk-srlp", Some("mtl-en-pos-chunk-srlp")))
+  lazy val mtlPosChunkSrlp: Metal = mtlPosChunkSrlpOpt.getOrElse {
+    getArgString(s"$prefix.language", Some("EN")) match {
+      case "PT" => throw new RuntimeException("PT model not trained yet") // Add PT
+      case "ES" => throw new RuntimeException("ES model not trained yet") // Add ES
+      case _ => Metal(getArgString(s"$prefix.mtl-pos-chunk-srlp", Some("mtl-en-pos-chunk-srlp")))
+    }
   }
 
   // one of the multi-task learning (MTL) models, which covers: NER
-  lazy val mtlNer: Metal = getArgString(s"$prefix.language", Some("EN")) match {
-    case "PT" => throw new RuntimeException("PT model not trained yet") // Add PT
-    case "ES" => throw new RuntimeException("ES model not trained yet") // Add ES
-    case _ => Metal(getArgString(s"$prefix.mtl-ner", Some("mtl-en-ner")))
+  lazy val mtlNer: Metal = mtlNerOpt.getOrElse {
+    getArgString(s"$prefix.language", Some("EN")) match {
+      case "PT" => throw new RuntimeException("PT model not trained yet") // Add PT
+      case "ES" => throw new RuntimeException("ES model not trained yet") // Add ES
+      case _ => Metal(getArgString(s"$prefix.mtl-ner", Some("mtl-en-ner")))
+    }
   }
 
   // recognizes numeric entities using Odin rules
-  lazy val numericEntityRecognizer = NumericEntityRecognizer()
+  lazy val numericEntityRecognizer: NumericEntityRecognizer =
+      numericEntityRecognizerOpt.getOrElse(NumericEntityRecognizer())
 
   // one of the multi-task learning (MTL) models, which covers: SRL (arguments)
-  lazy val mtlSrla: Metal = getArgString(s"$prefix.language", Some("EN")) match {
-    case "PT" => throw new RuntimeException("PT model not trained yet") // Add PT
-    case "ES" => throw new RuntimeException("ES model not trained yet") // Add ES
-    case _ => Metal(getArgString(s"$prefix.mtl-srla", Some("mtl-en-srla")))
+  lazy val mtlSrla: Metal = mtlSrlaOpt.getOrElse {
+    getArgString(s"$prefix.language", Some("EN")) match {
+      case "PT" => throw new RuntimeException("PT model not trained yet") // Add PT
+      case "ES" => throw new RuntimeException("ES model not trained yet") // Add ES
+      case _ => Metal(getArgString(s"$prefix.mtl-srla", Some("mtl-en-srla")))
+    }
   }
 
   /*
@@ -88,10 +133,12 @@ class CluProcessor (val config: Config = ConfigFactory.load("cluprocessor"),
     case _ => Metal(getArgString(s"$prefix.mtl-depsl", Some("mtl-en-depsl")))
   }
   */
-  lazy val mtlDeps: Metal = getArgString(s"$prefix.language", Some("EN")) match {
-    case "PT" => throw new RuntimeException("PT model not trained yet") // Add PT
-    case "ES" => throw new RuntimeException("ES model not trained yet") // Add ES
-    case _ => Metal(getArgString(s"$prefix.mtl-deps", Some("mtl-en-deps")))
+  lazy val mtlDeps: Metal = mtlDepsOpt.getOrElse {
+    getArgString(s"$prefix.language", Some("EN")) match {
+      case "PT" => throw new RuntimeException("PT model not trained yet") // Add PT
+      case "ES" => throw new RuntimeException("ES model not trained yet") // Add ES
+      case _ => Metal(getArgString(s"$prefix.mtl-deps", Some("mtl-en-deps")))
+    }
   }
 
   // Although this uses no class members, the method is sometimes called from tests
@@ -172,27 +219,23 @@ class CluProcessor (val config: Config = ConfigFactory.load("cluprocessor"),
     val allLabels = mtlNer.predictJointly(AnnotatedSentence(words), embeddings)
 
     // NER labels from the custom NER
-    val optionalNERLabels: Option[Array[String]] = {
-      if(optionalNER.isEmpty) {
-        None
-      } else {
-        val sentence = Sentence(
-          words,
-          startCharOffsets,
-          endCharOffsets,
-          words,
-          Some(tags),
-          lemmas = lemmas,
-          entities = None,
-          norms = None,
-          chunks = None,
-          tree = None,
-          deps = EMPTY_GRAPH,
-          relations = None
-        )
+    val optionalNERLabels: Option[Array[String]] = optionalNER.map { ner =>
+      val sentence = Sentence(
+        words,
+        startCharOffsets,
+        endCharOffsets,
+        words,
+        Some(tags),
+        lemmas = lemmas,
+        entities = None,
+        norms = None,
+        chunks = None,
+        tree = None,
+        deps = EMPTY_GRAPH,
+        relations = None
+      )
 
-        Some(optionalNER.get.find(sentence))
-      }
+      ner.find(sentence)
     }
 
     if(optionalNERLabels.isEmpty) {
@@ -367,7 +410,7 @@ class CluProcessor (val config: Config = ConfigFactory.load("cluprocessor"),
     doc.getAttachment(CONST_EMBEDDINGS_ATTACHMENT_NAME).get.asInstanceOf[EmbeddingsAttachment].embeddings
 
   /** Part of speech tagging + chunking + SRL (predicates), jointly */
-  override def tagPartsOfSpeech(doc:Document) {
+  override def tagPartsOfSpeech(doc:Document): Unit = {
     basicSanityCheck(doc)
 
     val embeddings = getEmbeddings(doc)
@@ -400,7 +443,7 @@ class CluProcessor (val config: Config = ConfigFactory.load("cluprocessor"),
   }
 
   /** Lematization; modifies the document in place */
-  override def lemmatize(doc:Document) {
+  override def lemmatize(doc:Document): Unit = {
     basicSanityCheck(doc)
     for(sent <- doc.sentences) {
       //println(s"Lemmatize sentence: ${sent.words.mkString(", ")}")
@@ -419,7 +462,7 @@ class CluProcessor (val config: Config = ConfigFactory.load("cluprocessor"),
   }
 
   /** Generates cheap lemmas with the word in lower case, for languages where a lemmatizer is not available */
-  def cheapLemmatize(doc:Document) {
+  def cheapLemmatize(doc:Document): Unit = {
     basicSanityCheck(doc)
     for(sent <- doc.sentences) {
       val lemmas = sent.words.map(_.toLowerCase())
@@ -571,12 +614,12 @@ class CluProcessor (val config: Config = ConfigFactory.load("cluprocessor"),
   }
 
   /** Coreference resolution; modifies the document in place */
-  def resolveCoreference(doc:Document) {
+  def resolveCoreference(doc:Document): Unit = {
     // TODO. Implement me
   }
 
   /** Discourse parsing; modifies the document in place */
-  def discourse(doc:Document) {
+  def discourse(doc:Document): Unit = {
     // TODO. Implement me
   }
 
@@ -597,7 +640,7 @@ class CluProcessor (val config: Config = ConfigFactory.load("cluprocessor"),
 }
 
 trait SentencePostProcessor {
-  def process(sentence: Sentence)
+  def process(sentence: Sentence): Unit
 }
 
 /** CluProcessor for Spanish */
@@ -618,7 +661,7 @@ class PortugueseCluProcessor extends CluProcessor(config = ConfigFactory.load("c
   }
 
   /** Lematization; modifies the document in place */
-  override def lemmatize(doc:Document) {
+  override def lemmatize(doc:Document): Unit = {
     basicSanityCheck(doc)
     for(sent <- doc.sentences) {
       // check if sentence tags were defined

--- a/main/src/main/scala/org/clulab/processors/clu/CluShell.scala
+++ b/main/src/main/scala/org/clulab/processors/clu/CluShell.scala
@@ -2,7 +2,6 @@ package org.clulab.processors.clu
 
 import org.clulab.dynet.Utils
 import org.clulab.utils.ReloadableProcessor
-import org.clulab.utils.ReloadableShell
 import org.clulab.utils.Shell
 
 import java.io.PrintWriter
@@ -12,7 +11,7 @@ import java.io.PrintWriter
   * User: mihais
   * Date: 8/2/17
   */
-class CluShell extends ReloadableShell {
+class CluShell extends Shell {
   Utils.initializeDyNet()
 
   val printWriter = new PrintWriter(System.out, true)
@@ -23,6 +22,7 @@ class CluShell extends ReloadableShell {
     doc.prettyPrint(printWriter)
   }
 
+  // We inherit now just from Shell, so no reloading is performed.
   def reload(): Unit = {
     println("The processor is reloading...")
     proc.reload()

--- a/main/src/main/scala/org/clulab/processors/clu/CluShell.scala
+++ b/main/src/main/scala/org/clulab/processors/clu/CluShell.scala
@@ -1,6 +1,8 @@
 package org.clulab.processors.clu
 
 import org.clulab.dynet.Utils
+import org.clulab.utils.ReloadableProcessor
+import org.clulab.utils.ReloadableShell
 import org.clulab.utils.Shell
 
 import java.io.PrintWriter
@@ -10,20 +12,25 @@ import java.io.PrintWriter
   * User: mihais
   * Date: 8/2/17
   */
-class CluShell extends Shell {
-  val printWriter = new PrintWriter(System.out, true)
-  val proc: CluProcessor = new CluProcessor()
+class CluShell extends ReloadableShell {
+  Utils.initializeDyNet()
 
-  override def work(text: String): Unit = {
-    val doc = proc.annotate(text)
+  val printWriter = new PrintWriter(System.out, true)
+  val proc = new ReloadableProcessor(() => new CluProcessor(), true)
+
+  def work(text: String): Unit = {
+    val doc = proc.get.annotate(text)
     doc.prettyPrint(printWriter)
+  }
+
+  def reload(): Unit = {
+    println("The processor is reloading...")
+    proc.reload()
   }
 }
 
 object CluShell {
   def main(args: Array[String]): Unit = {
-    Utils.initializeDyNet()
-    val sh = new CluShell
-    sh.shell()
+    new CluShell().shell()
   }
 }

--- a/main/src/main/scala/org/clulab/sequences/LexiconNERBuilder.scala
+++ b/main/src/main/scala/org/clulab/sequences/LexiconNERBuilder.scala
@@ -6,22 +6,17 @@
 package org.clulab.sequences
 
 import java.util.function.Consumer
-
 import org.clulab.struct.BooleanHashTrie
 import org.clulab.struct.DebugBooleanHashTrie
 import org.clulab.struct.EntityValidator
 import org.clulab.struct.IntHashTrie
-import org.clulab.utils.Files.loadStreamFromClasspath
+import org.clulab.utils.Files
 import org.clulab.utils.Serializer
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
-import scala.collection.mutable.{
-  HashMap => MutableHashMap,
-  HashSet => MutableHashSet,
-  Map => MutableMap,
-  Set => MutableSet
-}
+import java.io.File
+import scala.collection.mutable.{HashMap => MutableHashMap, HashSet => MutableHashSet, Map => MutableMap, Set => MutableSet}
 import scala.collection.mutable.ArrayBuffer
 
 /**
@@ -77,8 +72,16 @@ trait KbSource {
 
 abstract class StandardKbSource(caseInsensitiveMatching: Boolean) extends KbSource {
   def getLabel: String
-  def getCaseInsensitiveMatching: Boolean
   def withTokens(f: Array[String] => Unit): Unit
+
+  def getLabel(resourceName: String): String = {
+    val slash = resourceName.lastIndexOf("/")
+    val dot = resourceName.indexOf('.')
+    val label = resourceName.substring(slash + 1, dot)
+    label
+  }
+
+  def getCaseInsensitiveMatching: Boolean = caseInsensitiveMatching
 
   protected def processLine(line: String, f: Array[String] => Unit): Unit = {
     val trimmedLine = removeCommentsAndTrim(line)
@@ -100,7 +103,7 @@ trait ResourceKbSource {
   }
 
   def consume(resourceName: String, consumer: Consumer[String]): Unit = {
-    Serializer.using(loadStreamFromClasspath(resourceName)) { bufferedReader =>
+    Serializer.using(Files.loadStreamFromClasspath(resourceName)) { bufferedReader =>
       bufferedReader.lines.forEach(consumer)
     }
   }
@@ -117,14 +120,7 @@ trait ResourceKbSource {
 class ResourceStandardKbSource(resourceName: String, caseInsensitiveMatching: Boolean)
     extends StandardKbSource(caseInsensitiveMatching) with ResourceKbSource {
 
-  def getLabel: String = {
-    val slash = resourceName.lastIndexOf("/")
-    val dot = resourceName.indexOf('.')
-    val label = resourceName.substring(slash + 1, dot)
-    label
-  }
-
-  def getCaseInsensitiveMatching: Boolean = caseInsensitiveMatching
+  def getLabel: String = getLabel(resourceName)
 
   def withTokens(f: Array[String] => Unit): Unit = {
     consume(resourceName, mkConsumer { line: String => processLine(line, f) })
@@ -133,12 +129,49 @@ class ResourceStandardKbSource(resourceName: String, caseInsensitiveMatching: Bo
   def getLines: Iterable[String] = getLines(resourceName)
 }
 
+trait FileKbSource {
+
+  def mkConsumer(f: String => Unit): Consumer[String] = {
+    new Consumer[String]() {
+      def accept(line: String): Unit = {
+        f(line)
+      }
+    }
+  }
+
+  def consume(resourceName: String, baseDir: File, consumer: Consumer[String]): Unit = {
+    val file = new File(baseDir, if (resourceName.startsWith("/")) resourceName.drop(1) else resourceName)
+
+    Serializer.using(Files.loadFile(file)) { bufferedReader =>
+      bufferedReader.lines.forEach(consumer)
+    }
+  }
+
+  // This is for testing and only for short files.
+  def getLines(resourceName: String, baseDir: File): Iterable[String] = {
+    var lines: List[String] = Nil
+
+    consume(resourceName, baseDir, mkConsumer { line: String => lines = line :: lines } )
+    lines.reverse
+  }
+}
+
+class FileStandardKbSource(resourceName: String, caseInsensitiveMatching: Boolean, baseDir: File)
+    extends StandardKbSource(caseInsensitiveMatching) with FileKbSource {
+
+  def getLabel: String = getLabel(resourceName)
+
+  def withTokens(f: Array[String] => Unit): Unit = {
+    consume(resourceName, baseDir, mkConsumer { line: String => processLine(line, f) })
+  }
+
+  def getLines: Iterable[String] = getLines(resourceName, baseDir)
+}
+
 class MemoryStandardKbSource(label: String, lines: Iterable[String], caseInsensitiveMatching: Boolean) extends
     StandardKbSource(caseInsensitiveMatching) {
 
   def getLabel: String = label
-
-  def getCaseInsensitiveMatching: Boolean = caseInsensitiveMatching
 
   def withTokens(f: Array[String] => Unit): Unit = {
     lines.foreach { line =>
@@ -174,6 +207,15 @@ class ResourceOverrideKbSource(resourceName: String) extends OverrideKbSource() 
   }
 
   def getLines: Iterable[String] = getLines(resourceName)
+}
+
+class FileOverrideKbSource(resourceName: String, baseDir: File) extends OverrideKbSource() with FileKbSource {
+
+  def withLabelAndTokens(f: (String, Array[String]) => Unit): Unit = {
+    consume(resourceName, baseDir, mkConsumer { line: String => processLine(line, f) })
+  }
+
+  def getLines: Iterable[String] = getLines(resourceName, baseDir)
 }
 
 class MemoryOverrideKbSource(lines: Iterable[String]) extends OverrideKbSource() {

--- a/main/src/main/scala/org/clulab/sequences/LexiconNERShell.scala
+++ b/main/src/main/scala/org/clulab/sequences/LexiconNERShell.scala
@@ -2,17 +2,23 @@ package org.clulab.sequences
 
 import org.clulab.dynet.Utils
 import org.clulab.processors.clu.CluProcessor
-import org.clulab.utils.Shell
+import org.clulab.utils.ReloadableProcessor
+import org.clulab.utils.ReloadableShell
 
-class LexiconNERShell(val lexiconNer: LexiconNER) extends Shell {
-  val proc: CluProcessor = new CluProcessor()
+class LexiconNERShell(val lexiconNer: LexiconNER) extends ReloadableShell {
+  val proc = new ReloadableProcessor(() => new CluProcessor(), true)
 
   override def work(text: String): Unit = {
-    val doc = proc.mkDocument(text)
+    val doc = proc.get.mkDocument(text)
     for (sent <- doc.sentences) {
       val labels = lexiconNer.find(sent)
       println(labels.mkString(", "))
     }
+  }
+
+  override def reload(): Unit = {
+    println("The processor is reloading...")
+    proc.reload()
   }
 }
 

--- a/main/src/main/scala/org/clulab/sequences/LexiconNERShell.scala
+++ b/main/src/main/scala/org/clulab/sequences/LexiconNERShell.scala
@@ -3,9 +3,9 @@ package org.clulab.sequences
 import org.clulab.dynet.Utils
 import org.clulab.processors.clu.CluProcessor
 import org.clulab.utils.ReloadableProcessor
-import org.clulab.utils.ReloadableShell
+import org.clulab.utils.Shell
 
-class LexiconNERShell(val lexiconNer: LexiconNER) extends ReloadableShell {
+class LexiconNERShell(val lexiconNer: LexiconNER) extends Shell {
   val proc = new ReloadableProcessor(() => new CluProcessor(), true)
 
   override def work(text: String): Unit = {
@@ -16,7 +16,9 @@ class LexiconNERShell(val lexiconNer: LexiconNER) extends ReloadableShell {
     }
   }
 
-  override def reload(): Unit = {
+
+  // We inherit now just from Shell, so no reloading is performed.
+  def reload(): Unit = {
     println("The processor is reloading...")
     proc.reload()
   }

--- a/main/src/main/scala/org/clulab/utils/Menu.scala
+++ b/main/src/main/scala/org/clulab/utils/Menu.scala
@@ -65,6 +65,8 @@ class Menu(greeting: String, lineReader: LineReader, mainMenuItems: Seq[MainMenu
   val maxKeyLength: Int = mainMenuItems.foldLeft(0) { (maxKeyLength: Int, mainMenuItem: MainMenuItem) => Math.max(maxKeyLength, mainMenuItem.key.length) }
   val indent: String = "    "
 
+  def withGreeting(greeting: String): Menu = new Menu(greeting, lineReader, mainMenuItems, defaultMenuItem)
+
   def printCommands(): Unit = {
     println("COMMANDS:")
     mainMenuItems.foreach { mainMenuItem =>
@@ -73,14 +75,25 @@ class Menu(greeting: String, lineReader: LineReader, mainMenuItems: Seq[MainMenu
     }
   }
 
+  def printEmpty(): Unit = {
+    println("Enter a command or some text to process.")
+    println()
+    printCommands()
+  }
+
   def processMenu: Boolean = {
     println()
     lineReader.readLineOpt().map { line =>
       println()
-      mainMenuItems
-          .find(_.key == line)
-          .map(_.command(this, line))
-          .getOrElse(defaultMenuItem.command(this, line))
+      if (line.trim.isEmpty) {
+        printEmpty()
+        true
+      }
+      else
+        mainMenuItems
+            .find(_.key == line)
+            .map(_.command(this, line))
+            .getOrElse(defaultMenuItem.command(this, line))
     }.getOrElse(MenuItem.eofCommand(this, ""))
   }
 

--- a/main/src/main/scala/org/clulab/utils/ReloadableProcessor.scala
+++ b/main/src/main/scala/org/clulab/utils/ReloadableProcessor.scala
@@ -1,0 +1,21 @@
+package org.clulab.utils
+
+import org.clulab.processors.Processor
+
+class ReloadableProcessor(constructor: () => Processor, impatient: Boolean = false) {
+  // We would like a lazy var, but they don't exist.
+  protected var processorOpt: Option[Processor] = if (impatient) construct() else None
+
+  protected def construct(): Option[Processor] = {
+    processorOpt = Option(constructor())
+    processorOpt
+  }
+
+  def get: Processor = {
+    if (processorOpt.isEmpty)
+      construct()
+    processorOpt.get
+  }
+
+  def reload(): Unit = construct()
+}

--- a/main/src/main/scala/org/clulab/utils/Shell.scala
+++ b/main/src/main/scala/org/clulab/utils/Shell.scala
@@ -28,3 +28,21 @@ abstract class Shell {
     mkMenu().run()
   }
 }
+
+abstract class ReloadableShell extends Shell {
+  def reload(): Unit
+
+  override def mkMenu(): Menu = {
+    // This IdeReader needed for debugging in IntelliJ for Windows.
+    // val lineReader = new IdeReader("(shell)>>> ")
+    val lineReader = new CliReader("(shell)>>> ", "user.home", ".shellhistory")
+    val mainMenuItems = Seq(
+      new HelpMenuItem(":help", "show commands"),
+      new SafeMainMenuItem(":reload", "reload rules from filesystem", reload),
+      new ExitMenuItem(":exit", "exit system")
+    )
+    val defaultMenuItem = new SafeDefaultMenuItem(work)
+
+    new Menu("Welcome to the shell!", lineReader, mainMenuItems, defaultMenuItem)
+  }
+}

--- a/main/src/main/scala/org/clulab/utils/Shell.scala
+++ b/main/src/main/scala/org/clulab/utils/Shell.scala
@@ -34,8 +34,8 @@ abstract class ReloadableShell extends Shell {
 
   override def mkMenu(): Menu = {
     // This IdeReader needed for debugging in IntelliJ for Windows.
-     val lineReader = new IdeReader("(shell)>>> ")
-//    val lineReader = new CliReader("(shell)>>> ", "user.home", ".shellhistory")
+    // val lineReader = new IdeReader("(shell)>>> ")
+    val lineReader = new CliReader("(shell)>>> ", "user.home", ".shellhistory")
     val mainMenuItems = Seq(
       new HelpMenuItem(":help", "show commands"),
       new SafeMainMenuItem(":reload", "reload rules from filesystem", reload),

--- a/main/src/main/scala/org/clulab/utils/Shell.scala
+++ b/main/src/main/scala/org/clulab/utils/Shell.scala
@@ -34,8 +34,8 @@ abstract class ReloadableShell extends Shell {
 
   override def mkMenu(): Menu = {
     // This IdeReader needed for debugging in IntelliJ for Windows.
-    // val lineReader = new IdeReader("(shell)>>> ")
-    val lineReader = new CliReader("(shell)>>> ", "user.home", ".shellhistory")
+     val lineReader = new IdeReader("(shell)>>> ")
+//    val lineReader = new CliReader("(shell)>>> ", "user.home", ".shellhistory")
     val mainMenuItems = Seq(
       new HelpMenuItem(":help", "show commands"),
       new SafeMainMenuItem(":reload", "reload rules from filesystem", reload),

--- a/main/src/test/scala/org/clulab/numeric/TestNumericEntityRecognition.scala
+++ b/main/src/test/scala/org/clulab/numeric/TestNumericEntityRecognition.scala
@@ -46,7 +46,7 @@ class TestNumericEntityRecognition extends FlatSpec with Matchers {
   }
 
   Utils.initializeDyNet()
-  val ner = new NumericEntityRecognizer
+  val ner = NumericEntityRecognizer()
   val proc = new HabitusProcessor()
 
   //


### PR DESCRIPTION
Account for reloading in shell menus and reload (i.e., create new processors) when requested. 

Nothing here yet accounts for locations of files.  It is likely that the exact same rules will be used upon reload.