### PR TITLE
Added support for before/after time expressions (no seasons)

### DIFF
--- a/main/src/main/resources/org/clulab/numeric/date-ranges.yml
+++ b/main/src/main/resources/org/clulab/numeric/date-ranges.yml
@@ -76,6 +76,24 @@
   pattern: |
     /(?i)until|through/ @date1:Date
 
+- name: date-unbound-range-1
+  priority: ${rulepriority}
+  label: DateRange
+  type: token
+  example: "Before June 2020"
+  action: mkDateUnboundRangeMentionBefore
+  pattern: |
+    /(?i)(before|prior|previous)/ /(?i)to/? @date1:Date
+
+- name: date-unbound-range-2
+  priority: ${rulepriority}
+  label: DateRange
+  type: token
+  example: "After June 2020"
+  action: mkDateUnboundRangeMentionAfter
+  pattern: |
+    /(?i)(after|beyond|following)/ @date1:Date
+
 # Date range derived from a season, with mandatory year
 - name: date-range-season-1
   priority: ${ rulepriority }

--- a/main/src/main/scala/org/clulab/numeric/actions/NumericActions.scala
+++ b/main/src/main/scala/org/clulab/numeric/actions/NumericActions.scala
@@ -87,6 +87,16 @@ class NumericActions(seasonNormalizer: SeasonNormalizer) extends Actions {
     convert(mentions, toDateRangeMentionWithSeasonUntilRef(seasonNormalizer), "toDateRangeMentionWithSeasonUntilRef")
   }
 
+  /** Constructs a DateRangeMention from a token pattern */
+  def mkDateUnboundRangeMentionBefore(mentions: Seq[Mention], state: State): Seq[Mention] = {
+    convert(mentions, toDateUnboundRangeMentionBefore, "toDateUnboundRangeMentionBefore")
+  }
+
+  /** Constructs a DateRangeMention from a token pattern */
+  def mkDateUnboundRangeMentionAfter(mentions: Seq[Mention], state: State): Seq[Mention] = {
+    convert(mentions, toDateUnboundRangeMentionAfter, "toDateUnboundRangeMentionAfter")
+  }
+
   /** Constructs a DateMention from a token pattern */
   def mkDateMention(mentions: Seq[Mention], state: State): Seq[Mention] = {
     convert(mentions, toDateMention, "toDateMention")

--- a/main/src/main/scala/org/clulab/numeric/mentions/DateRangeMention.scala
+++ b/main/src/main/scala/org/clulab/numeric/mentions/DateRangeMention.scala
@@ -15,10 +15,11 @@ class DateRangeMention ( labels: Seq[String],
                          var date2Norm: String )
   extends TextBoundMention(labels, tokenInterval, sentence, document, keep, foundBy, attachments) with Norm {
 
-  // Change date1Norm if the date1Norm does not have a year value but date2Norm has a year value
+  // Change date1Norm if the date1Norm is not undefined (i.e., XXXX-XX-XX) and
+  // does not have a year value but date2Norm has a year value
   // This will handle date ranges of form month date and month date of year.
   // Ex: "Sowing dates between May 3 and October 2, 2020" will have a normalized value of 2020-05-03 -- 2020-10-02
-  if (date1Norm contains "XXXX") {
+  if (!date1Norm.equals("XXXX-XX-XX") && date1Norm.contains("XXXX")) {
     if (!(date2Norm contains "XXXX")) {
       // Keep everything from date1Norm except for the year value, which will be copied from date2Norm.
       date1Norm = date2Norm.substring(0,4) + date1Norm.substring(4)

--- a/main/src/main/scala/org/clulab/numeric/mentions/package.scala
+++ b/main/src/main/scala/org/clulab/numeric/mentions/package.scala
@@ -213,6 +213,54 @@ package object mentions {
       throw new RuntimeException(s"ERROR: cannot convert mention of type [${m.getClass.toString}] to DateRangeMention!")
   }
 
+  def toDateUnboundRangeMentionBefore(mention: Mention): DateRangeMention =  mention match {
+    case m: DateRangeMention => m
+
+    case m: RelationMention =>
+      val date1Norm = getArgNorm("date1", m)
+      if(date1Norm.isEmpty)
+        throw new RuntimeException(s"ERROR: could not find argument date1 in mention [${m.raw.mkString(" ")}]!")
+
+      new DateRangeMention(
+        m.labels,
+        m.tokenInterval,
+        m.sentence,
+        m.document,
+        m.keep,
+        m.foundBy,
+        m.attachments,
+        "XXXX-XX-XX",
+        date1Norm.get
+      )
+
+    case m =>
+      throw new RuntimeException(s"ERROR: cannot convert mention of type ${m.getClass.toString} to DateRangeMention!")
+  }
+
+  def toDateUnboundRangeMentionAfter(mention: Mention): DateRangeMention =  mention match {
+    case m: DateRangeMention => m
+
+    case m: RelationMention =>
+      val date1Norm = getArgNorm("date1", m)
+      if(date1Norm.isEmpty)
+        throw new RuntimeException(s"ERROR: could not find argument date1 in mention [${m.raw.mkString(" ")}]!")
+
+      new DateRangeMention(
+        m.labels,
+        m.tokenInterval,
+        m.sentence,
+        m.document,
+        m.keep,
+        m.foundBy,
+        m.attachments,
+        date1Norm.get,
+        "XXXX-XX-XX"
+      )
+
+    case m =>
+      throw new RuntimeException(s"ERROR: cannot convert mention of type ${m.getClass.toString} to DateRangeMention!")
+  }
+
   def toDateRangeMentionWithSeason(seasonNormalizer: SeasonNormalizer)(mention: Mention): DateRangeMention =  mention match {
     case m: DateRangeMention => m
 

--- a/main/src/test/scala/org/clulab/numeric/TestNumericEntityRecognition.scala
+++ b/main/src/test/scala/org/clulab/numeric/TestNumericEntityRecognition.scala
@@ -193,6 +193,14 @@ class TestNumericEntityRecognition extends FlatSpec with Matchers {
     ensure("January 2016 and June 2017", Interval(3, 5), "DATE", "2017-06-XX")
   }
 
+  it should "recognize unbounded dates" in {
+    ensure("before July 2016", Interval(0, 3), "DATE-RANGE", "XXXX-XX-XX -- 2016-07-XX")
+    ensure("prior to July 2016", Interval(0, 4), "DATE-RANGE", "XXXX-XX-XX -- 2016-07-XX")
+    ensure("after July 2016", Interval(0, 3), "DATE-RANGE", "2016-07-XX -- XXXX-XX-XX")
+    ensure("before July 15", Interval(0, 3), "DATE-RANGE", "XXXX-XX-XX -- XXXX-07-15")
+    ensure("after July 15", Interval(0, 3), "DATE-RANGE", "XXXX-07-15 -- XXXX-XX-XX")
+  }
+
   it should "recognize relative dates" in {
     ensure("Since January 2016", Interval(0, 3), "DATE-RANGE", "2016-01-XX -- ref-date")
     ensure("Until January 2016", Interval(0, 3), "DATE-RANGE", "ref-date -- 2016-01-XX")


### PR DESCRIPTION
This pull request adds support to recognize time expressions of unbounded date ranges. It doesn't cover seasons yet.