### PR TITLE
Add support for before/after time expression

### DIFF
--- a/main/src/main/resources/org/clulab/numeric/TimeNormEvalSet/WorldModelersDatesRangesTimex.csv
+++ b/main/src/main/resources/org/clulab/numeric/TimeNormEvalSet/WorldModelersDatesRangesTimex.csv
@@ -1,12 +1,16 @@
+CLiMIS_FAO_UNICEF_WFP_South_Sudan_IPC_Jun-16,499,510,XXXX-02-XX -- XXXX-06-XX
 CLiMIS_FAO_UNICEF_WFP_South_Sudan_IPC_Jun-16,2212,2222,2014-XX-XX -- ref-date
+CLiMIS_FAO_UNICEF_WFP_South_Sudan_IPC_Jun-16,2748,2759,XXXX-02-XX -- XXXX-06-XX
 CLiMIS_FAO_UNICEF_WFP_South_Sudan_IPC_Jun-16,2804,2808,2016-XX-XX
 CLiMIS_FAO_UNICEF_WFP_South_Sudan_IPC_Jun-16,3209,3213,2016-XX-XX
 Enhancing_Food_Security_in_South_Sudan_Nov-15,1056,1060,2011-XX-XX
 Enhancing_Food_Security_in_South_Sudan_Nov-15,1264,1268,2013-XX-XX
 Enhancing_Food_Security_in_South_Sudan_Nov-15,1485,1489,2013-XX-XX
+Enhancing_Food_Security_in_South_Sudan_Nov-15,1773,1785,XXXX-06-XX -- XXXX-10-XX
 Enhancing_Food_Security_in_South_Sudan_Nov-15,191,195,2015-XX-XX
 Enhancing_Food_Security_in_South_Sudan_Nov-15,2289,2293,2011-XX-XX
 Enhancing_Food_Security_in_South_Sudan_Nov-15,2982,2986,2013-XX-XX
+Enhancing_Food_Security_in_South_Sudan_Nov-15,3592,3604,XXXX-06-XX -- XXXX-10-XX
 Enhancing_Food_Security_in_South_Sudan_Nov-15,3617,3621,2012-XX-XX
 Enhancing_Food_Security_in_South_Sudan_Nov-15,3641,3645,2012-XX-XX
 Enhancing_Food_Security_in_South_Sudan_Nov-15,4047,4051,2015-XX-XX
@@ -15,28 +19,89 @@ Enhancing_Food_Security_in_South_Sudan_Nov-15,4270,4274,2015-XX-XX
 Enhancing_Food_Security_in_South_Sudan_Nov-15,565,569,2012-XX-XX
 Enhancing_Food_Security_in_South_Sudan_Nov-15,627,631,2014-XX-XX
 Enhancing_Food_Security_in_South_Sudan_Nov-15,634,644,2013-XX-XX -- ref-date
+Ethiopia_Food_Security_Outlook_1-Feb-17,125,160,2017-02-XX -- 2017-09-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,244,268,2016-10-XX -- 2016-12-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,274,280,XXXX-10-XX -- XXXX-11-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,602,633,2017-06-XX -- 2017-09-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,637,642,XXXX-09-XX -- XXXX-02-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,836,841,XXXX-09-XX -- XXXX-02-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,955,990,2017-02-XX -- 2017-09-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,998,1002,2017-XX-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,1145,1162,ref-date -- 2017-06-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,1462,1466,XXXX-10-XX -- XXXX-11-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,1845,1849,XXXX-10-XX -- XXXX-11-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,1845,1861,2016-10-XX -- 2016-11-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,1911,1928,2016-03-XX -- 2016-05-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,1972,2002,2016-07-XX -- 2016-12-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,2024,2034,1982-XX-XX -- ref-date
+Ethiopia_Food_Security_Outlook_1-Feb-17,2502,2523,2016-06-XX -- 2016-10-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,2731,2746,2016-XX-XX -- ref-date
+Ethiopia_Food_Security_Outlook_1-Feb-17,4058,4087,2016-06-XX -- 2016-09-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,4237,4242,XXXX-09-XX -- XXXX-02-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,4265,4275,2016-09-XX -- 2017-02-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,4344,4348,2015-XX-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,4422,4432,2016-09-XX -- 2017-02-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,4489,4493,2015-XX-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,4809,4819,2016-09-XX -- 2017-02-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,5092,5097,XXXX-09-XX -- XXXX-02-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,5712,5750,2016-12-XX -- 2017-01-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,5965,5977,2016-01-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,6128,6140,2016-01-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,6307,6312,XXXX-09-XX -- XXXX-02-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,6441,6453,2017-01-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,6541,6560,2016-12-XX -- ref-date
+Ethiopia_Food_Security_Outlook_1-Feb-17,7404,7450,2016-12-23 -- 2017-02-06
+Ethiopia_Food_Security_Outlook_1-Feb-17,7645,7664,2013-12-XX -- ref-date
+Ethiopia_Food_Security_Outlook_1-Feb-17,7669,7681,2016-10-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,7686,7698,2017-01-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,7992,7996,2017-XX-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,8109,8138,2017-01-XX -- 2017-06-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,8222,8226,XXXX-04-XX -- XXXX-05-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,8330,8336,XXXX-06-XX -- XXXX-09-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,8343,8374,2017-06-XX -- 2017-09-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,8689,8691,XXXX-04-XX -- XXXX-05-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,9560,9582,ref-date -- 2017-09-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,10577,10581,2017-XX-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,10629,10659,2017-02-XX -- 2017-06-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,10980,11006,2017-06-XX -- 2017-12-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,11298,11323,2017-03-XX -- 2017-05-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,1145,1162,ref-date -- 2017-06-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,11102,11107,XXXX-09-XX -- XXXX-02-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,11367,11377,2016-09-XX -- 2017-02-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,11568,11578,2016-09-XX -- 2017-02-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,11697,11719,2017-06-XX -- 2017-09-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,11770,11775,XXXX-09-XX -- XXXX-02-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,11788,11800,2017-10-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,12092,12096,2016-XX-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,12384,12397,2017-05-XX -- 2017-06-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,125,160,2017-02-XX -- 2017-09-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,12473,12478,XXXX-09-XX -- XXXX-02-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,12506,12511,XXXX-09-XX -- XXXX-02-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,12677,12706,2017-01-XX -- 2017-06-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,12801,12830,2016-01-XX -- 2016-06-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,12943,12965,ref-date -- 2017-09-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,13131,13141,2016-09-XX -- 2017-02-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,13149,13154,XXXX-09-XX -- XXXX-02-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,13207,13211,XXXX-04-XX -- XXXX-05-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,13443,13447,XXXX-04-XX -- XXXX-05-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,13452,13457,XXXX-09-XX -- XXXX-02-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,13576,13611,2017-02-XX -- 2017-09-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,13703,13707,2016-XX-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,13775,13805,2015-XX-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,14085,14089,2015-XX-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,14426,14448,ref-date -- 2017-09-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,14573,14602,2017-02-XX -- 2017-06-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,14725,14730,XXXX-04-XX -- XXXX-05-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,14725,14745,2017-04-XX -- 2017-05-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,14735,14745,2017-06-XX -- 2017-09-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,14755,14759,2016-XX-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,14782,14788,XXXX-06-XX -- XXXX-09-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,14782,14813,2016-06-XX -- 2016-09-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,14790,14813,2016-06-XX -- 2016-09-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,15051,15062,2016-06-XX -- 2016-09-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,15207,15213,XXXX-06-XX -- XXXX-09-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,15299,15303,2015-XX-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,15324,15334,2016-09-XX -- 2017-02-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,15407,15413,XXXX-06-XX -- XXXX-09-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,16656,16661,XXXX-09-XX -- XXXX-02-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,16909,16922,2016-12-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,16965,16978,2016-11-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,17125,17138,2016-12-XX
@@ -44,15 +109,22 @@ Ethiopia_Food_Security_Outlook_1-Feb-17,17442,17451,2016-XX-XX -- ref-date
 Ethiopia_Food_Security_Outlook_1-Feb-17,17679,17706,2016-05-XX -- 2016-10-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,18288,18317,2017-01-XX -- 2017-06-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,19001,19023,2017-03-XX -- 2017-05-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,1911,1928,2016-03-XX -- 2016-05-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,19117,19139,2017-06-XX -- 2017-09-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,1972,2002,2016-07-XX -- 2016-12-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,2024,2034,1982-XX-XX -- ref-date
+Ethiopia_Food_Security_Outlook_1-Feb-17,19140,19146,XXXX-06-XX -- XXXX-09-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,19312,19322,2016-09-XX -- 2017-02-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,19726,19730,XXXX-04-XX -- XXXX-05-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,19726,19746,2017-04-XX -- 2017-05-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,19735,19746,2017-06-XX -- 2017-09-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,19929,19940,XXXX-02-XX -- XXXX-06-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,20260,20270,2016-09-XX -- 2017-02-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,20756,20778,ref-date -- 2017-09-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,20886,20915,2017-02-XX -- 2017-05-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,20919,20950,2017-06-XX -- 2017-09-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,21543,21560,2016-03-XX -- 2016-05-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,21561,21563,XXXX-04-XX -- XXXX-05-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,21564,21576,XXXX-06-XX -- XXXX-10-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,21582,21606,2016-10-XX -- 2016-12-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,21691,21703,XXXX-06-XX -- XXXX-10-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,21861,21870,2001-XX-XX -- 2016-XX-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,21935,21945,2001-XX-XX -- ref-date
 Ethiopia_Food_Security_Outlook_1-Feb-17,22005,22027,2016-06-XX -- 2016-09-XX
@@ -63,16 +135,19 @@ Ethiopia_Food_Security_Outlook_1-Feb-17,23476,23505,2017-01-XX -- 2017-06-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,23553,23574,2017-01-XX -- 2017-03-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,24254,24267,2017-02-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,24353,24382,2016-10-XX -- 2016-12-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,244,268,2016-10-XX -- 2016-12-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,24815,24827,2017-01-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,25081,25093,2017-01-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,25246,25258,2017-01-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,25496,25527,2017-02-XX -- 2017-03-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,25562,25569,2017-04-XX -- 2017-05-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,25836,25858,XXXX-04-XX -- XXXX-05-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,25911,25943,ref-data -- 2017-10-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,25953,25965,2017-10-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,26247,26269,ref-date -- 2017-09-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,26761,26763,XXXX-04-XX -- XXXX-05-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,26674,26698,2016-10-XX -- 2016-12-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,26699,26703,XXXX-10-XX -- XXXX-11-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,26743,26760,2017-03-XX -- 2017-05-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,2731,2746,2016-XX-XX -- ref-date
 Ethiopia_Food_Security_Outlook_1-Feb-17,27340,27374,2017-02-XX -- 2017-09-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,27570,27601,2017-06-XX -- 2017-09-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,27644,27668,2016-10-XX -- 2016-12-XX
@@ -80,6 +155,7 @@ Ethiopia_Food_Security_Outlook_1-Feb-17,27819,27846,2016-12-XX -- 2017-03-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,28837,28849,2017-01-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,28865,28877,2016-01-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,28989,29001,2016-01-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,29259,29268,2016-10-XX -- 2016-11-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,29359,29383,2015-05-XX -- 2015-10-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,29396,29412,2016-05-XX -- 2016-10-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,29514,29534,2017-03-XX -- 2017-05-XX
@@ -87,16 +163,25 @@ Ethiopia_Food_Security_Outlook_1-Feb-17,29663,29685,2017-06-XX -- 2017-09-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,29785,29820,2017-02-XX -- 2017-09-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,29853,29874,ref-date -- 2016-10-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,30319,30339,2017-03-XX -- 2017-05-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,30658,30665,2017-04-XX -- 2017-05-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,31237,31272,2017-02-XX -- 2017-09-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,31357,31381,2016-10-XX -- 2016-12-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,31540,31549,2001-XX-XX -- 2016-XX-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,31630,31640,2001-XX-XX -- ref-date
+Ethiopia_Food_Security_Outlook_1-Feb-17,31387,31393,XXXX-10-XX -- XXXX-11-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,31848,31852,XXXX-10-XX -- XXXX-11-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,31853,31859,XXXX-10-XX -- XXXX-11-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,31860,31872,XXXX-06-XX -- XXXX-10-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,31909,31926,2016-03-XX -- 2016-05-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,32087,32091,XXXX-10-XX -- XXXX-11-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,32087,32103,2016-10-XX -- 2016-11-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,32114,32127,2017-02-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,32390,32402,2017-01-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,32730,32742,2017-01-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,33121,33134,2016-12-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,33594,33617,2017-03-XX -- 2017-05-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,34145,34157,XXXX-06-XX -- XXXX-10-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,34191,34203,XXXX-06-XX -- XXXX-10-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,34361,34383,ref-date -- 2017-09-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,34589,34598,2016-06-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,34650,34654,2017-XX-XX
@@ -104,65 +189,34 @@ Ethiopia_Food_Security_Outlook_1-Feb-17,35396,35418,ref-date -- 2017-09-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,35556,35560,2017-XX-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,36406,36423,2017-03-XX -- 2017-05-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,36653,36675,ref-date -- 2017-09-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,4058,4087,2016-06-XX -- 2016-09-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,4344,4348,2015-XX-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,4489,4493,2015-XX-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,5712,5750,2016-12-XX -- 2017-01-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,5965,5977,2016-01-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,602,633,2017-06-XX -- 2017-09-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,6128,6140,2016-01-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,6441,6453,2017-01-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,6541,6560,2016-12-XX -- ref-date
-Ethiopia_Food_Security_Outlook_1-Feb-17,7404,7450,2016-12-23 -- 2017-02-06
-Ethiopia_Food_Security_Outlook_1-Feb-17,7645,7664,2013-12-XX -- ref-date
-Ethiopia_Food_Security_Outlook_1-Feb-17,7669,7681,2016-10-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,7686,7698,2017-01-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,7992,7996,2017-XX-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,8109,8138,2017-01-XX -- 2017-06-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,8343,8374,2017-06-XX -- 2017-09-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,955,990,2017-02-XX -- 2017-09-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,9560,9582,ref-date -- 2017-09-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,998,1002,2017-XX-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,13131,13141,2016-09-XX -- 2017-02-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,25911,25943,ref-data -- 2017-10-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,32087,32103,2016-10-XX -- 2016-11-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,4265,4275,2016-09-XX -- 2017-02-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,29259,29268,2016-10-XX -- 2016-11-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,11367,11377,2016-09-XX -- 2017-02-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,25562,25569,2017-04-XX -- 2017-05-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,15051,15062,2016-06-XX -- 2016-09-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,15324,15334,2016-09-XX -- 2017-02-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,19726,19746,2017-04-XX -- 2017-05-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,19735,19746,2017-06-XX -- 2017-09-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,2502,2523,2016-06-XX -- 2016-10-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,4422,4432,2016-09-XX -- 2017-02-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,30658,30665,2017-04-XX -- 2017-05-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,20260,20270,2016-09-XX -- 2017-02-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,1845,1861,2016-10-XX -- 2016-11-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,4809,4819,2016-09-XX -- 2017-02-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,14725,14745,2017-04-XX -- 2017-05-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,14735,14745,2017-06-XX -- 2017-09-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,11568,11578,2016-09-XX -- 2017-02-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,19312,19322,2016-09-XX -- 2017-02-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,14782,14813,2016-06-XX -- 2016-09-XX
+FAO_GIEWS_South_Sudan_Country_Brief_Sep-17,80,93,2017-02-XX
 FAO_GIEWS_South_Sudan_Country_Brief_Sep-17,2187,2191,2017-XX-XX
 FAO_GIEWS_South_Sudan_Country_Brief_Sep-17,2657,2661,2016-XX-XX
-FAO_GIEWS_South_Sudan_Country_Brief_Sep-17,80,93,2017-02-XX
+FEWS_NET_South_Sudan_Famine_Risk_Alert_Jan-17,806,815,2016-07-XX
 FEWS_NET_South_Sudan_Famine_Risk_Alert_Jan-17,1295,1299,2016-XX-XX
 FEWS_NET_South_Sudan_Famine_Risk_Alert_Jan-17,1545,1555,2014-XX-XX -- ref-date
 FEWS_NET_South_Sudan_Famine_Risk_Alert_Jan-17,2040,2161,2015-XX-XX
 FEWS_NET_South_Sudan_Famine_Risk_Alert_Jan-17,2193,2206,2013-11-XX
 FEWS_NET_South_Sudan_Famine_Risk_Alert_Jan-17,3059,3094,2016-09-XX -- 2016-11-XX
 FEWS_NET_South_Sudan_Famine_Risk_Alert_Jan-17,3689,3693,2017-XX-XX
-FEWS_NET_South_Sudan_Famine_Risk_Alert_Jan-17,806,815,2016-07-XX
-FEWS_NET_South_Sudan_Outlook_Jan-18,2424,2441,ref-date -- 2018-07-XX
 FEWS_NET_South_Sudan_Famine_Risk_Alert_Jan-17,3863,3879,2016-02-XX -- 2016-06-XX
 FEWS_NET_South_Sudan_Outlook_Jan-18,268,284,2018-02-XX -- 2018-06-XX
+FEWS_NET_South_Sudan_Outlook_Jan-18,2424,2441,ref-date -- 2018-07-XX
+FEWS_NET_South_Sudan_Famine_Risk_Alert_Jan-17,3337,3348,XXXX-02-XX -- XXXX-06-XX
+FEWS_NET_South_Sudan_Famine_Risk_Alert_Jan-17,209,220,XXXX-02-XX -- XXXX-06-XX
+FEWS_NET_South_Sudan_Famine_Risk_Alert_Jan-17,3273,3284,XXXX-02-XX -- XXXX-06-XX
+FEWS_NET_South_Sudan_Outlook_Jan-18,394,405,XXXX-02-XX -- XXXX-06-XX
 FFP_Fact_Sheet_South_Sudan_Jan-18,1149,1161,2017-01-XX
 FFP_Fact_Sheet_South_Sudan_Jan-18,1969,1976,2017-XX-XX
 FFP_Fact_Sheet_South_Sudan_Jan-18,350,382,2017-XX-XX
 FFP_Fact_Sheet_South_Sudan_Jan-18,514,531,2018-02-XX -- 2018-06-XX
 FFP_Fact_Sheet_South_Sudan_Jan-18,135,151,2017-02-XX -- 2017-06-XX
+FFP_Fact_Sheet_South_Sudan_Jan-18,140,151,XXXX-02-XX -- XXXX-06-XX
+Food_Assistance_Outlook_Brief_1-Jan-18,3263,3274,XXXX-02-XX -- XXXX-06-XX
+Food_Assistance_Outlook_Brief_1-Jan-18,393,404,XXXX-02-XX -- XXXX-06-XX
+Food_Assistance_Outlook_Brief_1-Jan-18,1896,1898,XXXX-04-XX -- XXXX-05-XX
+Food_Assistance_Outlook_Brief_1-Jan-18,1819,1823,XXXX-10-XX -- XXXX-11-XX
+Food_Assistance_Outlook_Brief_1-Jan-18,2625,2636,XXXX-02-XX -- XXXX-06-XX
 Food_Assistance_Outlook_Brief_1-Jan-18,1151,1155,2017-XX-XX
 Food_Assistance_Outlook_Brief_1-Jan-18,1284,1300,2018-01-XX -- 2018-03-XX
 Food_Assistance_Outlook_Brief_1-Jan-18,1510,1522,ref-date -- 2018-XX-XX
@@ -193,6 +247,10 @@ Price_Watch_28-Feb-18,17540,17544,2017-XX-XX
 Price_Watch_28-Feb-18,2378,2397,2014-12-XX -- ref-date
 Price_Watch_28-Feb-18,3666,3670,2018-XX-XX
 Price_Watch_28-Feb-18,5475,5479,2017-XX-XX
+Price_Watch_28-Feb-18,9952,9963,XXXX-02-XX -- XXXX-06-XX
+Price_Watch_28-Feb-18,1206,1217,XXXX-02-XX -- XXXX-06-XX
+Price_Watch_28-Feb-18,6966,6977,XXXX-02-XX -- XXXX-06-XX
+Price_Watch_28-Feb-18,6415,6426,XXXX-02-XX -- XXXX-06-XX
 South_Sudan_Humanitarian_Response_Plan_Jan-18,1028,1041,2017-02-XX
 South_Sudan_Humanitarian_Response_Plan_Jan-18,1091,1095,2018-XX-XX
 South_Sudan_Humanitarian_Response_Plan_Jan-18,1136,1162,2018-01-XX -- 2018-03-XX
@@ -201,8 +259,11 @@ South_Sudan_Humanitarian_Response_Plan_Jan-18,2178,2182,2018-XX-XX
 South_Sudan_Humanitarian_Response_Plan_Jan-18,2580,2584,2018-XX-XX
 South_Sudan_Humanitarian_Response_Plan_Jan-18,95,99,2018-XX-XX
 South_Sudan_Humanitarian_Response_Plan_Jan-18,1589,1610,2018-02-XX -- 2018-06-XX
+South_Sudan_Humanitarian_Response_Plan_Jan-18,1599,1610,XXXX-02-XX -- XXXX-06-XX
+South_Sudan_Humanitarian_Response_Plan_Jan-18,1418,1429,XXXX-02-XX -- XXXX-06-XX
 South_Sudanese_Risk_Facing_Famine_Jan-18,1244,1257,2013-12-XX
 South_Sudanese_Risk_Facing_Famine_Jan-18,958,971,2017-12-XX
+South_Sudanese_Risk_Facing_Famine_Jan-18,208,219,XXXX-02-XX -- XXXX-06-XX
 TECHNICAL_BRIEF_(RE)ASSESSING_THE_RELATIONSHIP_BETWEEN_FOOD_AID_AND_ARMED_CONFLICT_Oct-14,10259,10263,1970-XX-XX
 TECHNICAL_BRIEF_(RE)ASSESSING_THE_RELATIONSHIP_BETWEEN_FOOD_AID_AND_ARMED_CONFLICT_Oct-14,10280,10284,2007-XX-XX
 TECHNICAL_BRIEF_(RE)ASSESSING_THE_RELATIONSHIP_BETWEEN_FOOD_AID_AND_ARMED_CONFLICT_Oct-14,10303,10307,2007-XX-XX
@@ -252,5 +313,15 @@ UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,766,776,2017-03-XX
 UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,7995,7999,2017-XX-XX
 UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,8563,8578,2016-07-XX -- ref-date
 UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,9713,9731,2017-01-XX -- ref-date
+UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,7583,7595,XXXX-06-XX -- XXXX-10-XX
+UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,2119,2123,XXXX-04-XX -- XXXX-05-XX
+UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,2599,2621,XXXX-04-01 -- XXXX-04-12
+UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,1337,1349,XXXX-06-XX -- XXXX-10-XX
+UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,7167,7171,XXXX-04-XX -- XXXX-05-XX
+UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,1885,1890,XXXX-09-XX -- XXXX-02-XX
+UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,7160,7166,XXXX-03-20 -- XXXX-06-21
+UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,1319,1323,XXXX-04-XX -- XXXX-05-XX
 WFP_Ethiopia_Drought_Emergency_Situation_Report_5_Jul-17,515,537,ref-date -- 2017-XX-XX
 WFP_Ethiopia_Drought_Emergency_Situation_Report_5_Jul-17,582,586,2017-XX-XX
+WFP_Ethiopia_Drought_Emergency_Situation_Report_5_Jul-17,442,448,XXXX-06-21 -- XXXX-09-22
+WFP_Ethiopia_Drought_Emergency_Situation_Report_5_Jul-17,449,454,XXXX-09-XX -- XXXX-02-XX

--- a/main/src/main/resources/org/clulab/numeric/date-ranges.yml
+++ b/main/src/main/resources/org/clulab/numeric/date-ranges.yml
@@ -102,7 +102,7 @@
   example: "It was summer 2000"
   action: mkDateRangeMentionWithSeason
   pattern: |
-    @season:PossibleSeason /(?i)(in|of)/? @year:PossibleYear
+    @season:PossibleSeason /(?i)(in|of)/? @year:PossibleYear?
 
 - name: date-range-season-2
   priority: ${ rulepriority }
@@ -129,7 +129,7 @@
   example: "Between spring and autumn 2017"
   action: mkDateRangeMentionWithSeasons
   pattern: |
-    /(?i)between/ @season1:PossibleSeason @year1:PossibleYear? /(?i)(and|to)/ @season2:PossibleSeason @year2:PossibleYear
+    /(?i)between/ @season1:PossibleSeason @year1:PossibleYear? /(?i)(and|to)/ @season2:PossibleSeason @year2:PossibleYear?
 
 - name: date-range-season-5
   priority: ${ rulepriority }
@@ -138,7 +138,7 @@
   example: "Since summer 2000"
   action: mkDateRangeMentionWithSeasonSinceRef
   pattern: |
-    /(?i)(since|from)/ @season:PossibleSeason @year:PossibleYear
+    /(?i)(since|from)/ @season:PossibleSeason @year:PossibleYear?
 
 - name: date-range-season-6
   priority: ${ rulepriority }
@@ -147,4 +147,22 @@
   example: "Until summer 2000"
   action: mkDateRangeMentionWithSeasonUntilRef
   pattern: |
-    /(?i)until|through/ @season:PossibleSeason @year:PossibleYear
+    /(?i)until|through/ @season:PossibleSeason @year:PossibleYear?
+
+- name: date-range-season-7
+  priority: ${ rulepriority }
+  label: DateRange
+  type: token
+  example: "Before summer 2000"
+  action: mkDateUnboundRangeMentionWithSeasonBefore
+  pattern: |
+    /(?i)(before|prior|previous)/ /(?i)to/? @season:PossibleSeason @year:PossibleYear?
+
+- name: date-range-season-8
+  priority: ${ rulepriority }
+  label: DateRange
+  type: token
+  example: "After summer 2000"
+  action: mkDateUnboundRangeMentionWithSeasonAfter
+  pattern: |
+    /(?i)(after|beyond|following)/ @season:PossibleSeason @year:PossibleYear?

--- a/main/src/main/resources/org/clulab/numeric/date-ranges.yml
+++ b/main/src/main/resources/org/clulab/numeric/date-ranges.yml
@@ -76,6 +76,24 @@
   pattern: |
     /(?i)until|through/ @date1:Date
 
+- name: date-unbound-range-1
+  priority: ${rulepriority}
+  label: DateRange
+  type: token
+  example: "Before June 2020"
+  action: mkDateUnboundRangeMentionBefore
+  pattern: |
+    /(?i)(before|prior|previous)/ /(?i)to/? @date1:Date
+
+- name: date-unbound-range-2
+  priority: ${rulepriority}
+  label: DateRange
+  type: token
+  example: "After June 2020"
+  action: mkDateUnboundRangeMentionAfter
+  pattern: |
+    /(?i)(after|beyond|following)/ @date1:Date
+
 # Date range derived from a season, with mandatory year
 - name: date-range-season-1
   priority: ${ rulepriority }

--- a/main/src/main/scala/org/clulab/numeric/actions/NumericActions.scala
+++ b/main/src/main/scala/org/clulab/numeric/actions/NumericActions.scala
@@ -87,6 +87,16 @@ class NumericActions(seasonNormalizer: SeasonNormalizer) extends Actions {
     convert(mentions, toDateRangeMentionWithSeasonUntilRef(seasonNormalizer), "toDateRangeMentionWithSeasonUntilRef")
   }
 
+  /** Constructs a DateRangeMention from a token pattern */
+  def mkDateUnboundRangeMentionBefore(mentions: Seq[Mention], state: State): Seq[Mention] = {
+    convert(mentions, toDateUnboundRangeMentionBefore, "toDateUnboundRangeMentionBefore")
+  }
+
+  /** Constructs a DateRangeMention from a token pattern */
+  def mkDateUnboundRangeMentionAfter(mentions: Seq[Mention], state: State): Seq[Mention] = {
+    convert(mentions, toDateUnboundRangeMentionAfter, "toDateUnboundRangeMentionAfter")
+  }
+
   /** Constructs a DateMention from a token pattern */
   def mkDateMention(mentions: Seq[Mention], state: State): Seq[Mention] = {
     convert(mentions, toDateMention, "toDateMention")

--- a/main/src/main/scala/org/clulab/numeric/actions/NumericActions.scala
+++ b/main/src/main/scala/org/clulab/numeric/actions/NumericActions.scala
@@ -68,6 +68,16 @@ class NumericActions(seasonNormalizer: SeasonNormalizer) extends Actions {
   }
 
   /** Constructs a DateRangeMention from a token pattern */
+  def mkDateUnboundRangeMentionBefore(mentions: Seq[Mention], state: State): Seq[Mention] = {
+    convert(mentions, toDateUnboundRangeMentionBefore, "toDateUnboundRangeMentionBefore")
+  }
+
+  /** Constructs a DateRangeMention from a token pattern */
+  def mkDateUnboundRangeMentionAfter(mentions: Seq[Mention], state: State): Seq[Mention] = {
+    convert(mentions, toDateUnboundRangeMentionAfter, "toDateUnboundRangeMentionAfter")
+  }
+
+  /** Constructs a DateRangeMention from a token pattern */
   def mkDateRangeMentionWithSeason(mentions: Seq[Mention], state: State): Seq[Mention] = {
     convert(mentions, toDateRangeMentionWithSeason(seasonNormalizer), "toDateRangeMentionWithSeason")
   }
@@ -88,13 +98,13 @@ class NumericActions(seasonNormalizer: SeasonNormalizer) extends Actions {
   }
 
   /** Constructs a DateRangeMention from a token pattern */
-  def mkDateUnboundRangeMentionBefore(mentions: Seq[Mention], state: State): Seq[Mention] = {
-    convert(mentions, toDateUnboundRangeMentionBefore, "toDateUnboundRangeMentionBefore")
+  def mkDateUnboundRangeMentionWithSeasonBefore(mentions: Seq[Mention], state: State): Seq[Mention] = {
+    convert(mentions, toDateUnboundRangeMentionWithSeasonBefore(seasonNormalizer), "toDateUnboundRangeMentionBefore")
   }
 
   /** Constructs a DateRangeMention from a token pattern */
-  def mkDateUnboundRangeMentionAfter(mentions: Seq[Mention], state: State): Seq[Mention] = {
-    convert(mentions, toDateUnboundRangeMentionAfter, "toDateUnboundRangeMentionAfter")
+  def mkDateUnboundRangeMentionWithSeasonAfter(mentions: Seq[Mention], state: State): Seq[Mention] = {
+    convert(mentions, toDateUnboundRangeMentionWithSeasonAfter(seasonNormalizer), "toDateUnboundRangeMentionAfter")
   }
 
   /** Constructs a DateMention from a token pattern */

--- a/main/src/main/scala/org/clulab/numeric/mentions/DateRangeMention.scala
+++ b/main/src/main/scala/org/clulab/numeric/mentions/DateRangeMention.scala
@@ -15,10 +15,11 @@ class DateRangeMention ( labels: Seq[String],
                          var date2Norm: String )
   extends TextBoundMention(labels, tokenInterval, sentence, document, keep, foundBy, attachments) with Norm {
 
-  // Change date1Norm if the date1Norm does not have a year value but date2Norm has a year value
+  // Change date1Norm if the date1Norm is not undefined (i.e., XXXX-XX-XX) and
+  // does not have a year value but date2Norm has a year value
   // This will handle date ranges of form month date and month date of year.
   // Ex: "Sowing dates between May 3 and October 2, 2020" will have a normalized value of 2020-05-03 -- 2020-10-02
-  if (date1Norm contains "XXXX") {
+  if (!date1Norm.equals("XXXX-XX-XX") && date1Norm.contains("XXXX")) {
     if (!(date2Norm contains "XXXX")) {
       // Keep everything from date1Norm except for the year value, which will be copied from date2Norm.
       date1Norm = date2Norm.substring(0,4) + date1Norm.substring(4)

--- a/main/src/main/scala/org/clulab/numeric/mentions/DateRangeMention.scala
+++ b/main/src/main/scala/org/clulab/numeric/mentions/DateRangeMention.scala
@@ -19,8 +19,8 @@ class DateRangeMention ( labels: Seq[String],
   // does not have a year value but date2Norm has a year value
   // This will handle date ranges of form month date and month date of year.
   // Ex: "Sowing dates between May 3 and October 2, 2020" will have a normalized value of 2020-05-03 -- 2020-10-02
-  if (!date1Norm.equals("XXXX-XX-XX") && date1Norm.contains("XXXX")) {
-    if (!(date2Norm contains "XXXX")) {
+  if (!date1Norm.equals("XXXX-XX-XX") && date1Norm.startsWith("XXXX")) {
+    if (!(date2Norm.equals("ref-date") || date2Norm.startsWith("XXXX"))) {
       // Keep everything from date1Norm except for the year value, which will be copied from date2Norm.
       date1Norm = date2Norm.substring(0,4) + date1Norm.substring(4)
     }

--- a/main/src/main/scala/org/clulab/numeric/mentions/DateRangeMention.scala
+++ b/main/src/main/scala/org/clulab/numeric/mentions/DateRangeMention.scala
@@ -19,8 +19,8 @@ class DateRangeMention ( labels: Seq[String],
   // does not have a year value but date2Norm has a year value
   // This will handle date ranges of form month date and month date of year.
   // Ex: "Sowing dates between May 3 and October 2, 2020" will have a normalized value of 2020-05-03 -- 2020-10-02
-  if (!date1Norm.equals("XXXX-XX-XX") && date1Norm.startsWith("XXXX")) {
-    if (!(date2Norm.equals("ref-date") || date2Norm.startsWith("XXXX"))) {
+  if (date1Norm != "XXXX-XX-XX" && date1Norm.startsWith("XXXX")) {
+    if (!(date2Norm == "ref-date" || date2Norm.startsWith("XXXX"))) {
       // Keep everything from date1Norm except for the year value, which will be copied from date2Norm.
       date1Norm = date2Norm.substring(0,4) + date1Norm.substring(4)
     }

--- a/main/src/main/scala/org/clulab/numeric/mentions/package.scala
+++ b/main/src/main/scala/org/clulab/numeric/mentions/package.scala
@@ -213,6 +213,54 @@ package object mentions {
       throw new RuntimeException(s"ERROR: cannot convert mention of type [${m.getClass.toString}] to DateRangeMention!")
   }
 
+  def toDateUnboundRangeMentionBefore(mention: Mention): DateRangeMention =  mention match {
+    case m: DateRangeMention => m
+
+    case m: RelationMention =>
+      val date1Norm = getArgNorm("date1", m)
+      if(date1Norm.isEmpty)
+        throw new RuntimeException(s"ERROR: could not find argument date1 in mention [${m.raw.mkString(" ")}]!")
+
+      new DateRangeMention(
+        m.labels,
+        m.tokenInterval,
+        m.sentence,
+        m.document,
+        m.keep,
+        m.foundBy,
+        m.attachments,
+        "XXXX-XX-XX",
+        date1Norm.get
+      )
+
+    case m =>
+      throw new RuntimeException(s"ERROR: cannot convert mention of type ${m.getClass.toString} to DateRangeMention!")
+  }
+
+  def toDateUnboundRangeMentionAfter(mention: Mention): DateRangeMention =  mention match {
+    case m: DateRangeMention => m
+
+    case m: RelationMention =>
+      val date1Norm = getArgNorm("date1", m)
+      if(date1Norm.isEmpty)
+        throw new RuntimeException(s"ERROR: could not find argument date1 in mention [${m.raw.mkString(" ")}]!")
+
+      new DateRangeMention(
+        m.labels,
+        m.tokenInterval,
+        m.sentence,
+        m.document,
+        m.keep,
+        m.foundBy,
+        m.attachments,
+        date1Norm.get,
+        "XXXX-XX-XX"
+      )
+
+    case m =>
+      throw new RuntimeException(s"ERROR: cannot convert mention of type ${m.getClass.toString} to DateRangeMention!")
+  }
+
   def toDateRangeMentionWithSeason(seasonNormalizer: SeasonNormalizer)(mention: Mention): DateRangeMention =  mention match {
     case m: DateRangeMention => m
 

--- a/main/src/main/scala/org/clulab/numeric/mentions/package.scala
+++ b/main/src/main/scala/org/clulab/numeric/mentions/package.scala
@@ -430,7 +430,7 @@ package object mentions {
         m.foundBy,
         m.attachments,
         "XXXX-XX-XX",
-        TempEvalFormatter.mkDate(seasonNorm.get.startDay, seasonNorm.get.startMonth, yearNorm),
+        TempEvalFormatter.mkDate(seasonNorm.get.startDay, seasonNorm.get.startMonth, yearNorm)
       )
 
     case m =>

--- a/main/src/main/scala/org/clulab/numeric/mentions/package.scala
+++ b/main/src/main/scala/org/clulab/numeric/mentions/package.scala
@@ -353,8 +353,8 @@ package object mentions {
         throw new RuntimeException(s"ERROR: could not find argument season in mention ${m.raw.mkString(" ")}!")
 
       val yearNorm = getArgWords("year", m) match {
-        case year if year.isDefined =>
-          val (_, yearEnd) = seasonNormalizer.adjustYearRange(seasonNorm.get, year.get)
+        case Some(year) =>
+          val (_, yearEnd) = seasonNormalizer.adjustYearRange(seasonNorm.get, year)
           Some(yearEnd)
         case _ => None
       }
@@ -384,8 +384,8 @@ package object mentions {
         throw new RuntimeException(s"ERROR: could not find argument season in mention ${m.raw.mkString(" ")}!")
 
       val yearNorm = getArgWords("year", m) match {
-        case year if year.isDefined =>
-          val (yearStart, _) = seasonNormalizer.adjustYearRange(seasonNorm.get, year.get)
+        case Some(year) =>
+          val (yearStart, _) = seasonNormalizer.adjustYearRange(seasonNorm.get, year)
           Some(yearStart)
         case _ => None
       }
@@ -415,8 +415,8 @@ package object mentions {
         throw new RuntimeException(s"ERROR: could not find argument season in mention ${m.raw.mkString(" ")}!")
 
       val yearNorm = getArgWords("year", m) match {
-        case year if year.isDefined =>
-          val (yearStart, _) = seasonNormalizer.adjustYearRange(seasonNorm.get, year.get)
+        case Some(year) =>
+          val (yearStart, _) = seasonNormalizer.adjustYearRange(seasonNorm.get, year)
           Some(yearStart)
         case _ => None
       }
@@ -446,8 +446,8 @@ package object mentions {
         throw new RuntimeException(s"ERROR: could not find argument season in mention ${m.raw.mkString(" ")}!")
 
       val yearNorm = getArgWords("year", m) match {
-        case year if year.isDefined =>
-          val (_, yearEnd) = seasonNormalizer.adjustYearRange(seasonNorm.get, year.get)
+        case Some(year) =>
+          val (_, yearEnd) = seasonNormalizer.adjustYearRange(seasonNorm.get, year)
           Some(yearEnd)
         case _ => None
       }

--- a/main/src/test/scala/org/clulab/numeric/TestNumericEntityRecognition.scala
+++ b/main/src/test/scala/org/clulab/numeric/TestNumericEntityRecognition.scala
@@ -193,18 +193,18 @@ class TestNumericEntityRecognition extends FlatSpec with Matchers {
     ensure("January 2016 and June 2017", Interval(3, 5), "DATE", "2017-06-XX")
   }
 
-  it should "recognize unbounded dates" in {
+  it should "recognize relative dates" in {
+    ensure("Since January 2016", Interval(0, 3), "DATE-RANGE", "2016-01-XX -- ref-date")
+    ensure("Until January 2016", Interval(0, 3), "DATE-RANGE", "ref-date -- 2016-01-XX")
+    ensure("from January 2016", Interval(0, 3), "DATE-RANGE", "2016-01-XX -- ref-date")
+  }
+
+  it should "recognize unbounded date ranges" in {
     ensure("before July 2016", Interval(0, 3), "DATE-RANGE", "XXXX-XX-XX -- 2016-07-XX")
     ensure("prior to July 2016", Interval(0, 4), "DATE-RANGE", "XXXX-XX-XX -- 2016-07-XX")
     ensure("after July 2016", Interval(0, 3), "DATE-RANGE", "2016-07-XX -- XXXX-XX-XX")
     ensure("before July 15", Interval(0, 3), "DATE-RANGE", "XXXX-XX-XX -- XXXX-07-15")
     ensure("after July 15", Interval(0, 3), "DATE-RANGE", "XXXX-07-15 -- XXXX-XX-XX")
-  }
-
-  it should "recognize relative dates" in {
-    ensure("Since January 2016", Interval(0, 3), "DATE-RANGE", "2016-01-XX -- ref-date")
-    ensure("Until January 2016", Interval(0, 3), "DATE-RANGE", "ref-date -- 2016-01-XX")
-    ensure("from January 2016", Interval(0, 3), "DATE-RANGE", "2016-01-XX -- ref-date")
   }
 
   it should "recognize date ranges from seasons" in {
@@ -214,15 +214,30 @@ class TestNumericEntityRecognition extends FlatSpec with Matchers {
     ensure("autumn 2017", Interval(0, 2), "DATE-RANGE", "2017-09-22 -- 2017-12-21")
     ensure("autumn in 2017", Interval(0, 3), "DATE-RANGE", "2017-09-22 -- 2017-12-21")
     ensure("2017 autumn", Interval(0, 2), "DATE-RANGE", "2017-09-22 -- 2017-12-21")
+    ensure("winter", Interval(0, 1), "DATE-RANGE", "XXXX-12-21 -- XXXX-03-20")
+    ensure("spring", Interval(0, 1), "DATE-RANGE", "XXXX-03-20 -- XXXX-06-21")
+
   }
 
   it should "recognize date ranges with seasons" in {
     ensure("from spring to autumn 2017", Interval(0, 4), "DATE-RANGE", "2017-06-21 -- 2017-09-22")
     ensure("between spring and autumn 2017", Interval(0, 4), "DATE-RANGE", "2017-06-21 -- 2017-09-22")
     ensure("between autumn 2017 and spring 2018", Interval(0, 5), "DATE-RANGE", "2017-12-21 -- 2018-03-20")
+    ensure("between autumn and spring", Interval(0, 4), "DATE-RANGE", "XXXX-12-21 -- XXXX-03-20")
     ensure("Since winter 2017", Interval(0, 3), "DATE-RANGE", "2017-03-20 -- ref-date")
+    ensure("Since winter", Interval(0, 2), "DATE-RANGE", "XXXX-03-20 -- ref-date")
     ensure("Until summer 2017", Interval(0, 3), "DATE-RANGE", "ref-date -- 2017-06-21")
+    ensure("Until summer", Interval(0, 2), "DATE-RANGE", "ref-date -- XXXX-06-21")
   }
+
+  it should "recognize unbounded date ranges with seasons" in {
+    ensure("before summer 2016", Interval(0, 3), "DATE-RANGE", "XXXX-XX-XX -- 2016-06-21")
+    ensure("prior to summer 2016", Interval(0, 4), "DATE-RANGE", "XXXX-XX-XX -- 2016-06-21")
+    ensure("after summer 2016", Interval(0, 3), "DATE-RANGE", "2016-09-22 -- XXXX-XX-XX")
+    ensure("before summer", Interval(0, 2), "DATE-RANGE", "XXXX-XX-XX -- XXXX-06-21")
+    ensure("after summer", Interval(0, 2), "DATE-RANGE", "XXXX-09-22 -- XXXX-XX-XX")
+  }
+
 
   it should "recognize measurement units" in {
     ensure("It was 12 ha", Interval(2, 4), "MEASUREMENT", "12.0 ha")

--- a/main/src/test/scala/org/clulab/numeric/TestNumericEntityRecognition.scala
+++ b/main/src/test/scala/org/clulab/numeric/TestNumericEntityRecognition.scala
@@ -193,6 +193,14 @@ class TestNumericEntityRecognition extends FlatSpec with Matchers {
     ensure("January 2016 and June 2017", Interval(3, 5), "DATE", "2017-06-XX")
   }
 
+  it should "recognize unbounded dates" in {
+    ensure("before July 2016", Interval(0, 3), "DATE-RANGE", "XXXX-XX-XX -- 2016-07-XX")
+    ensure("prior to July 2016", Interval(0, 4), "DATE-RANGE", "XXXX-XX-XX -- 2016-07-XX")
+    ensure("after July 2016", Interval(0, 3), "DATE-RANGE", "2016-07-XX -- XXXX-XX-XX")
+    ensure("before July 15", Interval(0, 3), "DATE-RANGE", "XXXX-XX-XX -- XXXX-07-15")
+    ensure("after July 15", Interval(0, 3), "DATE-RANGE", "XXXX-07-15 -- XXXX-XX-XX")
+  }
+
   it should "recognize relative dates" in {
     ensure("Since January 2016", Interval(0, 3), "DATE-RANGE", "2016-01-XX -- ref-date")
     ensure("Until January 2016", Interval(0, 3), "DATE-RANGE", "ref-date -- 2016-01-XX")


### PR DESCRIPTION
This pull request adds support to recognize time expressions of unbounded date ranges. 
It also covers properly time expressions with seasons a not a year (e.g. "since summer").