### PR TITLE
Jollyday integration

### DIFF
--- a/main/build.sbt
+++ b/main/build.sbt
@@ -27,6 +27,7 @@ libraryDependencies ++= {
     // NLP tools used by CluProcessor
     "org.antlr"                   % "antlr4-runtime"           % "4.9.2",   // for tokenization
     "org.clulab"                  % "lemport"                  % "0.9.10", // Portuguese lemmatizer
+    "de.jollyday"                 % "jollyday"                 % "0.5.10", // for holidays normalization
     // logging
     "ch.qos.logback"              % "logback-classic"          % "1.0.10",
     "com.typesafe.scala-logging" %% "scala-logging"            % "3.7.2",

--- a/main/src/main/resources/org/clulab/numeric/HOLIDAY.tsv
+++ b/main/src/main/resources/org/clulab/numeric/HOLIDAY.tsv
@@ -1,0 +1,39 @@
+# list of holidays
+Lincoln's Birthday
+Easter Monday
+Washington's Birthday
+Labour day
+César Chávez's Birthday
+Seward's Day
+Christmas Eve
+Mardi Gras
+Battle of Bennington
+Arbor Day
+West Virginia Day
+Election day
+Confederate Memorial Day
+Statehood day
+Truman Day
+Christmas
+Presidents Day
+Prince Jonah Kuhio Kalanianaole Day
+Independence Day
+New Years Eve
+Jefferson Davis Day
+Lee-Jackson Day
+Patriots' Day
+Alaska Day
+Victory Day
+New Year
+Veterans Day
+Columbus Day
+undefined
+Thanksgiving Day
+Martin Luther King, Jr. Day
+Good Friday
+Casimir Pulaski Day
+Memorial Day
+Service Reduction Day
+Kamehameha Day
+Pioneer Day
+Nevada Day

--- a/main/src/main/resources/org/clulab/numeric/HOLIDAY.tsv
+++ b/main/src/main/resources/org/clulab/numeric/HOLIDAY.tsv
@@ -2,9 +2,9 @@
 # List of holidays in the United States extracted from the Jollyday api.
 # This list can be obtained with the following snippet:
 #
-#   import de.jollyday.{HolidayManager, HolidayCalendar}
+#   import de.jollyday.{HolidayManager, HolidayCalendar, ManagerParameters}
 #   import collection.JavaConverters._
-#   val holidayManager = HolidayManager.getInstance(HolidayCalendar.UNITED_STATES)
+#   val holidayManager = HolidayManager.getInstance(ManagerParameters.create(HolidayCalendar.UNITED_STATES))
 #   holidayManager.getCalendarHierarchy.getChildren.keySet.asScala.
 #                   map(holidayManager.getHolidays(2021, _).asScala).flatten.map(_.getDescription)
 #

--- a/main/src/main/resources/org/clulab/numeric/HOLIDAY.tsv
+++ b/main/src/main/resources/org/clulab/numeric/HOLIDAY.tsv
@@ -1,4 +1,14 @@
-# list of holidays
+#
+# List of holidays in the United States extracted from the Jollyday api.
+# This list can be obtained with the following snippet:
+#
+#   import de.jollyday.{HolidayManager, HolidayCalendar}
+#   import collection.JavaConverters._
+#   val holidayManager = HolidayManager.getInstance(HolidayCalendar.UNITED_STATES)
+#   holidayManager.getCalendarHierarchy.getChildren.keySet.asScala.
+#                   map(holidayManager.getHolidays(2021, _).asScala).flatten.map(_.getDescription)
+#
+#
 Lincoln's Birthday
 Easter Monday
 Washington's Birthday

--- a/main/src/main/resources/org/clulab/numeric/HOLIDAY.tsv
+++ b/main/src/main/resources/org/clulab/numeric/HOLIDAY.tsv
@@ -1,49 +1,132 @@
 #
 # List of holidays in the United States extracted from the Jollyday api.
-# This list can be obtained with the following snippet:
+# Each phrase before // is an alternative name of a holiday and must be in lower case.
+# The comment after // is the canonical form given by Jollyday.
+# This list of canonical forms can be obtained with the following snippet:
 #
 #   import de.jollyday.{HolidayManager, HolidayCalendar, ManagerParameters}
 #   import collection.JavaConverters._
 #   val holidayManager = HolidayManager.getInstance(ManagerParameters.create(HolidayCalendar.UNITED_STATES))
 #   holidayManager.getCalendarHierarchy.getChildren.keySet.asScala.
-#                   map(holidayManager.getHolidays(2021, _).asScala).flatten.map(_.getDescription)
+#                   flatMap(holidayManager.getHolidays(2021, _).asScala).map(_.getDescription)
 #
 #
-Lincoln's Birthday
-Easter Monday
-Washington's Birthday
-Labour day
-César Chávez's Birthday
-Seward's Day
-Christmas Eve
-Mardi Gras
-Battle of Bennington
-Arbor Day
-West Virginia Day
-Election day
-Confederate Memorial Day
-Statehood day
-Truman Day
-Christmas
-Presidents Day
-Prince Jonah Kuhio Kalanianaole Day
-Independence Day
-New Years Eve
-Jefferson Davis Day
-Lee-Jackson Day
-Patriots' Day
-Alaska Day
-Victory Day
-New Year
-Veterans Day
-Columbus Day
-undefined
-Thanksgiving Day
-Martin Luther King, Jr. Day
-Good Friday
-Casimir Pulaski Day
-Memorial Day
-Service Reduction Day
-Kamehameha Day
-Pioneer Day
-Nevada Day
+lincoln 's birthday						//	Lincoln's Birthday
+lincoln birthday						//	Lincoln's Birthday
+lincoln 's day  						//	Lincoln's Birthday
+lincoln day     						//	Lincoln's Birthday
+easter monday							//	Easter Monday
+bright monday							//	Easter Monday
+renewal monday							//	Easter Monday
+washington 's birthday                  //	Washington's Birthday
+washington birthday 					//	Washington's Birthday
+washington 's day   					//	Washington's Birthday
+washington day      					//	Washington's Birthday
+presidents day							//	Presidents Day
+presidents ' day						//	Presidents Day
+labour day								//	Labour day
+labor day								//	Labour day
+césar chávez 's birthday				//	César Chávez's Birthday
+césar chávez birthday				    //	César Chávez's Birthday
+cesar chavez 's birthday				//	César Chávez's Birthday
+cesar chavez birthday				    //	César Chávez's Birthday
+césar chávez 's day				        //	César Chávez's Birthday
+césar chávez day				        //	César Chávez's Birthday
+cesar chavez 's day				        //	César Chávez's Birthday
+cesar chavez day				        //	César Chávez's Birthday
+seward 's day							//	Seward's Day
+seward day  							//	Seward's Day
+christmas eve							//	Christmas Eve
+christmas evening					    //	Christmas Eve
+christmas vigil							//	Christmas Eve
+day before christmas					//	Christmas Eve
+night before christmas					//	Christmas Eve
+mardi gras								//	Mardi Gras
+fat tuesday								//	Mardi Gras
+shrove tuesday							//	Mardi Gras
+pancake tuesday							//	Mardi Gras
+battle of bennington					//	Battle of Bennington
+battle of bennington day				//	Battle of Bennington
+bennington battle day					//	Battle of Bennington
+arbor day								//	Arbor Day
+arbour day								//	Arbor Day
+west virginia day						//	West Virginia Day
+election day							//	Election day
+polling day 							//	Election day
+confederate memorial day				//	Confederate Memorial Day
+confederate heroes day				    //	Confederate Memorial Day
+confederate decoration day				//	Confederate Memorial Day
+statehood day							//	Statehood day
+admission day							//	Statehood day
+truman day								//	Truman Day
+truman 's day							//	Truman Day
+truman birthday							//	Truman Day
+truman 's birthday						//	Truman Day
+christmas								//	Christmas
+christmas day   						//	Christmas
+prince jonah kuhio kalanianaole day		//	Prince Jonah Kuhio Kalanianaole Day
+prince jonah kuhio kalanianaole 's day	//	Prince Jonah Kuhio Kalanianaole Day
+prince jonah kūhiō kalanianaole day		//	Prince Jonah Kuhio Kalanianaole Day
+prince jonah kūhiō kalanianaole 's day	//	Prince Jonah Kuhio Kalanianaole Day
+prince kuhio day                        //	Prince Jonah Kuhio Kalanianaole Day
+prince kuhio 's day                     //	Prince Jonah Kuhio Kalanianaole Day
+prince kūhiō day                        //	Prince Jonah Kuhio Kalanianaole Day
+prince kūhiō 's day                     //	Prince Jonah Kuhio Kalanianaole Day
+kuhio day                       		//	Prince Jonah Kuhio Kalanianaole Day
+kuhio 's day                       		//	Prince Jonah Kuhio Kalanianaole Day
+kūhiō day                       		//	Prince Jonah Kuhio Kalanianaole Day
+kūhiō 's day                       		//	Prince Jonah Kuhio Kalanianaole Day
+independence day						//	Independence Day
+fourth of july						    //	Independence Day
+new years eve							//	New Years Eve
+new year 's eve							//	New Years Eve
+new year eve							//	New Years Eve
+jefferson davis day						//	Jefferson Davis Day
+jefferson davis ' day					//	Jefferson Davis Day
+jefferson davis birthday      			//	Jefferson Davis Day
+jefferson davis ' birthday				//	Jefferson Davis Day
+lee-jackson day							//	Lee-Jackson Day
+patriots ' day							//	Patriots' Day
+patriot 's day							//	Patriots' Day
+patriots day							//	Patriots' Day
+alaska day								//	Alaska Day
+victory day								//	Victory Day
+victory over japan day				    //	Victory Day
+vj day				                    //	Victory Day
+world war ii memorial day				//	Victory Day
+new year								//	New Year
+new year day							//	New Year
+new years day							//	New Year
+new year 's day							//	New Year
+veterans day							//	Veterans Day
+veterans ' day							//	Veterans Day
+armistice day							//	Veterans Day
+columbus day							//	Columbus Day
+columbus ' day							//	Columbus Day
+indigenous peoples day				    //	Columbus Day
+indigenous peoples ' day			    //	Columbus Day
+thanksgiving day						//	Thanksgiving Day
+thanksgiving    						//	Thanksgiving Day
+martin luther king, jr. day				//	Martin Luther King, Jr. Day
+martin luther king jr. day				//	Martin Luther King, Jr. Day
+mlk day                                 //	Martin Luther King, Jr. Day
+king day                                //	Martin Luther King, Jr. Day
+reverend dr. martin luther king jr. day //	Martin Luther King, Jr. Day
+good friday								//	Good Friday
+holy friday								//	Good Friday
+great friday							//	Good Friday
+great and holy friday					//	Good Friday
+holy and great friday					//	Good Friday
+casimir pulaski day						//	Casimir Pulaski Day
+casimir pulaski 's day					//	Casimir Pulaski Day
+memorial day							//	Memorial Day
+decoration day							//	Memorial Day
+service reduction day					//	Service Reduction Day
+kamehameha day							//	Kamehameha Day
+kamehameha 's day						//	Kamehameha Day
+king kamehameha day						//	Kamehameha Day
+king kamehameha 's day					//	Kamehameha Day
+king kamehameha i day                   //	Kamehameha Day
+pioneer day								//	Pioneer Day
+nevada day								//	Nevada Day
+

--- a/main/src/main/resources/org/clulab/numeric/atomic.yml
+++ b/main/src/main/resources/org/clulab/numeric/atomic.yml
@@ -47,3 +47,11 @@ rules:
     type: token
     pattern: |
       [entity=/B-SEASON/] [entity=/I-SEASON/]*
+
+  # possible holiday
+  - name: holiday-name
+    label: PossibleHoliday
+    priority: ${ rulepriority }
+    type: token
+    pattern: |
+      [entity=/B-HOLIDAY/] [entity=/I-HOLIDAY/]*

--- a/main/src/main/resources/org/clulab/numeric/atomic.yml
+++ b/main/src/main/resources/org/clulab/numeric/atomic.yml
@@ -50,7 +50,7 @@ rules:
 
   # possible holiday
   - name: holiday-name
-    label: PossibleHoliday
+    label: Holiday
     priority: ${ rulepriority }
     type: token
     pattern: |

--- a/main/src/main/resources/org/clulab/numeric/dates.yml
+++ b/main/src/main/resources/org/clulab/numeric/dates.yml
@@ -120,3 +120,13 @@ rules:
     pattern: |
       [word=/^(1\d\d\d|2\d\d\d)(:|\/|\-)(0?[1-9]|1[012])$/]
 
+  # Rule for holidays
+  - name: date-holiday
+    label: Date
+    priority: ${ rulepriority }
+    type: token
+    example: "It was Christmas 2021."
+    action: mkDateMentionHoliday
+    pattern: |
+      @holiday:PossibleHoliday @year:PossibleYear?
+

--- a/main/src/main/resources/org/clulab/numeric/dates.yml
+++ b/main/src/main/resources/org/clulab/numeric/dates.yml
@@ -138,5 +138,5 @@ rules:
     example: "It was Christmas 2021."
     action: mkDateMentionHoliday
     pattern: |
-      @holiday:PossibleHoliday @year:PossibleYear?
+      @holiday:Holiday @year:PossibleYear?
 

--- a/main/src/main/resources/org/clulab/numeric/master.yml
+++ b/main/src/main/resources/org/clulab/numeric/master.yml
@@ -3,6 +3,7 @@ taxonomy:
       - NumericEntity:
           - Atomic:
               - PossibleDay
+              - PossibleHoliday
               - PossibleMonth
               - PossibleSeason
               - PossibleYear
@@ -24,6 +25,7 @@ taxonomy:
               - NumberRange
               - Measurement
       - NamedEntity:
+          - Holiday
           - Month
           - MeasurementUnit
           - Season

--- a/main/src/main/scala/org/clulab/numeric/HolidayNormalizer.scala
+++ b/main/src/main/scala/org/clulab/numeric/HolidayNormalizer.scala
@@ -1,14 +1,16 @@
 package org.clulab.numeric
 
-import de.jollyday.{Holiday, HolidayManager}
+import de.jollyday.{Holiday, HolidayCalendar, HolidayManager, ManagerParameters}
 
 import collection.JavaConverters._
 
 object HolidayNormalizer {
 
-  /** Retrieves date for holiday */
+  /** Retrieves date (day and month) for holiday */
   def norm(holidaySeq: Seq[String], yearOpt: Option [Seq[String]]): Option[(String, String)] = {
-    val holidayManager = HolidayManager.getInstance()
+    val holidayManager = HolidayManager.getInstance(
+      ManagerParameters.create(HolidayCalendar.UNITED_STATES)
+    )
     val holiday = holidaySeq.mkString("_").toLowerCase()
     val year = yearOpt match {
       case Some(yearSeq) => yearSeq.mkString.toInt

--- a/main/src/main/scala/org/clulab/numeric/HolidayNormalizer.scala
+++ b/main/src/main/scala/org/clulab/numeric/HolidayNormalizer.scala
@@ -5,23 +5,31 @@ import de.jollyday.{Holiday, HolidayCalendar, HolidayManager, ManagerParameters}
 import collection.JavaConverters._
 
 object HolidayNormalizer {
+  private val normMapper = UnitNormalizer.readNormsFromResource("/org/clulab/numeric/HOLIDAY.tsv")
 
   private val holidayManager = HolidayManager.getInstance(
     ManagerParameters.create(HolidayCalendar.UNITED_STATES)
   )
 
-  /** Retrieves date (day and month) for holiday */
+  /** Retrieves date (day and month) for a holiday */
   def norm(holidaySeq: Seq[String], yearOpt: Option [Seq[String]]): Option[(String, String)] = {
-    val holiday = holidaySeq.mkString("_").toLowerCase()
-    val year = yearOpt match {
-      case Some(yearSeq) => yearSeq.mkString.toInt
-      case _ => java.time.LocalDate.now.getYear
-    }
-    val holidays: Array[Holiday] = holidayManager.getHolidays(year).asScala.toArray
-    holidays.filter(_.getPropertiesKey.toLowerCase == holiday) match {
-      case Array(h) =>
-        val date = h.getDate
-        Some((date.getDayOfMonth.toString, date.getMonthValue.toString))
+    val holiday = holidaySeq.mkString(" ").toLowerCase()
+    normMapper.get(holiday) match {
+      case Some(holidayCanonical) =>
+        // If year is None use current year as default
+        val year = yearOpt match {
+          case Some(yearSeq) => yearSeq.mkString.toInt
+          case _ => java.time.LocalDate.now.getYear
+        }
+        // Get holidays from jolliday for the U.S. and all the states.
+        val holidays: Array[Holiday] = holidayManager.getCalendarHierarchy.getChildren.keySet.asScala
+          .flatMap(holidayManager.getHolidays(year, _).asScala).toArray
+        holidays.filter(_.getDescription == holidayCanonical) match {
+          case Array(h) =>
+            val date = h.getDate
+            Some((date.getDayOfMonth.toString, date.getMonthValue.toString))
+          case _ => None
+        }
       case _ => None
     }
   }

--- a/main/src/main/scala/org/clulab/numeric/HolidayNormalizer.scala
+++ b/main/src/main/scala/org/clulab/numeric/HolidayNormalizer.scala
@@ -1,0 +1,25 @@
+package org.clulab.numeric
+
+import de.jollyday.{Holiday, HolidayManager}
+
+import collection.JavaConverters._
+
+object HolidayNormalizer {
+
+  /** Retrieves date for holiday */
+  def run(holidaySeq: Seq[String], yearOpt: Option [Seq[String]]): Option[(String, String)] = {
+    val holidayManager = HolidayManager.getInstance()
+    val holiday = holidaySeq.mkString("_").toLowerCase()
+    val year = yearOpt match {
+      case Some(yearSeq) => yearSeq.mkString.toInt
+      case _ => java.time.LocalDate.now.getYear
+    }
+    val holidays: Array[Holiday] = holidayManager.getHolidays(year).asScala.toArray
+    holidays.filter(_.getPropertiesKey.toLowerCase == holiday) match {
+      case Array(h) =>
+        val date = h.getDate
+        Some((date.getDayOfMonth.toString, date.getMonthValue.toString))
+      case _ => None
+    }
+  }
+}

--- a/main/src/main/scala/org/clulab/numeric/HolidayNormalizer.scala
+++ b/main/src/main/scala/org/clulab/numeric/HolidayNormalizer.scala
@@ -7,7 +7,7 @@ import collection.JavaConverters._
 object HolidayNormalizer {
 
   /** Retrieves date for holiday */
-  def run(holidaySeq: Seq[String], yearOpt: Option [Seq[String]]): Option[(String, String)] = {
+  def norm(holidaySeq: Seq[String], yearOpt: Option [Seq[String]]): Option[(String, String)] = {
     val holidayManager = HolidayManager.getInstance()
     val holiday = holidaySeq.mkString("_").toLowerCase()
     val year = yearOpt match {

--- a/main/src/main/scala/org/clulab/numeric/HolidayNormalizer.scala
+++ b/main/src/main/scala/org/clulab/numeric/HolidayNormalizer.scala
@@ -6,11 +6,12 @@ import collection.JavaConverters._
 
 object HolidayNormalizer {
 
+  private val holidayManager = HolidayManager.getInstance(
+    ManagerParameters.create(HolidayCalendar.UNITED_STATES)
+  )
+
   /** Retrieves date (day and month) for holiday */
   def norm(holidaySeq: Seq[String], yearOpt: Option [Seq[String]]): Option[(String, String)] = {
-    val holidayManager = HolidayManager.getInstance(
-      ManagerParameters.create(HolidayCalendar.UNITED_STATES)
-    )
     val holiday = holidaySeq.mkString("_").toLowerCase()
     val year = yearOpt match {
       case Some(yearSeq) => yearSeq.mkString.toInt

--- a/main/src/main/scala/org/clulab/numeric/NumericEntityRecognizer.scala
+++ b/main/src/main/scala/org/clulab/numeric/NumericEntityRecognizer.scala
@@ -73,6 +73,7 @@ object NumericEntityRecognizer {
       // These shouldn't start with a leading /.
       "org/clulab/numeric/MONTH.tsv",
       "org/clulab/numeric/MEASUREMENT-UNIT.tsv",
+      "org/clulab/numeric/HOLIDAY.tsv",
       if (seasonsPath.startsWith("/")) seasonsPath.drop(1) else seasonsPath
     )
     val isLocal = kbs.forall(new File(resourceDir, _).exists)
@@ -80,6 +81,7 @@ object NumericEntityRecognizer {
       kbs,
       Seq(
         false, // false = case sensitive matching
+        true,
         true,
         true // This should be the case for any seasonsPath.
       ),

--- a/main/src/main/scala/org/clulab/numeric/actions/NumericActions.scala
+++ b/main/src/main/scala/org/clulab/numeric/actions/NumericActions.scala
@@ -142,6 +142,11 @@ class NumericActions(seasonNormalizer: SeasonNormalizer) extends Actions {
     convert(mentions, toDateMentionYyMmDd, "toDateMentionYyMmDd")
   }
 
+  /** Constructs a DateMention from the yy-mm single token */
+  def mkDateMentionHoliday(mentions: Seq[Mention], state: State): Seq[Mention] = {
+    convert(mentions, toDateMentionHoliday, "toDateMentionHoliday")
+  }
+
   //
   // global actions below this points
   //

--- a/main/src/main/scala/org/clulab/numeric/mentions/package.scala
+++ b/main/src/main/scala/org/clulab/numeric/mentions/package.scala
@@ -730,7 +730,7 @@ package object mentions {
   }
 
   private def getHoliday(holiday: Seq[String], year: Option[Seq[String]]): (Option[Seq[String]], Option[Seq[String]]) = {
-    val dayMonthOpt = HolidayNormalizer.run(holiday, year)
+    val dayMonthOpt = HolidayNormalizer.norm(holiday, year)
     dayMonthOpt match {
       case Some((dayString, monthString)) =>
         (Some(Seq(dayString)), Some(Seq(monthString)))

--- a/main/src/main/scala/org/clulab/numeric/mentions/package.scala
+++ b/main/src/main/scala/org/clulab/numeric/mentions/package.scala
@@ -617,10 +617,7 @@ package object mentions {
       if(holiday.isEmpty)
         throw new RuntimeException(s"ERROR: could not find argument holiday in mention ${m.raw.mkString(" ")}!")
 
-      val year = getArgWords("year", m) match {
-        case Some(y) => Some(y)
-        case _ => None
-      }
+      val year = getArgWords("year", m)
 
       val (day, month) = getHoliday(holiday.get, year)
 
@@ -734,7 +731,7 @@ package object mentions {
     dayMonthOpt match {
       case Some((day, month)) =>
         (Some(Seq(day)), Some(Seq(month)))
-      case _ => throw new RuntimeException(s"ERROR: ${holiday.mkString(" ")} not found in holiday taxonomy!")
+      case _ => throw new RuntimeException(s"ERROR: cannot get date for ${holiday.mkString(" ")}!")
     }
   }
 

--- a/main/src/main/scala/org/clulab/numeric/mentions/package.scala
+++ b/main/src/main/scala/org/clulab/numeric/mentions/package.scala
@@ -732,9 +732,9 @@ package object mentions {
   private def getHoliday(holiday: Seq[String], year: Option[Seq[String]]): (Option[Seq[String]], Option[Seq[String]]) = {
     val dayMonthOpt = HolidayNormalizer.norm(holiday, year)
     dayMonthOpt match {
-      case Some((dayString, monthString)) =>
-        (Some(Seq(dayString)), Some(Seq(monthString)))
-      case _ => throw new RuntimeException(s"ERROR: ${holiday.mkString(" ")} is not a holiday!")
+      case Some((day, month)) =>
+        (Some(Seq(day)), Some(Seq(month)))
+      case _ => throw new RuntimeException(s"ERROR: ${holiday.mkString(" ")} not found in holiday taxonomy!")
     }
   }
 

--- a/main/src/test/scala/org/clulab/numeric/TestNumericEntityRecognition.scala
+++ b/main/src/test/scala/org/clulab/numeric/TestNumericEntityRecognition.scala
@@ -181,7 +181,13 @@ class TestNumericEntityRecognition extends FlatSpec with Matchers {
 
   it should "recognize date from holiday" in {
     ensure(sentence= "Christmas 2016", Interval(0, 2), goldEntity= "DATE", goldNorm= "2016-12-25")
-    ensure(sentence= "Independence day", Interval(0, 2), goldEntity= "DATE", goldNorm= "XXXX-07-04")
+    ensure(sentence= "Independence Day", Interval(0, 2), goldEntity= "DATE", goldNorm= "XXXX-07-04")
+    ensure(sentence= "independence day", Interval(0, 2), goldEntity= "DATE", goldNorm= "XXXX-07-04")
+    ensure(sentence= "New Years Eve", Interval(0, 2), goldEntity= "DATE", goldNorm= "XXXX-12-31")
+    ensure(sentence= "new year's eve", Interval(0, 2), goldEntity= "DATE", goldNorm= "XXXX-12-31")
+    ensure(sentence= "Martin Luther King Jr. Day 2022", Interval(0, 4), goldEntity= "DATE", goldNorm= "2022-01-17")
+    ensure(sentence= "MLK day 2022", Interval(0, 1), goldEntity= "DATE", goldNorm= "2022-01-17")
+    ensure(sentence= "before Patriots' day 2021", Interval(0, 2), goldEntity= "DATE-RANGE", goldNorm= "XXXX-XX-XX -- 2021-04-19")
     ensure(sentence= "between Christmas and New Year", Interval(0, 4), goldEntity= "DATE-RANGE", goldNorm= "XXXX-12-25 -- XXXX-01-01")
   }
 

--- a/main/src/test/scala/org/clulab/numeric/TestNumericEntityRecognition.scala
+++ b/main/src/test/scala/org/clulab/numeric/TestNumericEntityRecognition.scala
@@ -174,6 +174,12 @@ class TestNumericEntityRecognition extends FlatSpec with Matchers {
     ensure(sentence = "Planting dates are between July 1st and August 2nd.", Interval(3, 9), goldEntity = "DATE-RANGE", "XXXX-07-01 -- XXXX-08-02")
   }
 
+  it should "recognize date from holiday" in {
+    ensure(sentence= "Christmas 2016", Interval(0, 2), goldEntity= "DATE", goldNorm= "2016-12-25")
+    ensure(sentence= "Independence day", Interval(0, 2), goldEntity= "DATE", goldNorm= "XXXX-07-04")
+    ensure(sentence= "between Christmas and New Year", Interval(0, 4), goldEntity= "DATE-RANGE", goldNorm= "XXXX-12-25 -- XXXX-01-01")
+  }
+
   it should "recognize date ranges" in {
     ensure("between 2020/10/10 and 2020/11/11", Interval(0, 4), "DATE-RANGE", "2020-10-10 -- 2020-11-11")
     ensure("from July 20 to July 31", Interval(0, 6), "DATE-RANGE", "XXXX-07-20 -- XXXX-07-31")


### PR DESCRIPTION
This PR includes:
- a new lexicon for holidays extracted from the jollyday library.
- a HolidayNormalizer that uses the jollyday library to retrieve the month and day given a holiday mention and a year. If the year is not given, it uses the current year as default.
- a rule to identify time expressions with holidays.