### PR TITLE
Dev single month as date

### DIFF
--- a/main/src/main/resources/org/clulab/numeric/TimeNormEvalSet/WorldModelersDatesRangesTimex.csv
+++ b/main/src/main/resources/org/clulab/numeric/TimeNormEvalSet/WorldModelersDatesRangesTimex.csv
@@ -1,13 +1,20 @@
 CLiMIS_FAO_UNICEF_WFP_South_Sudan_IPC_Jun-16,499,510,XXXX-02-XX -- XXXX-06-XX
+CLiMIS_FAO_UNICEF_WFP_South_Sudan_IPC_Jun-16,592,604,ref-date -- XXXX-08-XX
+CLiMIS_FAO_UNICEF_WFP_South_Sudan_IPC_Jun-16,926,938,ref-date -- XXXX-07-XX
+CLiMIS_FAO_UNICEF_WFP_South_Sudan_IPC_Jun-16,963,968,XXXX-04-XX
+CLiMIS_FAO_UNICEF_WFP_South_Sudan_IPC_Jun-16,1872,1876,XXXX-06-XX
 CLiMIS_FAO_UNICEF_WFP_South_Sudan_IPC_Jun-16,2212,2222,2014-XX-XX -- ref-date
 CLiMIS_FAO_UNICEF_WFP_South_Sudan_IPC_Jun-16,2748,2759,XXXX-02-XX -- XXXX-06-XX
 CLiMIS_FAO_UNICEF_WFP_South_Sudan_IPC_Jun-16,2804,2808,2016-XX-XX
 CLiMIS_FAO_UNICEF_WFP_South_Sudan_IPC_Jun-16,3209,3213,2016-XX-XX
+Enhancing_Food_Security_in_South_Sudan_Nov-15,191,195,2015-XX-XX
+Enhancing_Food_Security_in_South_Sudan_Nov-15,565,569,2012-XX-XX
+Enhancing_Food_Security_in_South_Sudan_Nov-15,627,631,2014-XX-XX
+Enhancing_Food_Security_in_South_Sudan_Nov-15,634,644,2013-XX-XX -- ref-date
 Enhancing_Food_Security_in_South_Sudan_Nov-15,1056,1060,2011-XX-XX
 Enhancing_Food_Security_in_South_Sudan_Nov-15,1264,1268,2013-XX-XX
 Enhancing_Food_Security_in_South_Sudan_Nov-15,1485,1489,2013-XX-XX
 Enhancing_Food_Security_in_South_Sudan_Nov-15,1773,1785,XXXX-06-XX -- XXXX-10-XX
-Enhancing_Food_Security_in_South_Sudan_Nov-15,191,195,2015-XX-XX
 Enhancing_Food_Security_in_South_Sudan_Nov-15,2289,2293,2011-XX-XX
 Enhancing_Food_Security_in_South_Sudan_Nov-15,2982,2986,2013-XX-XX
 Enhancing_Food_Security_in_South_Sudan_Nov-15,3592,3604,XXXX-06-XX -- XXXX-10-XX
@@ -16,9 +23,6 @@ Enhancing_Food_Security_in_South_Sudan_Nov-15,3641,3645,2012-XX-XX
 Enhancing_Food_Security_in_South_Sudan_Nov-15,4047,4051,2015-XX-XX
 Enhancing_Food_Security_in_South_Sudan_Nov-15,4086,4090,2014-XX-XX
 Enhancing_Food_Security_in_South_Sudan_Nov-15,4270,4274,2015-XX-XX
-Enhancing_Food_Security_in_South_Sudan_Nov-15,565,569,2012-XX-XX
-Enhancing_Food_Security_in_South_Sudan_Nov-15,627,631,2014-XX-XX
-Enhancing_Food_Security_in_South_Sudan_Nov-15,634,644,2013-XX-XX -- ref-date
 Ethiopia_Food_Security_Outlook_1-Feb-17,125,160,2017-02-XX -- 2017-09-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,244,268,2016-10-XX -- 2016-12-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,274,280,XXXX-10-XX -- XXXX-11-XX
@@ -28,14 +32,18 @@ Ethiopia_Food_Security_Outlook_1-Feb-17,836,841,XXXX-09-XX -- XXXX-02-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,955,990,2017-02-XX -- 2017-09-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,998,1002,2017-XX-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,1145,1162,ref-date -- 2017-06-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,1442,1461,XXXX-10-XX -- XXXX-12-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,1462,1466,XXXX-10-XX -- XXXX-11-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,1845,1849,XXXX-10-XX -- XXXX-11-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,1845,1861,2016-10-XX -- 2016-11-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,1911,1928,2016-03-XX -- 2016-05-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,1972,2002,2016-07-XX -- 2016-12-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,2024,2034,1982-XX-XX -- ref-date
+Ethiopia_Food_Security_Outlook_1-Feb-17,2181,2194,2017-02-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,2502,2523,2016-06-XX -- 2016-10-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,2731,2746,2016-XX-XX -- ref-date
+Ethiopia_Food_Security_Outlook_1-Feb-17,3443,3451,XXXX-02-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,3668,3689,XXXX-03-XX -- XXXX-05-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,4058,4087,2016-06-XX -- 2016-09-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,4237,4242,XXXX-09-XX -- XXXX-02-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,4265,4275,2016-09-XX -- 2017-02-XX
@@ -43,6 +51,7 @@ Ethiopia_Food_Security_Outlook_1-Feb-17,4344,4348,2015-XX-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,4422,4432,2016-09-XX -- 2017-02-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,4489,4493,2015-XX-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,4809,4819,2016-09-XX -- 2017-02-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,5022,5050,XXXX-11-XX -- XXXX-01-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,5092,5097,XXXX-09-XX -- XXXX-02-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,5712,5750,2016-12-XX -- 2017-01-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,5965,5977,2016-01-XX
@@ -59,13 +68,20 @@ Ethiopia_Food_Security_Outlook_1-Feb-17,8109,8138,2017-01-XX -- 2017-06-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,8222,8226,XXXX-04-XX -- XXXX-05-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,8330,8336,XXXX-06-XX -- XXXX-09-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,8343,8374,2017-06-XX -- 2017-09-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,8582,8587,XXXX-03-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,8689,8691,XXXX-04-XX -- XXXX-05-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,8707,8728,XXXX-03-XX -- XXXX-05-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,8873,8899,XXXX-06-XX -- XXXX-09-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,9109,9136,XXXX-03-XX -- XXXX-09-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,9249,9261,XXXX-03-XX -- XXXX-05-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,9560,9582,ref-date -- 2017-09-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,9748,9760,XXXX-03-XX -- XXXX-05-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,10474,10478,XXXX-06-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,10577,10581,2017-XX-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,10629,10659,2017-02-XX -- 2017-06-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,10980,11006,2017-06-XX -- 2017-12-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,11298,11323,2017-03-XX -- 2017-05-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,11102,11107,XXXX-09-XX -- XXXX-02-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,11298,11323,2017-03-XX -- 2017-05-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,11367,11377,2016-09-XX -- 2017-02-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,11568,11578,2016-09-XX -- 2017-02-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,11697,11719,2017-06-XX -- 2017-09-XX
@@ -74,6 +90,8 @@ Ethiopia_Food_Security_Outlook_1-Feb-17,11788,11800,2017-10-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,12092,12096,2016-XX-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,12384,12397,2017-05-XX -- 2017-06-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,12473,12478,XXXX-09-XX -- XXXX-02-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,12488,12496,XXXX-11-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,12497,12505,XXXX-12-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,12506,12511,XXXX-09-XX -- XXXX-02-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,12677,12706,2017-01-XX -- 2017-06-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,12801,12830,2016-01-XX -- 2016-06-XX
@@ -97,15 +115,21 @@ Ethiopia_Food_Security_Outlook_1-Feb-17,14782,14788,XXXX-06-XX -- XXXX-09-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,14782,14813,2016-06-XX -- 2016-09-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,14790,14813,2016-06-XX -- 2016-09-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,15051,15062,2016-06-XX -- 2016-09-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,15129,15133,XXXX-07-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,15138,15144,XXXX-08-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,15207,15213,XXXX-06-XX -- XXXX-09-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,15299,15303,2015-XX-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,15324,15334,2016-09-XX -- 2017-02-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,15407,15413,XXXX-06-XX -- XXXX-09-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,15488,15492,XXXX-07-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,15497,15503,XXXX-08-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,16656,16661,XXXX-09-XX -- XXXX-02-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,16909,16922,2016-12-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,16965,16978,2016-11-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,17125,17138,2016-12-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,17410,17418,XXXX-12-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,17442,17451,2016-XX-XX -- ref-date
+Ethiopia_Food_Security_Outlook_1-Feb-17,17509,17517,XXXX-12-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,17679,17706,2016-05-XX -- 2016-10-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,18288,18317,2017-01-XX -- 2017-06-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,19001,19023,2017-03-XX -- 2017-05-XX
@@ -116,6 +140,7 @@ Ethiopia_Food_Security_Outlook_1-Feb-17,19726,19730,XXXX-04-XX -- XXXX-05-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,19726,19746,2017-04-XX -- 2017-05-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,19735,19746,2017-06-XX -- 2017-09-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,19929,19940,XXXX-02-XX -- XXXX-06-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,19944,19958,2017-09-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,20260,20270,2016-09-XX -- 2017-02-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,20756,20778,ref-date -- 2017-09-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,20886,20915,2017-02-XX -- 2017-05-XX
@@ -140,18 +165,23 @@ Ethiopia_Food_Security_Outlook_1-Feb-17,25081,25093,2017-01-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,25246,25258,2017-01-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,25496,25527,2017-02-XX -- 2017-03-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,25562,25569,2017-04-XX -- 2017-05-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,25636,25648,ref-date -- XXXX-06-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,25712,25734,XXXX-07-XX -- XXXX-09-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,25836,25858,XXXX-04-XX -- XXXX-05-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,25911,25943,ref-data -- 2017-10-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,25953,25965,2017-10-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,26247,26269,ref-date -- 2017-09-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,26761,26763,XXXX-04-XX -- XXXX-05-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,26674,26698,2016-10-XX -- 2016-12-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,26699,26703,XXXX-10-XX -- XXXX-11-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,26743,26760,2017-03-XX -- 2017-05-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,26761,26763,XXXX-04-XX -- XXXX-05-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,27340,27374,2017-02-XX -- 2017-09-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,27570,27601,2017-06-XX -- 2017-09-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,27644,27668,2016-10-XX -- 2016-12-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,27819,27846,2016-12-XX -- 2017-03-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,28391,28416,XXXX-01-XX -- XXXX-03-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,28421,28425,XXXX-07-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,28430,28439,XXXX-09-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,28837,28849,2017-01-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,28865,28877,2016-01-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,28989,29001,2016-01-XX
@@ -163,12 +193,14 @@ Ethiopia_Food_Security_Outlook_1-Feb-17,29663,29685,2017-06-XX -- 2017-09-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,29785,29820,2017-02-XX -- 2017-09-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,29853,29874,ref-date -- 2016-10-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,30319,30339,2017-03-XX -- 2017-05-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,30512,30529,XXXX-06-XX -- XXXX-09-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,30658,30665,2017-04-XX -- 2017-05-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,31237,31272,2017-02-XX -- 2017-09-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,31357,31381,2016-10-XX -- 2016-12-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,31540,31549,2001-XX-XX -- 2016-XX-XX
-Ethiopia_Food_Security_Outlook_1-Feb-17,31630,31640,2001-XX-XX -- ref-date
 Ethiopia_Food_Security_Outlook_1-Feb-17,31387,31393,XXXX-10-XX -- XXXX-11-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,31540,31549,2001-XX-XX -- 2016-XX-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,31603,31622,XXXX-10-XX -- XXXX-12-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,31630,31640,2001-XX-XX -- ref-date
 Ethiopia_Food_Security_Outlook_1-Feb-17,31848,31852,XXXX-10-XX -- XXXX-11-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,31853,31859,XXXX-10-XX -- XXXX-11-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,31860,31872,XXXX-06-XX -- XXXX-10-XX
@@ -179,91 +211,166 @@ Ethiopia_Food_Security_Outlook_1-Feb-17,32114,32127,2017-02-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,32390,32402,2017-01-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,32730,32742,2017-01-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,33121,33134,2016-12-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,33554,33577,XXXX-01-XX -- XXXX-06-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,33594,33617,2017-03-XX -- 2017-05-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,34145,34157,XXXX-06-XX -- XXXX-10-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,34191,34203,XXXX-06-XX -- XXXX-10-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,34361,34383,ref-date -- 2017-09-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,34589,34598,2016-06-XX
+Ethiopia_Food_Security_Outlook_1-Feb-17,34608,34616,XXXX-12-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,34650,34654,2017-XX-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,35396,35418,ref-date -- 2017-09-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,35556,35560,2017-XX-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,36406,36423,2017-03-XX -- 2017-05-XX
 Ethiopia_Food_Security_Outlook_1-Feb-17,36653,36675,ref-date -- 2017-09-XX
 FAO_GIEWS_South_Sudan_Country_Brief_Sep-17,80,93,2017-02-XX
+FAO_GIEWS_South_Sudan_Country_Brief_Sep-17,187,191,XXXX-06-XX
+FAO_GIEWS_South_Sudan_Country_Brief_Sep-17,316,324,XXXX-02-XX
+FAO_GIEWS_South_Sudan_Country_Brief_Sep-17,344,348,XXXX-06-XX
+FAO_GIEWS_South_Sudan_Country_Brief_Sep-17,598,606,XXXX-02-XX
+FAO_GIEWS_South_Sudan_Country_Brief_Sep-17,640,644,XXXX-06-XX
+FAO_GIEWS_South_Sudan_Country_Brief_Sep-17,1594,1600,XXXX-08-XX
+FAO_GIEWS_South_Sudan_Country_Brief_Sep-17,1781,1786,XXXX-04-XX
+FAO_GIEWS_South_Sudan_Country_Brief_Sep-17,1987,2011,XXXX-11-XX -- XXXX-01-XX
 FAO_GIEWS_South_Sudan_Country_Brief_Sep-17,2187,2191,2017-XX-XX
 FAO_GIEWS_South_Sudan_Country_Brief_Sep-17,2657,2661,2016-XX-XX
+FAO_GIEWS_South_Sudan_Country_Brief_Sep-17,3234,3238,XXXX-06-XX
+FAO_GIEWS_South_Sudan_Country_Brief_Sep-17,3413,3436,XXXX-06-XX -- XXXX-08-XX
+FAO_GIEWS_South_Sudan_Country_Brief_Sep-17,3785,3791,XXXX-08-XX
+FAO_GIEWS_South_Sudan_Country_Brief_Sep-17,3834,3840,XXXX-08-XX
+FAO_GIEWS_South_Sudan_Country_Brief_Sep-17,3881,3887,XXXX-08-XX
+FEWS_NET_South_Sudan_Famine_Risk_Alert_Jan-17,209,220,XXXX-02-XX -- XXXX-06-XX
 FEWS_NET_South_Sudan_Famine_Risk_Alert_Jan-17,806,815,2016-07-XX
+FEWS_NET_South_Sudan_Famine_Risk_Alert_Jan-17,945,955,XXXX-07-XX -- ref-date
 FEWS_NET_South_Sudan_Famine_Risk_Alert_Jan-17,1295,1299,2016-XX-XX
 FEWS_NET_South_Sudan_Famine_Risk_Alert_Jan-17,1545,1555,2014-XX-XX -- ref-date
 FEWS_NET_South_Sudan_Famine_Risk_Alert_Jan-17,2040,2161,2015-XX-XX
 FEWS_NET_South_Sudan_Famine_Risk_Alert_Jan-17,2193,2206,2013-11-XX
 FEWS_NET_South_Sudan_Famine_Risk_Alert_Jan-17,3059,3094,2016-09-XX -- 2016-11-XX
+FEWS_NET_South_Sudan_Famine_Risk_Alert_Jan-17,3256,3272,XXXX-02-XX -- XXXX-07-XX
+FEWS_NET_South_Sudan_Famine_Risk_Alert_Jan-17,3273,3284,XXXX-02-XX -- XXXX-06-XX
+FEWS_NET_South_Sudan_Famine_Risk_Alert_Jan-17,3337,3348,XXXX-02-XX -- XXXX-06-XX
 FEWS_NET_South_Sudan_Famine_Risk_Alert_Jan-17,3689,3693,2017-XX-XX
 FEWS_NET_South_Sudan_Famine_Risk_Alert_Jan-17,3863,3879,2016-02-XX -- 2016-06-XX
+FEWS_NET_South_Sudan_Famine_Risk_Alert_Jan-17,4208,4231,XXXX-08-XX -- XXXX-11-XX
+FEWS_NET_South_Sudan_Outlook_Jan-18,99,106,XXXX-01-XX
 FEWS_NET_South_Sudan_Outlook_Jan-18,268,284,2018-02-XX -- 2018-06-XX
-FEWS_NET_South_Sudan_Outlook_Jan-18,2424,2441,ref-date -- 2018-07-XX
-FEWS_NET_South_Sudan_Famine_Risk_Alert_Jan-17,3337,3348,XXXX-02-XX -- XXXX-06-XX
-FEWS_NET_South_Sudan_Famine_Risk_Alert_Jan-17,209,220,XXXX-02-XX -- XXXX-06-XX
-FEWS_NET_South_Sudan_Famine_Risk_Alert_Jan-17,3273,3284,XXXX-02-XX -- XXXX-06-XX
 FEWS_NET_South_Sudan_Outlook_Jan-18,394,405,XXXX-02-XX -- XXXX-06-XX
-FFP_Fact_Sheet_South_Sudan_Jan-18,1149,1161,2017-01-XX
-FFP_Fact_Sheet_South_Sudan_Jan-18,1969,1976,2017-XX-XX
-FFP_Fact_Sheet_South_Sudan_Jan-18,350,382,2017-XX-XX
-FFP_Fact_Sheet_South_Sudan_Jan-18,514,531,2018-02-XX -- 2018-06-XX
+FEWS_NET_South_Sudan_Outlook_Jan-18,409,413,XXXX-07-XX
+FEWS_NET_South_Sudan_Outlook_Jan-18,414,420,XXXX-08-XX
+FEWS_NET_South_Sudan_Outlook_Jan-18,1299,1307,XXXX-12-XX
+FEWS_NET_South_Sudan_Outlook_Jan-18,2047,2055,XXXX-12-XX
+FEWS_NET_South_Sudan_Outlook_Jan-18,2060,2067,XXXX-01-XX
+FEWS_NET_South_Sudan_Outlook_Jan-18,2226,2233,XXXX-01-XX
+FEWS_NET_South_Sudan_Outlook_Jan-18,2240,2248,XXXX-02-XX
+FEWS_NET_South_Sudan_Outlook_Jan-18,2424,2441,ref-date -- 2018-07-XX
 FFP_Fact_Sheet_South_Sudan_Jan-18,135,151,2017-02-XX -- 2017-06-XX
 FFP_Fact_Sheet_South_Sudan_Jan-18,140,151,XXXX-02-XX -- XXXX-06-XX
-Food_Assistance_Outlook_Brief_1-Jan-18,3263,3274,XXXX-02-XX -- XXXX-06-XX
+FFP_Fact_Sheet_South_Sudan_Jan-18,155,164,XXXX-09-XX
+FFP_Fact_Sheet_South_Sudan_Jan-18,350,382,2017-XX-XX
+FFP_Fact_Sheet_South_Sudan_Jan-18,484,508,XXXX-10-XX -- XXXX-12-XX
+FFP_Fact_Sheet_South_Sudan_Jan-18,514,531,2018-02-XX -- 2018-06-XX
+FFP_Fact_Sheet_South_Sudan_Jan-18,541,548,XXXX-01-XX
+FFP_Fact_Sheet_South_Sudan_Jan-18,694,707,ref-date -- XXXX-03-XX
+FFP_Fact_Sheet_South_Sudan_Jan-18,1149,1161,2017-01-XX
+FFP_Fact_Sheet_South_Sudan_Jan-18,1969,1976,2017-XX-XX
+Food_Assistance_Outlook_Brief_1-Jan-18,221,230,2018-07-XX
+Food_Assistance_Outlook_Brief_1-Jan-18,369,373,XXXX-07-XX
 Food_Assistance_Outlook_Brief_1-Jan-18,393,404,XXXX-02-XX -- XXXX-06-XX
-Food_Assistance_Outlook_Brief_1-Jan-18,1896,1898,XXXX-04-XX -- XXXX-05-XX
-Food_Assistance_Outlook_Brief_1-Jan-18,1819,1823,XXXX-10-XX -- XXXX-11-XX
-Food_Assistance_Outlook_Brief_1-Jan-18,2625,2636,XXXX-02-XX -- XXXX-06-XX
+Food_Assistance_Outlook_Brief_1-Jan-18,630,642,ref-date -- XXXX-07-XX
+Food_Assistance_Outlook_Brief_1-Jan-18,914,930,2018-02-XX -- 2018-06-XX
 Food_Assistance_Outlook_Brief_1-Jan-18,1151,1155,2017-XX-XX
 Food_Assistance_Outlook_Brief_1-Jan-18,1284,1300,2018-01-XX -- 2018-03-XX
 Food_Assistance_Outlook_Brief_1-Jan-18,1510,1522,ref-date -- 2018-XX-XX
 Food_Assistance_Outlook_Brief_1-Jan-18,1794,1814,2018-01-XX -- 2018-03-XX
-Food_Assistance_Outlook_Brief_1-Jan-18,221,230,2018-07-XX
+Food_Assistance_Outlook_Brief_1-Jan-18,1819,1823,XXXX-10-XX -- XXXX-11-XX
+Food_Assistance_Outlook_Brief_1-Jan-18,1879,1886,XXXX-01-XX
+Food_Assistance_Outlook_Brief_1-Jan-18,1896,1898,XXXX-04-XX -- XXXX-05-XX
+Food_Assistance_Outlook_Brief_1-Jan-18,1946,1950,XXXX-07-XX
 Food_Assistance_Outlook_Brief_1-Jan-18,2316,2336,2018-01-XX -- 2018-04-XX
+Food_Assistance_Outlook_Brief_1-Jan-18,2625,2636,XXXX-02-XX -- XXXX-06-XX
+Food_Assistance_Outlook_Brief_1-Jan-18,2640,2650,2018-04-XX
 Food_Assistance_Outlook_Brief_1-Jan-18,2721,2738,2018-03-XX -- 2018-06-XX
+Food_Assistance_Outlook_Brief_1-Jan-18,2989,3002,ref-date -- XXXX-04-XX
+Food_Assistance_Outlook_Brief_1-Jan-18,3037,3048,XXXX-04-XX -- XXXX-XX-XX
+Food_Assistance_Outlook_Brief_1-Jan-18,3263,3274,XXXX-02-XX -- XXXX-06-XX
+Food_Assistance_Outlook_Brief_1-Jan-18,3325,3332,XXXX-01-XX
+Food_Assistance_Outlook_Brief_1-Jan-18,3337,3340,XXXX-05-XX
+Food_Assistance_Outlook_Brief_1-Jan-18,3361,3365,XXXX-07-XX
 Food_Assistance_Outlook_Brief_1-Jan-18,3617,3631,2018-03-XX -- 2018-05-XX
+Food_Assistance_Outlook_Brief_1-Jan-18,4059,4067,XXXX-02-XX
 Food_Assistance_Outlook_Brief_1-Jan-18,4072,4097,2018-02-XX -- 2018-09-XX
-Food_Assistance_Outlook_Brief_1-Jan-18,914,930,2018-02-XX -- 2018-06-XX
+Price_Watch_28-Feb-18,1206,1217,XXXX-02-XX -- XXXX-06-XX
+Price_Watch_28-Feb-18,2163,2170,XXXX-01-XX
+Price_Watch_28-Feb-18,2378,2397,2014-12-XX -- ref-date
+Price_Watch_28-Feb-18,3066,3073,XXXX-01-XX
+Price_Watch_28-Feb-18,3666,3670,2018-XX-XX
+Price_Watch_28-Feb-18,5021,5028,XXXX-01-XX
+Price_Watch_28-Feb-18,5475,5479,2017-XX-XX
+Price_Watch_28-Feb-18,6346,6351,XXXX-03-XX
+Price_Watch_28-Feb-18,6352,6357,XXXX-04-XX
+Price_Watch_28-Feb-18,6415,6426,XXXX-02-XX -- XXXX-06-XX
+Price_Watch_28-Feb-18,6954,6958,XXXX-06-XX
+Price_Watch_28-Feb-18,6966,6977,XXXX-02-XX -- XXXX-06-XX
+Price_Watch_28-Feb-18,7039,7042,XXXX-05-XX
+Price_Watch_28-Feb-18,9952,9963,XXXX-02-XX -- XXXX-06-XX
 Price_Watch_28-Feb-18,10119,10123,2017-XX-XX
+Price_Watch_28-Feb-18,10274,10281,XXXX-01-XX
 Price_Watch_28-Feb-18,10627,10631,2017-XX-XX
 Price_Watch_28-Feb-18,10838,10851,2017-11-XX
+Price_Watch_28-Feb-18,11066,11073,XXXX-01-XX
 Price_Watch_28-Feb-18,11536,11554,ref-date -- 2018-03-XX
 Price_Watch_28-Feb-18,11885,11889,2018-XX-XX
+Price_Watch_28-Feb-18,12105,12118,ref-date -- XXXX-03-XX
+Price_Watch_28-Feb-18,12170,12182,XXXX-03-XX -- XXXX-XX-XX
 Price_Watch_28-Feb-18,12207,12211,2018-XX-XX
+Price_Watch_28-Feb-18,12281,12286,XXXX-03-XX
+Price_Watch_28-Feb-18,12381,12386,XXXX-03-XX
+Price_Watch_28-Feb-18,13193,13200,XXXX-01-XX
+Price_Watch_28-Feb-18,13354,13361,XXXX-01-XX
+Price_Watch_28-Feb-18,13683,13690,XXXX-01-XX
 Price_Watch_28-Feb-18,13722,13726,2017-XX-XX
+Price_Watch_28-Feb-18,14414,14421,XXXX-01-XX
+Price_Watch_28-Feb-18,14631,14644,ref-date -- XXXX-04-XX
+Price_Watch_28-Feb-18,14734,14739,XXXX-04-XX
 Price_Watch_28-Feb-18,14915,14931,ref-date -- 2018-05-XX
+Price_Watch_28-Feb-18,15278,15286,XXXX-02-XX
 Price_Watch_28-Feb-18,15420,15441,2018-03-20 -- 2018-05-21
+Price_Watch_28-Feb-18,16110,16118,XXXX-12-XX
 Price_Watch_28-Feb-18,16193,16216,ref-date -- 2017-XX-XX
 Price_Watch_28-Feb-18,16237,16241,2016-XX-XX
 Price_Watch_28-Feb-18,16330,16368,2017-12-XX -- 2018-01-XX
+Price_Watch_28-Feb-18,16430,16458,XXXX-12-XX -- XXXX-01-XX
 Price_Watch_28-Feb-18,16502,16506,2017-XX-XX
+Price_Watch_28-Feb-18,16674,16702,XXXX-12-XX -- XXXX-01-XX
 Price_Watch_28-Feb-18,16780,16784,2017-XX-XX
 Price_Watch_28-Feb-18,16955,16967,2017-01-XX
 Price_Watch_28-Feb-18,17049,17061,2017-01-XX
+Price_Watch_28-Feb-18,17327,17334,XXXX-01-XX
 Price_Watch_28-Feb-18,17540,17544,2017-XX-XX
-Price_Watch_28-Feb-18,2378,2397,2014-12-XX -- ref-date
-Price_Watch_28-Feb-18,3666,3670,2018-XX-XX
-Price_Watch_28-Feb-18,5475,5479,2017-XX-XX
-Price_Watch_28-Feb-18,9952,9963,XXXX-02-XX -- XXXX-06-XX
-Price_Watch_28-Feb-18,1206,1217,XXXX-02-XX -- XXXX-06-XX
-Price_Watch_28-Feb-18,6966,6977,XXXX-02-XX -- XXXX-06-XX
-Price_Watch_28-Feb-18,6415,6426,XXXX-02-XX -- XXXX-06-XX
+South_Sudan_Humanitarian_Response_Plan_Jan-18,95,99,2018-XX-XX
 South_Sudan_Humanitarian_Response_Plan_Jan-18,1028,1041,2017-02-XX
 South_Sudan_Humanitarian_Response_Plan_Jan-18,1091,1095,2018-XX-XX
 South_Sudan_Humanitarian_Response_Plan_Jan-18,1136,1162,2018-01-XX -- 2018-03-XX
+South_Sudan_Humanitarian_Response_Plan_Jan-18,1418,1429,XXXX-02-XX -- XXXX-06-XX
+South_Sudan_Humanitarian_Response_Plan_Jan-18,1589,1610,2018-02-XX -- 2018-06-XX
+South_Sudan_Humanitarian_Response_Plan_Jan-18,1599,1610,XXXX-02-XX -- XXXX-06-XX
 South_Sudan_Humanitarian_Response_Plan_Jan-18,2146,2150,2017-XX-XX
 South_Sudan_Humanitarian_Response_Plan_Jan-18,2178,2182,2018-XX-XX
 South_Sudan_Humanitarian_Response_Plan_Jan-18,2580,2584,2018-XX-XX
-South_Sudan_Humanitarian_Response_Plan_Jan-18,95,99,2018-XX-XX
-South_Sudan_Humanitarian_Response_Plan_Jan-18,1589,1610,2018-02-XX -- 2018-06-XX
-South_Sudan_Humanitarian_Response_Plan_Jan-18,1599,1610,XXXX-02-XX -- XXXX-06-XX
-South_Sudan_Humanitarian_Response_Plan_Jan-18,1418,1429,XXXX-02-XX -- XXXX-06-XX
-South_Sudanese_Risk_Facing_Famine_Jan-18,1244,1257,2013-12-XX
-South_Sudanese_Risk_Facing_Famine_Jan-18,958,971,2017-12-XX
 South_Sudanese_Risk_Facing_Famine_Jan-18,208,219,XXXX-02-XX -- XXXX-06-XX
+South_Sudanese_Risk_Facing_Famine_Jan-18,237,242,XXXX-03-XX
+South_Sudanese_Risk_Facing_Famine_Jan-18,958,971,2017-12-XX
+South_Sudanese_Risk_Facing_Famine_Jan-18,1244,1257,2013-12-XX
+TECHNICAL_BRIEF_(RE)ASSESSING_THE_RELATIONSHIP_BETWEEN_FOOD_AID_AND_ARMED_CONFLICT_Oct-14,695,699,2014-XX-XX
+TECHNICAL_BRIEF_(RE)ASSESSING_THE_RELATIONSHIP_BETWEEN_FOOD_AID_AND_ARMED_CONFLICT_Oct-14,862,883,1971-XX-XX -- 2006-XX-XX
+TECHNICAL_BRIEF_(RE)ASSESSING_THE_RELATIONSHIP_BETWEEN_FOOD_AID_AND_ARMED_CONFLICT_Oct-14,8251,8255,1975-XX-XX
+TECHNICAL_BRIEF_(RE)ASSESSING_THE_RELATIONSHIP_BETWEEN_FOOD_AID_AND_ARMED_CONFLICT_Oct-14,8271,8275,2005-XX-XX
+TECHNICAL_BRIEF_(RE)ASSESSING_THE_RELATIONSHIP_BETWEEN_FOOD_AID_AND_ARMED_CONFLICT_Oct-14,8284,8288,2009-XX-XX
+TECHNICAL_BRIEF_(RE)ASSESSING_THE_RELATIONSHIP_BETWEEN_FOOD_AID_AND_ARMED_CONFLICT_Oct-14,8298,8302,2011-XX-XX
+TECHNICAL_BRIEF_(RE)ASSESSING_THE_RELATIONSHIP_BETWEEN_FOOD_AID_AND_ARMED_CONFLICT_Oct-14,9620,9624,2004-XX-XX
+TECHNICAL_BRIEF_(RE)ASSESSING_THE_RELATIONSHIP_BETWEEN_FOOD_AID_AND_ARMED_CONFLICT_Oct-14,9642,9646,2008-XX-XX
+TECHNICAL_BRIEF_(RE)ASSESSING_THE_RELATIONSHIP_BETWEEN_FOOD_AID_AND_ARMED_CONFLICT_Oct-14,9784,9788,2008-XX-XX
 TECHNICAL_BRIEF_(RE)ASSESSING_THE_RELATIONSHIP_BETWEEN_FOOD_AID_AND_ARMED_CONFLICT_Oct-14,10259,10263,1970-XX-XX
 TECHNICAL_BRIEF_(RE)ASSESSING_THE_RELATIONSHIP_BETWEEN_FOOD_AID_AND_ARMED_CONFLICT_Oct-14,10280,10284,2007-XX-XX
 TECHNICAL_BRIEF_(RE)ASSESSING_THE_RELATIONSHIP_BETWEEN_FOOD_AID_AND_ARMED_CONFLICT_Oct-14,10303,10307,2007-XX-XX
@@ -285,43 +392,54 @@ TECHNICAL_BRIEF_(RE)ASSESSING_THE_RELATIONSHIP_BETWEEN_FOOD_AID_AND_ARMED_CONFLI
 TECHNICAL_BRIEF_(RE)ASSESSING_THE_RELATIONSHIP_BETWEEN_FOOD_AID_AND_ARMED_CONFLICT_Oct-14,20009,20013,2010-XX-XX
 TECHNICAL_BRIEF_(RE)ASSESSING_THE_RELATIONSHIP_BETWEEN_FOOD_AID_AND_ARMED_CONFLICT_Oct-14,20082,20086,2010-XX-XX
 TECHNICAL_BRIEF_(RE)ASSESSING_THE_RELATIONSHIP_BETWEEN_FOOD_AID_AND_ARMED_CONFLICT_Oct-14,20376,20380,2012-XX-XX
-TECHNICAL_BRIEF_(RE)ASSESSING_THE_RELATIONSHIP_BETWEEN_FOOD_AID_AND_ARMED_CONFLICT_Oct-14,695,699,2014-XX-XX
-TECHNICAL_BRIEF_(RE)ASSESSING_THE_RELATIONSHIP_BETWEEN_FOOD_AID_AND_ARMED_CONFLICT_Oct-14,8251,8255,1975-XX-XX
-TECHNICAL_BRIEF_(RE)ASSESSING_THE_RELATIONSHIP_BETWEEN_FOOD_AID_AND_ARMED_CONFLICT_Oct-14,8271,8275,2005-XX-XX
-TECHNICAL_BRIEF_(RE)ASSESSING_THE_RELATIONSHIP_BETWEEN_FOOD_AID_AND_ARMED_CONFLICT_Oct-14,8284,8288,2009-XX-XX
-TECHNICAL_BRIEF_(RE)ASSESSING_THE_RELATIONSHIP_BETWEEN_FOOD_AID_AND_ARMED_CONFLICT_Oct-14,8298,8302,2011-XX-XX
-TECHNICAL_BRIEF_(RE)ASSESSING_THE_RELATIONSHIP_BETWEEN_FOOD_AID_AND_ARMED_CONFLICT_Oct-14,862,883,1971-XX-XX -- 2006-XX-XX
-TECHNICAL_BRIEF_(RE)ASSESSING_THE_RELATIONSHIP_BETWEEN_FOOD_AID_AND_ARMED_CONFLICT_Oct-14,9620,9624,2004-XX-XX
-TECHNICAL_BRIEF_(RE)ASSESSING_THE_RELATIONSHIP_BETWEEN_FOOD_AID_AND_ARMED_CONFLICT_Oct-14,9642,9646,2008-XX-XX
-TECHNICAL_BRIEF_(RE)ASSESSING_THE_RELATIONSHIP_BETWEEN_FOOD_AID_AND_ARMED_CONFLICT_Oct-14,9784,9788,2008-XX-XX
-UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,10204,10233,2017-04-01 -- 2017-03-15
+UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,3,7,2017-XX-XX
+UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,153,165,XXXX-01-XX -- ref-date
+UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,178,186,XXXX-02-XX
+UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,766,776,2017-03-XX
+UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,1010,1013,XXXX-05-XX
+UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,1319,1323,XXXX-04-XX -- XXXX-05-XX
+UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,1337,1349,XXXX-06-XX -- XXXX-10-XX
 UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,1631,1635,2017-XX-XX
-UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,16892,16905,2017-02-XX
 UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,1728,1732,2017-XX-XX
+UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,1885,1890,XXXX-09-XX -- XXXX-02-XX
+UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,2119,2123,XXXX-04-XX -- XXXX-05-XX
 UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,2312,2347,2017-01-01 -- 2017-03-14
+UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,2599,2621,XXXX-04-01 -- XXXX-04-12
 UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,2703,2723,2016-09-XX -- ref-date
 UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,2738,2748,2017-03-XX
 UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,2861,2874,2017-02-XX
 UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,2907,2927,2016-09-XX -- ref-date
-UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,3,7,2017-XX-XX
 UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,3013,3025,2016-10-XX
 UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,5409,5442,2017-01-XX -- 2017-02-XX
+UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,5527,5539,XXXX-01-XX -- ref-date
+UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,5552,5560,XXXX-02-XX
 UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,5810,5823,2016-12-XX
 UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,5836,5848,2017-01-XX
 UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,5871,5884,2017-02-XX
-UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,766,776,2017-03-XX
+UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,7160,7166,XXXX-03-20 -- XXXX-06-21
+UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,7167,7171,XXXX-04-XX -- XXXX-05-XX
+UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,7583,7595,XXXX-06-XX -- XXXX-10-XX
 UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,7995,7999,2017-XX-XX
 UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,8563,8578,2016-07-XX -- ref-date
 UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,9713,9731,2017-01-XX -- ref-date
-UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,7583,7595,XXXX-06-XX -- XXXX-10-XX
-UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,2119,2123,XXXX-04-XX -- XXXX-05-XX
-UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,2599,2621,XXXX-04-01 -- XXXX-04-12
-UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,1337,1349,XXXX-06-XX -- XXXX-10-XX
-UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,7167,7171,XXXX-04-XX -- XXXX-05-XX
-UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,1885,1890,XXXX-09-XX -- XXXX-02-XX
-UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,7160,7166,XXXX-03-20 -- XXXX-06-21
-UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,1319,1323,XXXX-04-XX -- XXXX-05-XX
-WFP_Ethiopia_Drought_Emergency_Situation_Report_5_Jul-17,515,537,ref-date -- 2017-XX-XX
-WFP_Ethiopia_Drought_Emergency_Situation_Report_5_Jul-17,582,586,2017-XX-XX
+UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,10204,10233,2017-04-01 -- 2017-03-15
+UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,16892,16905,2017-02-XX
+UNICEF_ETHIOPIA_HUMANITARIAN_SITUATION_REPORT_Apr-17,17062,17067,XXXX-04-XX
+WFP_Ethiopia_Drought_Emergency_Situation_Report_5_Jul-17,419,426,XXXX-10-XX
 WFP_Ethiopia_Drought_Emergency_Situation_Report_5_Jul-17,442,448,XXXX-06-21 -- XXXX-09-22
 WFP_Ethiopia_Drought_Emergency_Situation_Report_5_Jul-17,449,454,XXXX-09-XX -- XXXX-02-XX
+WFP_Ethiopia_Drought_Emergency_Situation_Report_5_Jul-17,515,537,ref-date -- 2017-XX-XX
+WFP_Ethiopia_Drought_Emergency_Situation_Report_5_Jul-17,582,586,2017-XX-XX
+WFP_Ethiopia_Drought_Emergency_Situation_Report_5_Jul-17,644,650,XXXX-08-XX
+WFP_Ethiopia_Drought_Emergency_Situation_Report_5_Jul-17,1537,1549,XXXX-10-XX -- ref-date
+WFP_Ethiopia_Drought_Emergency_Situation_Report_5_Jul-17,1777,1781,XXXX-07-XX
+WFP_Ethiopia_Drought_Emergency_Situation_Report_5_Jul-17,2502,2513,XXXX-08-XX -- ref-date
+WFP_Ethiopia_Drought_Emergency_Situation_Report_5_Jul-17,2519,2527,XXXX-12-XX
+WFP_Ethiopia_Drought_Emergency_Situation_Report_5_Jul-17,2810,2814,XXXX-07-XX
+WFP_Ethiopia_Drought_Emergency_Situation_Report_5_Jul-17,3187,3191,XXXX-07-XX
+WFP_Ethiopia_Drought_Emergency_Situation_Report_5_Jul-17,3268,3271,XXXX-05-XX
+WFP_Ethiopia_Drought_Emergency_Situation_Report_5_Jul-17,3288,3292,XXXX-07-XX
+WFP_Ethiopia_Drought_Emergency_Situation_Report_5_Jul-17,3619,3623,XXXX-07-XX
+WFP_Ethiopia_Drought_Emergency_Situation_Report_5_Jul-17,4127,4139,XXXX-10-XX -- ref-date
+WFP_Ethiopia_Drought_Emergency_Situation_Report_5_Jul-17,4305,4317,2017-08-XX
+WFP_Ethiopia_Drought_Emergency_Situation_Report_5_Jul-17,4570,4576,XXXX-08-XX

--- a/main/src/main/resources/org/clulab/numeric/atomic.yml
+++ b/main/src/main/resources/org/clulab/numeric/atomic.yml
@@ -8,14 +8,6 @@ rules:
     pattern: |
       [entity=/B-MONTH/] [entity=/I-MONTH/]*
 
-  # month values, 1 to 12
-  - name: month-values
-    label: PossibleMonth
-    priority: ${ rulepriority }
-    type: token
-    pattern: |
-      [word=/^([1-9]|1[012])$/]
-
   # measurement units, from the MEASUREMENT-UNIT lexicon
   - name: measurement-unit
     label: MeasurementUnit

--- a/main/src/main/resources/org/clulab/numeric/dates.yml
+++ b/main/src/main/resources/org/clulab/numeric/dates.yml
@@ -59,6 +59,16 @@ rules:
     pattern: |
       @year:PossibleYear ( ","? @month:PossibleMonth )?
 
+  # Date with just a single month name
+  - name: date-5
+    label: Date
+    priority: ${ rulepriority }
+    type: token
+    example: "It was May"
+    action: mkDateMention
+    pattern: |
+        @month:PossibleMonth
+
   # Rule for YYYY-MM-DD (accepts -, :, / as separators)
   - name: date-yyyy-mm-dd
     label: Date

--- a/main/src/test/scala/org/clulab/numeric/TestEvalTimeNorm.scala
+++ b/main/src/test/scala/org/clulab/numeric/TestEvalTimeNorm.scala
@@ -7,7 +7,7 @@ class TestEvalTimeNorm extends FlatSpec with Matchers{
   behavior of "temporal parser"
 
   it should "not degrade in performance" in {
-    val expectedFscore = 0.81
+    val expectedFscore = 0.85
     val proc = new CluProcessor(seasonPathOpt = Some("/org/clulab/numeric/custom/SEASON.tsv"))
     val ner = NumericEntityRecognizer(seasonPath = "/org/clulab/numeric/custom/SEASON.tsv")
     val actualFscore = EvalTimeNorm.test(proc, ner)

--- a/main/src/test/scala/org/clulab/numeric/TestNumericEntityRecognition.scala
+++ b/main/src/test/scala/org/clulab/numeric/TestNumericEntityRecognition.scala
@@ -243,6 +243,13 @@ class TestNumericEntityRecognition extends FlatSpec with Matchers {
     ensure("after summer", Interval(0, 2), "DATE-RANGE", "XXXX-09-22 -- XXXX-XX-XX")
   }
 
+  it should "recognize dates and date-ranges with single months" in {
+    ensure("It was January", Interval(2, 3), "DATE", "XXXX-01-XX")
+    ensure("It was Jan", Interval(2, 3), "DATE", "XXXX-01-XX")
+    ensure("It was between January and March", Interval(2, 3), "DATE-RANGE", "XXXX-01-XX -- XXXX-03-XX")
+    ensure("until January", Interval(0, 2), "DATE-RANGE", "ref-date -- XXXX-01-XX")
+    ensure("after January", Interval(0, 2), "DATE-RANGE", "XXXX-01-XX -- XXXX-XX-XX")
+  }
 
   it should "recognize measurement units" in {
     ensure("It was 12 ha", Interval(2, 4), "MEASUREMENT", "12.0 ha")


### PR DESCRIPTION
A few changes to recognize dates with single months (e.g. `it was May`) and an updated version of the timenorm test file that includes those cases.