### PR TITLE
Do not name resolver simply Artifactory

### DIFF
--- a/main/build.sbt
+++ b/main/build.sbt
@@ -2,11 +2,11 @@ name := "processors-main"
 description := "processors-main"
 
 pomIncludeRepository := { (repo: MavenRepository) =>
-  repo.root.startsWith("http://artifactory.cs.arizona.edu")
+  repo.root.contains("artifactory.cs.arizona.edu")
 }
 
 // for processors-models
-resolvers += "Artifactory" at "http://artifactory.cs.arizona.edu:8081/artifactory/sbt-release"
+resolvers += "artifactory.cs.arizona.edu" at "http://artifactory.cs.arizona.edu:8081/artifactory/sbt-release"
 
 libraryDependencies ++= {
   val json4sVersion = "3.5.2"


### PR DESCRIPTION
A side effect of the simple name is a POM file containing

        <repository>
            <id>Artifactory</id>
            <name>Artifactory</name>
            <url>http://artifactory.cs.arizona.edu:8081/artifactory/sbt-release/</url>
            <layout>default</layout>
        </repository>

which may cause clashes with other respositories.  The new name results in

        <repository>
            <id>artifactorycsarizonaedu</id>
            <name>artifactory.cs.arizona.edu</name>
            <url>http://artifactory.cs.arizona.edu:8081/artifactory/sbt-release/</url>
            <layout>default</layout>
        </repository>

which should play better with others.