### PR TITLE
more date and measurement normalization

### DIFF
--- a/main/src/main/resources/org/clulab/numeric/atomic.yml
+++ b/main/src/main/resources/org/clulab/numeric/atomic.yml
@@ -14,7 +14,7 @@ rules:
     priority: ${ rulepriority }
     type: token
     pattern: |
-      [entity=/B-MEASUREMENT-UNIT/] [entity=/I-MEASUREMENT-UNIT/]*
+      [entity=/B-MEASUREMENT-UNIT/ & !word = "DS"] [entity=/I-MEASUREMENT-UNIT/]*
 
   # possible years, from 1ddd to 20dd
   - name: year

--- a/main/src/main/resources/org/clulab/numeric/date-ranges.yml
+++ b/main/src/main/resources/org/clulab/numeric/date-ranges.yml
@@ -180,7 +180,7 @@
   label: Date
   priority: ${ rulepriority }
   type: token
-  example: "Seeding dates ranged from 22 August to 26 September in 2011WS, from 29 February to 1 April in the 2012DS, and from 5 to 23 March in the 2013DS."
+  example: "Seeding dates ranged from 22 August to 26 September in 2011WS."
   action: mkDateRangeMentionVagueSeason
   pattern: |
     /^(1\d\d\d|2\d\d\d)(WS|DS)$/ | @year:PossibleYear (?<season> [word = /^(WS|DS)$/])

--- a/main/src/main/resources/org/clulab/numeric/date-ranges.yml
+++ b/main/src/main/resources/org/clulab/numeric/date-ranges.yml
@@ -175,3 +175,12 @@
   action: mkDateUnboundRangeMentionWithSeasonAfter
   pattern: |
     /(?i)(after|beyond|following)/ @season:PossibleSeason @year:PossibleYear?
+
+- name: date-yyyy-vague-season
+  label: Date
+  priority: ${ rulepriority }
+  type: token
+  example: "Seeding dates ranged from 22 August to 26 September in 2011WS, from 29 February to 1 April in the 2012DS, and from 5 to 23 March in the 2013DS."
+  action: mkDateRangeMentionVagueSeason
+  pattern: |
+    /^(1\d\d\d|2\d\d\d)(WS|DS)$/ | @year:PossibleYear (?<season> [word = /^(WS|DS)$/])

--- a/main/src/main/resources/org/clulab/numeric/dates.yml
+++ b/main/src/main/resources/org/clulab/numeric/dates.yml
@@ -69,6 +69,15 @@ rules:
     pattern: |
         @month:PossibleMonth
 
+  - name: date-with-vague-season
+    label: Date
+    priority: ${ rulepriority }
+    type: token
+    example: "26 September in 2011WS"
+    action: mkDateMention
+    pattern: |
+      @day:PossibleDay @month:PossibleMonth /^in$/ (?<year> [word = /^(\d\d\d\d)(WS|DS)$/])
+
   # Rule for YYYY-MM-DD (accepts -, :, / as separators)
   - name: date-yyyy-mm-dd
     label: Date

--- a/main/src/main/resources/org/clulab/numeric/dates.yml
+++ b/main/src/main/resources/org/clulab/numeric/dates.yml
@@ -76,7 +76,7 @@ rules:
     example: "26 September in 2011WS"
     action: mkDateMention
     pattern: |
-      @day:PossibleDay @month:PossibleMonth /^in$/ (?<year> [word = /^(\d\d\d\d)(WS|DS)$/])
+      ( @day:PossibleDay @month:PossibleMonth | @month:PossibleMonth @day:PossibleDay) /^in$/ (?<year> [word = /^(\d\d\d\d)(WS|DS)$/])
 
   # Rule for YYYY-MM-DD (accepts -, :, / as separators)
   - name: date-yyyy-mm-dd

--- a/main/src/main/resources/org/clulab/numeric/number-ranges.yml
+++ b/main/src/main/resources/org/clulab/numeric/number-ranges.yml
@@ -20,3 +20,12 @@
   pattern: |
     @number1:Number /(?i)(to|\-)/ @number2:Number
 
+- name: one-token-number-range
+  priority: ${rulepriority}
+  label: NumberRange
+  type: token
+  example: "irrigated plots with a 2-5 cm depth sheet of water"
+  action: mkNumberRangeMention
+  pattern: |
+    /^\d+\-\d+$/ (?= [entity = /B-MEASUREMENT-UNIT/])
+

--- a/main/src/main/scala/org/clulab/numeric/NumberParser.scala
+++ b/main/src/main/scala/org/clulab/numeric/NumberParser.scala
@@ -17,7 +17,7 @@ object NumberParser {
           var word = w
           // this is to take care of years with season, e.g., 2011DS, when used in dates with days specified
           if (word.endsWith("WS") || word.endsWith("DS")) {
-            word = word.replace("WS", "").replace("DS","")
+            word = word.dropRight(2)
           }
           // lowercase
           word = word.toLowerCase()

--- a/main/src/main/scala/org/clulab/numeric/NumberParser.scala
+++ b/main/src/main/scala/org/clulab/numeric/NumberParser.scala
@@ -14,8 +14,13 @@ object NumberParser {
         None
       case words =>
         val cleanWords = removePlusMinus(words).flatMap { w =>
+          var word = w
+          // this is to take care of years with season, e.g., 2011DS, when used in dates with days specified
+          if (word.endsWith("WS") || word.endsWith("DS")) {
+            word = word.replace("WS", "").replace("DS","")
+          }
           // lowercase
-          var word = w.toLowerCase()
+          word = word.toLowerCase()
           // remove commas from numbers like 100,000
           word = word.replace(",", "")
           // remove "+"

--- a/main/src/main/scala/org/clulab/numeric/actions/NumericActions.scala
+++ b/main/src/main/scala/org/clulab/numeric/actions/NumericActions.scala
@@ -51,6 +51,10 @@ class NumericActions(seasonNormalizer: SeasonNormalizer) extends Actions {
     convert(mentions, toDateRangeMention, "toDateRangeMention")
   }
 
+  def mkDateRangeMentionWithVagueSeason(mentions: Seq[Mention], state: State): Seq[Mention] = {
+    convert(mentions, toDateRangeMentionWithVagueSeason, "toDateRangeMentionWithVagueSeason")
+  }
+
   /** Constructs a DateRangeMention from a token pattern */
   def mkDateRangeMentionWithNumber(mentions: Seq[Mention], state: State): Seq[Mention] = {
     convert(mentions, toDateRangeMentionWithNumber, "toDateRangeMentionWithNumber")
@@ -109,6 +113,11 @@ class NumericActions(seasonNormalizer: SeasonNormalizer) extends Actions {
   /** Constructs a DateRangeMention from a token pattern */
   def mkDateUnboundRangeMentionWithSeasonAfter(mentions: Seq[Mention], state: State): Seq[Mention] = {
     convert(mentions, toDateUnboundRangeMentionWithSeasonAfter(seasonNormalizer), "toDateUnboundRangeMentionAfter")
+  }
+
+  /** Constructs a DateRangeMention from a token pattern */
+  def mkDateRangeMentionVagueSeason(mentions: Seq[Mention], state: State): Seq[Mention] = {
+    convert(mentions, toDateRangeMentionFromVagueSeason, "mkDateRangeMentionVagueSeason")
   }
 
   /** Constructs a DateMention from a token pattern */

--- a/main/src/main/scala/org/clulab/numeric/mentions/DateRangeMention.scala
+++ b/main/src/main/scala/org/clulab/numeric/mentions/DateRangeMention.scala
@@ -1,6 +1,6 @@
 package org.clulab.numeric.mentions
 
-import org.clulab.odin.{Attachment, TextBoundMention}
+import org.clulab.odin.{Attachment, Mention, TextBoundMention}
 import org.clulab.processors.Document
 import org.clulab.struct.Interval
 
@@ -34,4 +34,21 @@ class DateRangeMention ( labels: Seq[String],
     "DATE-RANGE"
   }
 
+}
+
+object DateRangeMention {
+
+  def apply(m: Mention, date1Norm: String, date2Norm: String):  DateRangeMention = {
+    new DateRangeMention(
+      m.labels,
+      m.tokenInterval,
+      m.sentence,
+      m.document,
+      m.keep,
+      m.foundBy,
+      m.attachments,
+      date1Norm,
+      date2Norm
+    )
+  }
 }

--- a/main/src/main/scala/org/clulab/numeric/mentions/package.scala
+++ b/main/src/main/scala/org/clulab/numeric/mentions/package.scala
@@ -135,6 +135,7 @@ package object mentions {
       throw new RuntimeException(s"ERROR: cannot convert mention of type ${m.getClass.toString} to DateRangeMention!")
   }
 
+  /** Makes a specific date range when the year is combined with season, e.g., from August 23 to October 10 in 2017WS */
   def toDateRangeMentionWithVagueSeason(mention: Mention): DateRangeMention =  mention match {
     case m: DateRangeMention => m
 
@@ -527,8 +528,8 @@ package object mentions {
       throw new RuntimeException(s"ERROR: cannot convert mention of type ${m.getClass.toString} to DateRangeMention!")
   }
 
+  /** handles years with dry/wet season attributes as ranges with undefined dates, e.g., 2011WS */
   def toDateRangeMentionFromVagueSeason(mention: Mention): DateRangeMention =  mention match {
-    // handles years with dry/wet season attributes as ranges with undefined dates, e.g., 2011WS
     case m: DateRangeMention => m
 
     case m: TextBoundMention =>

--- a/main/src/main/scala/org/clulab/numeric/mentions/package.scala
+++ b/main/src/main/scala/org/clulab/numeric/mentions/package.scala
@@ -119,14 +119,8 @@ package object mentions {
       if(date2Norm.isEmpty)
         throw new RuntimeException(s"ERROR: could not find argument date2 in mention [${m.raw.mkString(" ")}]!")
 
-      new DateRangeMention(
-        m.labels,
-        m.tokenInterval,
-        m.sentence,
-        m.document,
-        m.keep,
-        m.foundBy,
-        m.attachments,
+      DateRangeMention(
+        m,
         date1Norm.get,
         date2Norm.get
       )
@@ -147,14 +141,8 @@ package object mentions {
       if(date2Norm.isEmpty)
         throw new RuntimeException(s"ERROR: could not find argument date2 in mention [${m.raw.mkString(" ")}]!")
 
-      new DateRangeMention(
-        m.labels,
-        m.tokenInterval,
-        m.sentence,
-        m.document,
-        m.keep,
-        m.foundBy,
-        m.attachments,
+      DateRangeMention(
+        m,
         date1Norm.get,
         date2Norm.get
       )
@@ -177,14 +165,8 @@ package object mentions {
       if(date2Norm.isEmpty)
         throw new RuntimeException(s"ERROR: could not find argument date2 in mention [${m.raw.mkString(" ")}]!")
 
-      new DateRangeMention(
-        m.labels,
-        m.tokenInterval,
-        m.sentence,
-        m.document,
-        m.keep,
-        m.foundBy,
-        m.attachments,
+      DateRangeMention(
+        m,
         TempEvalFormatter.mkDate1Norm(numberVal.get, date2Norm.get),
         date2Norm.get
       )
@@ -209,14 +191,8 @@ package object mentions {
       if(month2Norm.isEmpty)
         throw new RuntimeException(s"ERROR: could not find argument number in mention [${m.raw.mkString(" ")}]!")
 
-      new DateRangeMention(
-        m.labels,
-        m.tokenInterval,
-        m.sentence,
-        m.document,
-        m.keep,
-        m.foundBy,
-        m.attachments,
+      DateRangeMention(
+        m,
         TempEvalFormatter.mkDate(None, month1Norm, yearNorm),
         TempEvalFormatter.mkDate(None, month2Norm, yearNorm)
       )
@@ -233,14 +209,8 @@ package object mentions {
       if(date1Norm.isEmpty)
         throw new RuntimeException(s"ERROR: could not find argument date1 in mention [${m.raw.mkString(" ")}]!")
 
-      new DateRangeMention(
-        m.labels,
-        m.tokenInterval,
-        m.sentence,
-        m.document,
-        m.keep,
-        m.foundBy,
-        m.attachments,
+      DateRangeMention(
+        m,
         date1Norm.get,
         "ref-date"
       )
@@ -257,14 +227,8 @@ package object mentions {
       if(date1Norm.isEmpty)
         throw new RuntimeException(s"ERROR: could not find argument date1 in mention [${m.raw.mkString(" ")}]!")
 
-      new DateRangeMention(
-        m.labels,
-        m.tokenInterval,
-        m.sentence,
-        m.document,
-        m.keep,
-        m.foundBy,
-        m.attachments,
+      DateRangeMention(
+        m,
         "ref-date",
         date1Norm.get
       )
@@ -281,14 +245,8 @@ package object mentions {
       if(date1Norm.isEmpty)
         throw new RuntimeException(s"ERROR: could not find argument date1 in mention [${m.raw.mkString(" ")}]!")
 
-      new DateRangeMention(
-        m.labels,
-        m.tokenInterval,
-        m.sentence,
-        m.document,
-        m.keep,
-        m.foundBy,
-        m.attachments,
+      DateRangeMention(
+        m,
         "XXXX-XX-XX",
         date1Norm.get
       )
@@ -305,14 +263,8 @@ package object mentions {
       if(date1Norm.isEmpty)
         throw new RuntimeException(s"ERROR: could not find argument date1 in mention [${m.raw.mkString(" ")}]!")
 
-      new DateRangeMention(
-        m.labels,
-        m.tokenInterval,
-        m.sentence,
-        m.document,
-        m.keep,
-        m.foundBy,
-        m.attachments,
+      DateRangeMention(
+        m,
         date1Norm.get,
         "XXXX-XX-XX"
       )
@@ -338,14 +290,8 @@ package object mentions {
         case _ => (None, None)
       }
 
-      new DateRangeMention(
-        m.labels,
-        m.tokenInterval,
-        m.sentence,
-        m.document,
-        m.keep,
-        m.foundBy,
-        m.attachments,
+      DateRangeMention(
+        m,
         TempEvalFormatter.mkDate(seasonNorm.get.startDay, seasonNorm.get.startMonth,yearStart),
         TempEvalFormatter.mkDate(seasonNorm.get.endDay, seasonNorm.get.endMonth, yearEnd)
       )
@@ -388,14 +334,8 @@ package object mentions {
         case _ => None
       }
 
-      new DateRangeMention(
-        m.labels,
-        m.tokenInterval,
-        m.sentence,
-        m.document,
-        m.keep,
-        m.foundBy,
-        m.attachments,
+      DateRangeMention(
+        m,
         TempEvalFormatter.mkDate(seasonNorm1.get.endDay, seasonNorm1.get.endMonth, yearEnd1),
         TempEvalFormatter.mkDate(seasonNorm2.get.startDay, seasonNorm2.get.startMonth, yearStart2)
       )
@@ -419,14 +359,8 @@ package object mentions {
         case _ => None
       }
 
-      new DateRangeMention(
-        m.labels,
-        m.tokenInterval,
-        m.sentence,
-        m.document,
-        m.keep,
-        m.foundBy,
-        m.attachments,
+      DateRangeMention(
+        m,
         TempEvalFormatter.mkDate(seasonNorm.get.endDay, seasonNorm.get.endMonth, yearNorm),
         "ref-date"
       )
@@ -450,14 +384,8 @@ package object mentions {
         case _ => None
       }
 
-      new DateRangeMention(
-        m.labels,
-        m.tokenInterval,
-        m.sentence,
-        m.document,
-        m.keep,
-        m.foundBy,
-        m.attachments,
+      DateRangeMention(
+        m,
         "ref-date",
         TempEvalFormatter.mkDate(seasonNorm.get.startDay, seasonNorm.get.startMonth, yearNorm)
       )
@@ -481,14 +409,8 @@ package object mentions {
         case _ => None
       }
 
-      new DateRangeMention(
-        m.labels,
-        m.tokenInterval,
-        m.sentence,
-        m.document,
-        m.keep,
-        m.foundBy,
-        m.attachments,
+      DateRangeMention(
+        m,
         "XXXX-XX-XX",
         TempEvalFormatter.mkDate(seasonNorm.get.startDay, seasonNorm.get.startMonth, yearNorm)
       )
@@ -512,14 +434,8 @@ package object mentions {
         case _ => None
       }
 
-      new DateRangeMention(
-        m.labels,
-        m.tokenInterval,
-        m.sentence,
-        m.document,
-        m.keep,
-        m.foundBy,
-        m.attachments,
+      DateRangeMention(
+        m,
         TempEvalFormatter.mkDate(seasonNorm.get.endDay, seasonNorm.get.endMonth, yearNorm),
         "XXXX-XX-XX"
       )
@@ -535,14 +451,8 @@ package object mentions {
     case m: TextBoundMention =>
       // remove season (i.e., remove non-digit characters from the year-season token, e.g., 2011WS -> 2011)
       val year = m.text.replaceAll("\\D\\D", "")
-      new DateRangeMention(
-        m.labels,
-        m.tokenInterval,
-        m.sentence,
-        m.document,
-        m.keep,
-        m.foundBy,
-        m.attachments,
+      DateRangeMention(
+        m,
         TempEvalFormatter.mkDate(None, None, Some(Seq(year))),
         TempEvalFormatter.mkDate(None, None, Some(Seq(year)))
       )
@@ -550,14 +460,8 @@ package object mentions {
     case m: RelationMention =>
       val year = m.arguments("year").map(_.text)
 
-      new DateRangeMention(
-        m.labels,
-        m.tokenInterval,
-        m.sentence,
-        m.document,
-        m.keep,
-        m.foundBy,
-        m.attachments,
+      DateRangeMention(
+        m,
         TempEvalFormatter.mkDate(None, None, Some(year)),
         TempEvalFormatter.mkDate(None, None, Some(year))
       )

--- a/main/src/test/scala/org/clulab/numeric/TestNumericEntityRecognition.scala
+++ b/main/src/test/scala/org/clulab/numeric/TestNumericEntityRecognition.scala
@@ -324,6 +324,11 @@ class TestNumericEntityRecognition extends FlatSpec with Matchers {
       Interval(3, 11), "DATE-RANGE", "2011-08-22 -- 2011-09-26")
   }
 
+  it should "recognize date ranges (month/day) with vague seasons" in {
+    ensure("from August 23 to October 11 in 2017WS.",
+      Interval(0, 8), "DATE-RANGE", "2017-08-23 -- 2017-10-11")
+  }
+
   it should "recognize years with vague seasons within same token as date ranges" in {
     ensure("Timing of basal fertilizer application was on average 26 days after sowing in 2011WS",
       Interval(13, 14), "DATE-RANGE", "2011-XX-XX -- 2011-XX-XX")
@@ -433,7 +438,6 @@ class TestNumericEntityRecognition extends FlatSpec with Matchers {
     
     // TODO: not sure what should be the output of such measurement '3 or 4 days'
     ensure(sentence= "and lasted 3 or 4 days in both wet seasons", Interval(4, 6), goldEntity="MEASUREMENT", goldNorm="4.0 d")
-
   }
 
   // TODO: this requires non trivial changes to the tokenizer

--- a/main/src/test/scala/org/clulab/numeric/TestNumericEntityRecognition.scala
+++ b/main/src/test/scala/org/clulab/numeric/TestNumericEntityRecognition.scala
@@ -319,6 +319,31 @@ class TestNumericEntityRecognition extends FlatSpec with Matchers {
       Interval(7, 15), "DATE-RANGE", "XXXX-02-XX -- XXXX-07-XX")
   }
 
+  it should "recognize date ranges with vague seasons" in {
+    ensure("Seeding dates ranged from 22 August to 26 September in 2011WS.",
+      Interval(3, 11), "DATE-RANGE", "2011-08-22 -- 2011-09-26")
+  }
+
+  it should "recognize years with vague seasons within same token as date ranges" in {
+    ensure("Timing of basal fertilizer application was on average 26 days after sowing in 2011WS",
+      Interval(13, 14), "DATE-RANGE", "2011-XX-XX -- 2011-XX-XX")
+  }
+
+  it should "recognize years with vague seasons (DS) within same token as date ranges" in {
+    ensure("Timing of basal fertilizer application was on average 26 days after sowing in 2015DS",
+      Interval(13, 14), "DATE-RANGE", "2015-XX-XX -- 2015-XX-XX")
+  }
+
+  it should "recognize years with vague seasons in separate tokens as date ranges" in {
+    ensure("Timing of basal fertilizer application was on average 26 days after sowing in 2011 WS",
+      Interval(13, 15), "DATE-RANGE", "2011-XX-XX -- 2011-XX-XX")
+  }
+
+  it should "recognize years with vague seasons (DS) in separate tokens as date ranges" in {
+    ensure("Timing of basal fertilizer application was on average 26 days after sowing in 2019 DS",
+      Interval(13, 15), "DATE-RANGE", "2019-XX-XX -- 2019-XX-XX")
+  }
+
   // TODO: Other dates that should be recognized
 
   it should "recognize numeric dates of form mm" in {
@@ -365,6 +390,7 @@ class TestNumericEntityRecognition extends FlatSpec with Matchers {
     ensure("It was 12 hectares", Interval(2, 4), "MEASUREMENT", "12.0 ha")
     ensure(sentence= "It was 12 meters long.", Interval(2, 4), goldEntity="MEASUREMENT", goldNorm= "12.0 m")
     ensure(sentence= "It was 12 kilograms.", Interval(2,4), goldEntity="MEASUREMENT", goldNorm= "12.0 kg")
+    ensure(sentence= "irrigated plots with a 2-5 cm depth sheet of water", Interval(4, 6), goldEntity="MEASUREMENT", goldNorm="2.0 -- 5.0 cm")
 
     // test for parsing literal numbers
     ensure("It was twelve hundred ha", Interval(2, 5), "MEASUREMENT", "1200.0 ha")
@@ -407,6 +433,7 @@ class TestNumericEntityRecognition extends FlatSpec with Matchers {
     
     // TODO: not sure what should be the output of such measurement '3 or 4 days'
     ensure(sentence= "and lasted 3 or 4 days in both wet seasons", Interval(4, 6), goldEntity="MEASUREMENT", goldNorm="4.0 d")
+
   }
 
   // TODO: this requires non trivial changes to the tokenizer


### PR DESCRIPTION
- creating numerical ranges for measurements with dashes (tokenized as one token, e.g., 2-5 cm)
- making a range out of year-season combinations (both one- and two-token combos), e.g., 2017WS
  - ATTN: the information about season is not currently stored
- using year-season combos as a regular year for examples with specific dates, e.g., "from August 10 to October 11 in 2017WS"
- adding relevant tests