### PR TITLE
Avoid possible runtime errors when using AutoCloser

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ val scala13 = "2.13.8"  // up to 2.13.8
 // scala13 is waiting on ai.lum %% common.
 
 ThisBuild / crossScalaVersions := Seq(scala12, scala11)
-ThisBuild / scalaVersion := crossScalaVersions.value(1)
+ThisBuild / scalaVersion := crossScalaVersions.value.head
 
 lazy val root = (project in file("."))
   .aggregate(main, corenlp, openie)

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ val scala13 = "2.13.8"  // up to 2.13.8
 // scala13 is waiting on ai.lum %% common.
 
 ThisBuild / crossScalaVersions := Seq(scala12, scala11)
-ThisBuild / scalaVersion := crossScalaVersions.value.head
+ThisBuild / scalaVersion := crossScalaVersions.value(1)
 
 lazy val root = (project in file("."))
   .aggregate(main, corenlp, openie)

--- a/corenlp/src/main/scala/org/clulab/processors/TextLabelToCoNNLU.scala
+++ b/corenlp/src/main/scala/org/clulab/processors/TextLabelToCoNNLU.scala
@@ -8,7 +8,7 @@ import org.slf4j.{Logger, LoggerFactory}
 import TextLabelToCoNLLU._
 import org.clulab.dynet.Utils
 import org.clulab.struct.GraphMap
-import org.clulab.utils.Closer.AutoCloser
+import org.clulab.utils.Closer.AutoBufferedSource
 
 /**
   * Processes raw text and saves the output in the CoNLL-U format

--- a/corenlp/src/main/scala/org/clulab/processors/TextLabelToCoNNLU.scala
+++ b/corenlp/src/main/scala/org/clulab/processors/TextLabelToCoNNLU.scala
@@ -8,7 +8,7 @@ import org.slf4j.{Logger, LoggerFactory}
 import TextLabelToCoNLLU._
 import org.clulab.dynet.Utils
 import org.clulab.struct.GraphMap
-import org.clulab.utils.Closer.AutoBufferedSource
+import org.clulab.utils.Closer.AutoSource
 
 /**
   * Processes raw text and saves the output in the CoNLL-U format

--- a/main/src/main/scala/org/clulab/embeddings/CompactWordEmbeddingMap.scala
+++ b/main/src/main/scala/org/clulab/embeddings/CompactWordEmbeddingMap.scala
@@ -7,6 +7,7 @@ import com.esotericsoftware.kryo.io.Output
 import java.io._
 import org.clulab.utils.ClassLoaderObjectInputStream
 import org.clulab.utils.Closer.AutoCloser
+import org.clulab.utils.Closer.AutoSource
 import org.clulab.utils.Logging
 import org.clulab.utils.Sourcer
 import org.clulab.utils.Timers

--- a/main/src/main/scala/org/clulab/embeddings/CullVectors.scala
+++ b/main/src/main/scala/org/clulab/embeddings/CullVectors.scala
@@ -3,6 +3,7 @@ package org.clulab.embeddings
 import java.io.File
 
 import org.clulab.utils.Closer.AutoCloser
+import org.clulab.utils.Closer.AutoSource
 import org.clulab.utils.Sinker
 import org.clulab.utils.Sourcer
 

--- a/main/src/main/scala/org/clulab/embeddings/ExplicitWordEmbeddingMap.scala
+++ b/main/src/main/scala/org/clulab/embeddings/ExplicitWordEmbeddingMap.scala
@@ -3,7 +3,7 @@ package org.clulab.embeddings
 import java.io._
 import org.clulab.utils.ClassLoaderObjectInputStream
 import org.clulab.utils.Closer.AutoCloser
-import org.clulab.utils.Closer.AutoBufferedSource
+import org.clulab.utils.Closer.AutoSource
 import org.clulab.utils.Logging
 import org.clulab.utils.Sourcer
 

--- a/main/src/main/scala/org/clulab/embeddings/ExplicitWordEmbeddingMap.scala
+++ b/main/src/main/scala/org/clulab/embeddings/ExplicitWordEmbeddingMap.scala
@@ -3,6 +3,7 @@ package org.clulab.embeddings
 import java.io._
 import org.clulab.utils.ClassLoaderObjectInputStream
 import org.clulab.utils.Closer.AutoCloser
+import org.clulab.utils.Closer.AutoBufferedSource
 import org.clulab.utils.Logging
 import org.clulab.utils.Sourcer
 

--- a/main/src/main/scala/org/clulab/embeddings/WordEmbeddingMapPool.scala
+++ b/main/src/main/scala/org/clulab/embeddings/WordEmbeddingMapPool.scala
@@ -72,19 +72,11 @@ object WordEmbeddingMapPool {
   def loadEmbedding(name: String, fileLocation: String, resourceLocation: String, compact: Boolean): WordEmbeddingMap = {
     val StreamResult(inputStream, _, format) = inputStreamer.stream(name, fileLocation, resourceLocation)
         .getOrElse(throw new RuntimeException(s"WordEmbeddingMap $name could not be opened."))
-    val wordEmbeddingMap = {
-        // This is intentionally not using autoClose because the inputStream might be a
-        // JarURLConnection#JarURLInputStream which can't be autoClosed in newer (> 1.8)
-        // versions of Java.  See further explanation in InputStreamer.
-        try {
-          val binary = format == InputStreamer.Format.Bin
+    val wordEmbeddingMap = inputStream.autoClose { inputStream =>
+      val binary = format == InputStreamer.Format.Bin
 
-          if (compact) CompactWordEmbeddingMap(inputStream, binary)
-          else ExplicitWordEmbeddingMap(inputStream, binary)
-        }
-        finally {
-          inputStream.close()
-        }
+      if (compact) CompactWordEmbeddingMap(inputStream, binary)
+      else ExplicitWordEmbeddingMap(inputStream, binary)
     }
 
     wordEmbeddingMap

--- a/main/src/main/scala/org/clulab/numeric/SeasonNormalizer.scala
+++ b/main/src/main/scala/org/clulab/numeric/SeasonNormalizer.scala
@@ -4,6 +4,7 @@ import java.io.File
 
 import org.clulab.sequences.CommentedStandardKbSource
 import org.clulab.utils.Closer.AutoCloser
+import org.clulab.utils.Closer.AutoBufferedSource
 import org.clulab.utils.Sourcer
 
 import scala.collection.mutable

--- a/main/src/main/scala/org/clulab/numeric/SeasonNormalizer.scala
+++ b/main/src/main/scala/org/clulab/numeric/SeasonNormalizer.scala
@@ -4,7 +4,7 @@ import java.io.File
 
 import org.clulab.sequences.CommentedStandardKbSource
 import org.clulab.utils.Closer.AutoCloser
-import org.clulab.utils.Closer.AutoBufferedSource
+import org.clulab.utils.Closer.AutoSource
 import org.clulab.utils.Sourcer
 
 import scala.collection.mutable

--- a/main/src/main/scala/org/clulab/numeric/UnitNormalizer.scala
+++ b/main/src/main/scala/org/clulab/numeric/UnitNormalizer.scala
@@ -2,7 +2,7 @@ package org.clulab.numeric
 
 import org.clulab.sequences.CommentedStandardKbSource
 import org.clulab.utils.Closer.AutoCloser
-import org.clulab.utils.Closer.AutoBufferedSource
+import org.clulab.utils.Closer.AutoSource
 import org.clulab.utils.Sourcer
 
 import scala.collection.mutable

--- a/main/src/main/scala/org/clulab/numeric/UnitNormalizer.scala
+++ b/main/src/main/scala/org/clulab/numeric/UnitNormalizer.scala
@@ -2,6 +2,7 @@ package org.clulab.numeric
 
 import org.clulab.sequences.CommentedStandardKbSource
 import org.clulab.utils.Closer.AutoCloser
+import org.clulab.utils.Closer.AutoBufferedSource
 import org.clulab.utils.Sourcer
 
 import scala.collection.mutable

--- a/main/src/main/scala/org/clulab/odin/impl/RuleReader.scala
+++ b/main/src/main/scala/org/clulab/odin/impl/RuleReader.scala
@@ -16,7 +16,7 @@ import org.yaml.snakeyaml.constructor.{Constructor, ConstructorException}
 import org.clulab.odin._
 import org.clulab.odin.impl.MarkdownGeneration._
 import org.clulab.utils.FileUtils
-import org.clulab.utils.Closer._
+import org.clulab.utils.Closer.AutoCloser
 
 
 

--- a/main/src/main/scala/org/clulab/sequences/ColumnReader.scala
+++ b/main/src/main/scala/org/clulab/sequences/ColumnReader.scala
@@ -2,7 +2,7 @@ package org.clulab.sequences
 
 import org.clulab.utils.Sourcer
 
-import org.clulab.utils.Closer.AutoCloser
+import org.clulab.utils.Closer.AutoBufferedSource
 
 import scala.collection.mutable.ArrayBuffer
 import scala.io.Source

--- a/main/src/main/scala/org/clulab/sequences/ColumnReader.scala
+++ b/main/src/main/scala/org/clulab/sequences/ColumnReader.scala
@@ -1,8 +1,7 @@
 package org.clulab.sequences
 
+import org.clulab.utils.Closer.AutoSource
 import org.clulab.utils.Sourcer
-
-import org.clulab.utils.Closer.AutoBufferedSource
 
 import scala.collection.mutable.ArrayBuffer
 import scala.io.Source

--- a/main/src/main/scala/org/clulab/utils/Closer.scala
+++ b/main/src/main/scala/org/clulab/utils/Closer.scala
@@ -1,13 +1,12 @@
 package org.clulab.utils
 
-import scala.language.reflectiveCalls
+import java.io.Closeable
+
 import scala.util.control.NonFatal
 
 object Closer {
 
-  protected type Closeable = {def close() : Unit}
-
-  def close[Resource <: Closeable](resource: => Resource): Unit = resource.close()
+  def close(resource: => Closeable): Unit = resource.close()
 
   // This is so that exceptions caused during close are caught, but don't
   // prevent the registration of any previous exception.
@@ -55,7 +54,7 @@ object Closer {
   }
 
   // Allow for alternative syntax closeable.autoClose { closeable => ... }
-  implicit class AutoCloser[Resource <: Closer.Closeable](resource: Resource) {
+  implicit class AutoCloser[Resource <: Closeable](resource: Resource) {
 
     def autoClose[Result](function: Resource => Result): Result = Closer.autoClose(resource)(function)
   }

--- a/main/src/main/scala/org/clulab/utils/Closer.scala
+++ b/main/src/main/scala/org/clulab/utils/Closer.scala
@@ -1,6 +1,7 @@
 package org.clulab.utils
 
 import scala.io.Source
+import scala.language.implicitConversions
 import scala.util.control.NonFatal
 
 object Closer {
@@ -56,7 +57,11 @@ object Closer {
 
   // Two arguments can be used generically if the Resource has inherited from Closeable.
   def autoClose[Resource <: AutoCloseable, Result](resource: Resource)(function: Resource => Result): Result =
-      Closer.autoClose3(resource)(() => resource.close())(function)
+      autoClose3(resource)(() => resource.close())(function)
+
+//  def autoClose[Resource <: AutoCloseable](resource: Resource): AutoCloser[Resource] = new AutoCloser(resource)
+//
+//  implicit def autoClose[Resource <: Source](resource: Resource): AutoSource[Resource] = new AutoSource(resource)
 
   // Allow for alternative syntax closeable.autoClose { closeable => ... }
   implicit class AutoCloser[Resource <: AutoCloseable](resource: Resource) {

--- a/main/src/main/scala/org/clulab/utils/Closer.scala
+++ b/main/src/main/scala/org/clulab/utils/Closer.scala
@@ -1,19 +1,18 @@
 package org.clulab.utils
 
-import java.io.Closeable
-
+import scala.io.{BufferedSource, Source}
 import scala.util.control.NonFatal
 
 object Closer {
 
-  def close(resource: => Closeable): Unit = resource.close()
+  def close(resource: => AutoCloseable): Unit = resource.close()
 
   // This is so that exceptions caused during close are caught, but don't
   // prevent the registration of any previous exception.
   // See also https://medium.com/@dkomanov/scala-try-with-resources-735baad0fd7d.
   // Others have resource: => Closeable, but I want the resource evaluated beforehand
   // so that it doesn't throw an exception before there is anything to close.
-  def autoClose[Resource <: Closeable, Result](resource: Resource)(function: Resource => Result): Result = {
+  def autoClose2[Resource, Result](resource: Resource)(closer: () => Unit)(function: Resource => Result): Result = {
 
     val (result: Option[Result], exception: Option[Throwable]) = try {
       (Some(function(resource)), None)
@@ -24,7 +23,7 @@ object Closer {
 
     val closeException: Option[Throwable] = Option(resource).flatMap { resource =>
       try {
-        resource.close()
+        closer()
         None
       }
       catch {
@@ -53,9 +52,28 @@ object Closer {
     }
   }
 
-  // Allow for alternative syntax closeable.autoClose { closeable => ... }
-  implicit class AutoCloser[Resource <: Closeable](resource: Resource) {
+  // Two arguments can be used generically if the Resource has inherited from Closeable.
+  def autoClose[Resource <: AutoCloseable, Result](resource: Resource)(function: Resource => Result): Result =
+      Closer.autoClose2(resource)(() => resource.close())(function)
 
-    def autoClose[Result](function: Resource => Result): Result = Closer.autoClose(resource)(function)
+  // In Scala 2.11, Source does not inherit from Closeable, so one has to tell Closer how to close() it.
+  implicit class AutoSource(resource: Source) {
+
+    def autoClose[Result](function: Source => Result) =
+        Closer.autoClose2(resource)(() => resource.close())(function)
+  }
+
+  // In Scala 2.11, Source does not inherit from Closeable, so one has to tell Closer how to close() it.
+  implicit class AutoBufferedSource(resource: BufferedSource) {
+
+    def autoClose[Result](function: Source => Result) =
+      Closer.autoClose2(resource)(() => resource.close())(function)
+  }
+
+  // Allow for alternative syntax closeable.autoClose { closeable => ... }
+  implicit class AutoCloser[Resource <: AutoCloseable](resource: Resource) {
+
+    def autoClose[Result](function: Resource => Result): Result =
+        Closer.autoClose(resource)(function)
   }
 }

--- a/main/src/main/scala/org/clulab/utils/FileUtils.scala
+++ b/main/src/main/scala/org/clulab/utils/FileUtils.scala
@@ -7,7 +7,7 @@ import java.nio.file.{Files => JFiles, Path, Paths}
 import java.util.zip.ZipFile
 
 import org.clulab.utils.Closer.AutoCloser
-
+import org.clulab.utils.Closer.AutoBufferedSource
 
 import scala.collection.JavaConverters._
 import scala.io.Source

--- a/main/src/main/scala/org/clulab/utils/FileUtils.scala
+++ b/main/src/main/scala/org/clulab/utils/FileUtils.scala
@@ -7,7 +7,7 @@ import java.nio.file.{Files => JFiles, Path, Paths}
 import java.util.zip.ZipFile
 
 import org.clulab.utils.Closer.AutoCloser
-import org.clulab.utils.Closer.AutoBufferedSource
+import org.clulab.utils.Closer.AutoSource
 
 import scala.collection.JavaConverters._
 import scala.io.Source

--- a/main/src/test/scala/org/clulab/embeddings/OldCompactWordEmbeddingMap.scala
+++ b/main/src/test/scala/org/clulab/embeddings/OldCompactWordEmbeddingMap.scala
@@ -1,6 +1,7 @@
 package org.clulab.embeddings
 
 import java.io._
+import org.clulab.utils.Closer.AutoBufferedSource
 import org.clulab.utils.Closer.AutoCloser
 import org.clulab.utils.{ClassLoaderObjectInputStream, Sourcer}
 import org.slf4j.{Logger, LoggerFactory}

--- a/main/src/test/scala/org/clulab/embeddings/OldCompactWordEmbeddingMap.scala
+++ b/main/src/test/scala/org/clulab/embeddings/OldCompactWordEmbeddingMap.scala
@@ -1,7 +1,7 @@
 package org.clulab.embeddings
 
 import java.io._
-import org.clulab.utils.Closer.AutoBufferedSource
+import org.clulab.utils.Closer.AutoSource
 import org.clulab.utils.Closer.AutoCloser
 import org.clulab.utils.{ClassLoaderObjectInputStream, Sourcer}
 import org.slf4j.{Logger, LoggerFactory}

--- a/main/src/test/scala/org/clulab/utils/TestAutoClosing.scala
+++ b/main/src/test/scala/org/clulab/utils/TestAutoClosing.scala
@@ -4,9 +4,11 @@ import org.clulab.utils.Closer.AutoCloser
 
 import org.scalatest._
 
+import java.io.Closeable
+
 class TestAutoClosing extends FlatSpec with Matchers {
 
-  class Closing(exception: Option[Throwable] = None) {
+  class Closing(exception: Option[Throwable] = None) extends Closeable {
     var closed: Boolean = false // test
 
     def close(): Unit = {

--- a/main/src/test/scala/org/clulab/utils/TestClosing.scala
+++ b/main/src/test/scala/org/clulab/utils/TestClosing.scala
@@ -2,9 +2,11 @@ package org.clulab.utils
 
 import org.scalatest._
 
+import java.io.Closeable
+
 class TestClosing extends FlatSpec with Matchers {
 
-  class Closing(exception: Option[Throwable] = None) {
+  class Closing(exception: Option[Throwable] = None) extends Closeable {
     var closed: Boolean = false // test
 
     def close(): Unit = {


### PR DESCRIPTION
Eidos was also having runtime reflection errors with newer versions of Java.  I decided that the runtime reflection is too dangerous for clients to use.  They will need to declare inheritance from Java's Closeable.  This may break compilation, but that is so that it doesn't break at runtime.