### PR TITLE
Fix Charset and closing in EvalTimeNorm

### DIFF
--- a/main/src/main/scala/org/clulab/numeric/EvalTimeNorm.scala
+++ b/main/src/main/scala/org/clulab/numeric/EvalTimeNorm.scala
@@ -3,7 +3,9 @@ package org.clulab.numeric
 import org.clulab.dynet.Utils
 import org.clulab.numeric.mentions.Norm
 import org.clulab.processors.clu.CluProcessor
+import org.clulab.utils.Closer.AutoCloser
 
+import java.nio.charset.StandardCharsets
 import scala.io.Source
 
 object EvalTimeNorm {
@@ -26,8 +28,12 @@ object EvalTimeNorm {
     // gold time expressions, predicted time expressions and the intersection
     val valuesPerDocument = for (docId <- goldTimex.keys.toSeq.sorted) yield {
       val gold = goldTimex(docId).toSet
-      val docStream = getClass.getResourceAsStream(s"$timeNormEvalDir/$docId/$docId")
-      val docText = Source.fromInputStream(docStream).getLines().mkString("\n")
+      val resource = s"$timeNormEvalDir/$docId/$docId"
+      val docStream = getClass.getResourceAsStream(resource)
+      val docText = Source.fromInputStream(docStream)(StandardCharsets.UTF_8).autoClose { source =>
+        // This ensures that line endings are LF.  FileUtils.getTextFromResource() will not.
+        source.getLines().mkString("\n")
+      }
       val doc = proc.annotate(docText)
       val mentions = ner.extractFrom(doc)
       setLabelsAndNorms(doc, mentions)


### PR DESCRIPTION
This is getting in the way of testing in other branches, so I'm fixing it here and then will merge it back.