### PR TITLE
not allowing year-like values to share units with other values

### DIFF
--- a/main/src/main/resources/org/clulab/numeric/measurements.yml
+++ b/main/src/main/resources/org/clulab/numeric/measurements.yml
@@ -22,7 +22,7 @@ rules:
     type: token
     action: mkSharedMeasurementMention
     pattern: |
-      (@number:Number ([tag = IN] [tag = CD])? [!tag = /^NN|LRB|CD/]{0,2} [word = /,|and|to/]*)+ @number:Number @unit:MeasurementUnit
+      ((?<number> [mention = "NumberWord" & !mention = "PossibleYear"]) ([tag = IN] [tag = CD])? [!tag = /^NN|LRB|CD/]{0,2} [word = /,|and|to/]*)+ @number:Number @unit:MeasurementUnit
 
   - name: measurement-percentage
     label: Percentage

--- a/main/src/test/scala/org/clulab/numeric/TestNumericEntityRecognition.scala
+++ b/main/src/test/scala/org/clulab/numeric/TestNumericEntityRecognition.scala
@@ -71,6 +71,11 @@ class TestNumericEntityRecognition extends FlatSpec with Matchers {
      ensure("It was 2000, May", Interval(2, 5), "DATE", "2000-05-XX")
    }
 
+  // this is to ensure the measurement-3 rule does not capture a preceding year as a value that shares a unit with another value (as in "yields were set to 6.4, 7.9, and 7.1 t/ha")
+  it should "not include a year as as a conjoined value" in {
+    ensure("average yield reached 72 t ha-1 in 1999 and 82 t ha-1 in 2000", Interval(7, 8), "DATE", "1999-XX-XX")
+  }
+
   it should "recognize numeric dates" in {
     // these should be captured by rule date-yyyy-mm-dd
     ensure("It is 2000:05:12", Interval(2, 3), "DATE", "2000-05-12")


### PR DESCRIPTION
Not allowing year-like values to share units with other values. Example of values sharing units:
```
yields were set to 7.9 and 7.1 t/ha
```
We want to avoid 1999 being associated with the unit `t ha-1`:
```
average yield reached 72 t ha-1 in 1999 and 82 t ha-1 in 2000
```
