### PR TITLE
Added support for keeping track of "section names"

### DIFF
--- a/corenlp/src/test/scala/org/clulab/serialization/TestDocumentSerializer.scala
+++ b/corenlp/src/test/scala/org/clulab/serialization/TestDocumentSerializer.scala
@@ -3,6 +3,7 @@ package org.clulab.serialization
 import org.clulab.processors.Processor
 import org.clulab.processors.corenlp.CoreNLPProcessor
 import org.clulab.processors.shallownlp.ShallowNLPProcessor
+import org.scalatest.OptionValues.convertOptionToValuable
 import org.scalatest._
 
 /**
@@ -99,6 +100,33 @@ Phosphorylation of ASPP2 by MAPK is required for the RAS-induced translocation o
     val out2 = ser.save(doc2, keepText=true)
     // println(out2)                          // DEBUGGING
     (out2) should be (out1)
+  }
+
+  "DocumentSerializer" should "save and section names when provided" in {
+    val doc1 = proc.annotate(bigText, true) // explicit keep text
+
+    // Add a section name hierarchy to the first and last sentences of this document
+    val firstSection = Array("Document Title")
+    val lastSections = Array("Last subsection", "Last section")
+
+    doc1.sentences.head.sections = Some(firstSection)
+    doc1.sentences.last.sections = Some(lastSections)
+
+    val out1 = ser.save(doc1, keepText = true)
+
+    val doc2 = ser.load(out1)
+
+    val firstSentence = doc2.sentences.head
+    val lastSentence = doc2.sentences.last
+
+    firstSentence.sections.value should be (Array("Document Title"))
+    lastSentence.sections.value should be (Array("Last subsection", "Last section"))
+
+    doc2.sentences.drop(1).dropRight(1) foreach {
+      s =>
+        s.sections should be (None)
+    }
+
   }
 
 }

--- a/main/src/main/scala/org/clulab/processors/Sentence.scala
+++ b/main/src/main/scala/org/clulab/processors/Sentence.scala
@@ -43,6 +43,11 @@ class Sentence(
   var graphs: GraphMap = new GraphMap
   /** Relation triples from OpenIE */
   var relations:Option[Array[RelationTriple]] = None
+  /**
+    * Hierarchy of section names to which this sentence belongs.
+    * The first element is inner-most sub-section name, and the last is the top-most section name
+    */
+  var section:Option[Array[String]] = None
 
 
   def size:Int = raw.length

--- a/main/src/main/scala/org/clulab/processors/Sentence.scala
+++ b/main/src/main/scala/org/clulab/processors/Sentence.scala
@@ -47,7 +47,7 @@ class Sentence(
     * Hierarchy of section names to which this sentence belongs.
     * The first element is inner-most sub-section name, and the last is the top-most section name
     */
-  var section:Option[Array[String]] = None
+  var sections:Option[Array[String]] = None
 
 
   def size:Int = raw.length
@@ -97,7 +97,8 @@ class Sentence(
     val h7 = mix(h6, getAnnotationsHash(norms))
     val h8 = mix(h7, getAnnotationsHash(chunks))
     val h9 = mix(h8, if (dependencies.nonEmpty) dependencies.get.equivalenceHash else None.hashCode)
-    finalizeHash(h9, 10) 
+    val h10 = mix(h9, getAnnotationsHash(sections))
+    finalizeHash(h10, 11)
   }
 
   /**
@@ -195,18 +196,19 @@ object Sentence {
     new Sentence(raw, startOffsets, endOffsets, words)
 
   def apply(
-    raw: Array[String],
-    startOffsets: Array[Int],
-    endOffsets: Array[Int],
-    words: Array[String],
-    tags: Option[Array[String]],
-    lemmas: Option[Array[String]],
-    entities: Option[Array[String]],
-    norms: Option[Array[String]],
-    chunks: Option[Array[String]],
-    tree: Option[Tree],
-    deps: GraphMap,
-    relations: Option[Array[RelationTriple]]
+             raw: Array[String],
+             startOffsets: Array[Int],
+             endOffsets: Array[Int],
+             words: Array[String],
+             tags: Option[Array[String]],
+             lemmas: Option[Array[String]],
+             entities: Option[Array[String]],
+             norms: Option[Array[String]],
+             chunks: Option[Array[String]],
+             tree: Option[Tree],
+             deps: GraphMap,
+             relations: Option[Array[RelationTriple]],
+             sections: Option[Array[String]]
   ): Sentence = {
     val s = Sentence(raw, startOffsets, endOffsets, words)
     // update annotations
@@ -218,6 +220,7 @@ object Sentence {
     s.syntacticTree = tree
     s.graphs = deps
     s.relations = relations
+    s.sections = sections
     s
   }
 

--- a/main/src/main/scala/org/clulab/processors/clu/CluProcessor.scala
+++ b/main/src/main/scala/org/clulab/processors/clu/CluProcessor.scala
@@ -251,7 +251,8 @@ class CluProcessor protected (
         chunks = None,
         tree = None,
         deps = EMPTY_GRAPH,
-        relations = None
+        relations = None,
+        sections = None
       )
 
       ner.find(sentence)


### PR DESCRIPTION
Added a new optional array field to the sentence object called `sections`. This optional field is meant to keep a hierarchy of section names to which the sentence belongs in its corresponding document.

`sections` values are assigned the by client code, not a processor instance, and its interpretation is left to the user of the field. The main use case for this is REACH, where we can keep track of the section names from the XML structure.

This PR adds support also for efficient serialization using `DocumentSerializer` as well as a test case. 

The code is backwards compatible and no existing code base should break if this PR is merged.