### PR TITLE
Move all hash code to HashCode class

### DIFF
--- a/main/src/main/scala/org/clulab/odin/Mention.scala
+++ b/main/src/main/scala/org/clulab/odin/Mention.scala
@@ -1,12 +1,13 @@
 package org.clulab.odin
 
-import scala.util.matching.Regex
-import scala.util.hashing.MurmurHash3._
-import org.clulab.struct.Interval
+import org.clulab.odin.impl.StringMatcher
 import org.clulab.processors.Document
 import org.clulab.scala.WrappedArray._
+import org.clulab.struct.Interval
 import org.clulab.utils.DependencyUtils
-import org.clulab.odin.impl.StringMatcher
+import org.clulab.utils.Hash
+
+import scala.util.matching.Regex
 
 
 trait Mention extends Equals with Ordered[Mention] with Serializable {
@@ -187,26 +188,29 @@ trait Mention extends Equals with Ordered[Mention] with Serializable {
 
   protected lazy val cachedHashCode = calculateHashCode
 
-  protected def calculateHashCode: Int = {
-    val h0 = stringHash("org.clulab.odin.Mention")
-    val h1 = mix(h0, labels.hashCode)
-    val h2 = mix(h1, tokenInterval.hashCode)
-    val h3 = mix(h2, sentence.hashCode)
-    val h4 = mix(h3, document.ambivalenceHash)
-    val h5 = mix(h4, argumentsHashCode)
-    val h6 = mixLast(h5, unorderedHash(attachments))
-    finalizeHash(h6, 6)
-  }
+  protected def calculateHashCode: Int = Hash.withLast(
+    Hash("org.clulab.odin.Mention"),
+    labels.hashCode,
+    tokenInterval.hashCode,
+    sentence.hashCode,
+    document.ambivalenceHash,
+    argsHash,
+    Hash.unordered(attachments)
+  )
 
-  private def argumentsHashCode: Int = {
-    val h0 = stringHash("Mention.arguments")
-    val hs = arguments map {
-      case (name, args) => mix(stringHash(name), unorderedHash(args))
+  // TODO: Compare this to argsHash in the package.
+  private def argsHash: Int = {
+    val argHashes = arguments.map { case (name, mentions) =>
+      val seed = Hash(name)
+      val data = mentions
+
+      Hash.mix(seed, Hash.unordered(data))
     }
-    val h = mixLast(h0, unorderedHash(hs))
-    finalizeHash(h, arguments.size)
+    Hash.withLast(arguments.size)(
+      Hash("Mention.arguments"),
+      Hash.unordered(argHashes)
+    )
   }
-
 }
 
 @SerialVersionUID(1L)
@@ -318,12 +322,11 @@ class EventMention(
   }
 
   // trigger should be part of the hashCode too
-  protected override def calculateHashCode: Int = {
-    val h0 = stringHash("org.clulab.odin.EventMention")
-    val h1 = mix(h0, super.calculateHashCode)
-    val h2 = mixLast(h1, trigger.hashCode)
-    finalizeHash(h2, 2)
-  }
+  protected override def calculateHashCode: Int = Hash.withLast(
+    Hash("org.clulab.odin.EventMention"),
+    super.calculateHashCode,
+    trigger.hashCode
+  )
 
   // Copy constructor for EventMention
   def copy(

--- a/main/src/main/scala/org/clulab/struct/DirectedGraph.scala
+++ b/main/src/main/scala/org/clulab/struct/DirectedGraph.scala
@@ -1,10 +1,10 @@
 package org.clulab.struct
 
 import org.clulab.scala.WrappedArray._
+import org.clulab.utils.Hash
 
 import scala.collection.mutable
 import scala.collection.mutable.{ArrayBuffer, ListBuffer}
-import scala.util.hashing.MurmurHash3._
 
 
 /**
@@ -41,14 +41,10 @@ case class DirectedGraph[E](
     *
     * @return a hash (Int) based on the [[edges]]
     */
-  def equivalenceHash: Int = {
-    val stringCode = "org.clulab.struct.DirectedGraph"
-    // the seed (not counted in the length of finalizeHash)
-    // decided to use the class name
-    val h0 = stringHash(stringCode)
-    val h1 = mix(h0, edges.hashCode)
-    finalizeHash(h1, 1)
-  }
+  def equivalenceHash: Int = Hash(
+    Hash("org.clulab.struct.DirectedGraph"),
+    edges.hashCode
+  )
 
   protected def computeSize(edges: List[Edge[_]]):Int = {
     val maxVertex = edges.foldLeft(0) { (max, edge) => math.max(max, math.max(edge.source, edge.destination)) }

--- a/main/src/main/scala/org/clulab/utils/Hash.scala
+++ b/main/src/main/scala/org/clulab/utils/Hash.scala
@@ -1,0 +1,50 @@
+package org.clulab.utils
+
+import scala.util.hashing.MurmurHash3
+
+object Hash {
+  val symmetricSeed = 0xb592f7ae
+
+  def apply(string: String): Int = stringHash(string)
+
+  def apply(seed: Int, data: Int*): Int = {
+    finalizeHash(data.foldLeft(seed)(mix), data.length)
+  }
+
+  // TODO: This count should probably not be used.  The caller is probably messed up.
+  def withLast(count: Int)(seed: Int, data: Int*): Int = withLastCount(count)(seed, data)
+
+  def withLast(seed: Int, data: Int*): Int = withLastCount(data.length)(seed, data)
+
+  def withLastCount(count: Int)(seed: Int, data: Seq[Int]): Int = {
+    val iterator = data.iterator
+
+    def loop(value: Int, remaining: Int): Int = {
+      val result = remaining match {
+        case 0 => finalizeHash(value, count)
+        case 1 => loop(mixLast(value, iterator.next()), 0)
+        case _ => loop(mix(value, iterator.next()), remaining - 1)
+      }
+
+      result
+    }
+
+    loop(seed, data.length)
+  }
+
+  def ordered(xs: TraversableOnce[Any]): Int = orderedHash(xs)
+
+  def unordered(xs: TraversableOnce[Any]): Int = unorderedHash(xs)
+
+  def stringHash(x: String): Int = MurmurHash3.stringHash(x)
+
+  def orderedHash(xs: TraversableOnce[Any]): Int = MurmurHash3.orderedHash(xs)
+
+  def unorderedHash(xs: TraversableOnce[Any]): Int = MurmurHash3.unorderedHash(xs)
+
+  def finalizeHash(hash: Int, length: Int): Int = MurmurHash3.finalizeHash(hash, length)
+
+  def mix(hash: Int, data: Int): Int = MurmurHash3.mix(hash, data)
+
+  def mixLast(hash: Int, data: Int): Int = MurmurHash3.mixLast(hash, data)
+}

--- a/main/src/test/scala-2.11_2.12/org/clulab/utils/TestHash.scala
+++ b/main/src/test/scala-2.11_2.12/org/clulab/utils/TestHash.scala
@@ -1,0 +1,99 @@
+package org.clulab.utils
+
+import org.clulab.odin.serialization.json._
+import org.clulab.odin.{CrossSentenceMention, EventMention, RelationMention, TextBoundMention, _}
+import org.clulab.processors.clu.CluProcessor
+import org.clulab.sequences.LexiconNER
+import org.clulab.struct.{DirectedGraph, Edge}
+
+class TestHash extends Test {
+  val customLexiconNer = {
+    val kbsAndCaseInsensitiveMatchings: Seq[(String, Boolean)] = Seq(
+      ("org/clulab/odinstarter/FOOD.tsv", true)
+    )
+    val kbs = kbsAndCaseInsensitiveMatchings.map(_._1)
+    val caseInsensitiveMatchings = kbsAndCaseInsensitiveMatchings.map(_._2)
+
+    LexiconNER(kbs, caseInsensitiveMatchings, None)
+  }
+  val processor = new CluProcessor(optionalNER = Some(customLexiconNer))
+  val extractorEngine = {
+    val rules = FileUtils.getTextFromResource("/org/clulab/odinstarter/main.yml")
+
+    ExtractorEngine(rules)
+  }
+  val document = processor.annotate("John eats cake.")
+  val mentions = extractorEngine.extractFrom(document).sortBy(_.arguments.size)
+  val sortedMentions = mentions.sortBy { mention => (mention.startOffset, mention.endOffset) }
+  val eventMention = sortedMentions.find(_.isInstanceOf[EventMention]).get.asInstanceOf[EventMention]
+  val otherMentions = sortedMentions.filterNot(_.eq(eventMention))
+  val relationMention = eventMention.toRelationMention
+  val crossSentenceMention = newCrossSentenceMention(eventMention, otherMentions.head, otherMentions.last)
+  val allMentions = sortedMentions :+ relationMention :+ crossSentenceMention
+
+  behavior of "Hash"
+
+  it should "compute the expected equivalence hash for a Document" in {
+    val expectedHash = -1960515414
+    val actualHash = document.equivalenceHash
+
+    actualHash should be (expectedHash)
+  }
+
+  def getEquivalenceHash(mention: Mention): Int = mention match {
+    case mention: TextBoundMention     => mention.equivalenceHash
+    case mention: EventMention         => mention.equivalenceHash
+    case mention: RelationMention      => mention.equivalenceHash
+    case mention: CrossSentenceMention => mention.equivalenceHash
+  }
+
+  def newCrossSentenceMention(mention: EventMention, anchor: Mention, neighbor: Mention): CrossSentenceMention = {
+    new CrossSentenceMention(
+      mention.labels,
+      anchor,
+      neighbor,
+      mention.arguments,
+      mention.document,
+      mention.keep,
+      mention.foundBy,
+      mention.attachments
+    )
+  }
+
+  it should "compute the expected equivalence hashes for Mentions" in {
+    val expectedHashes = Array(-1163474360, 1678747586, 308621545, 1846645205, -1357918569)
+    val actualHashes = allMentions.map(getEquivalenceHash)
+
+    actualHashes should be (expectedHashes)
+  }
+
+  it should "compute the expected hashCode for Mentions" in {
+    val expectedHashes = Array(-681771612, -254169462, -1589508928, 823771056, 1600327181)
+    val actualHashes = allMentions.map(_.hashCode)
+
+    actualHashes should be(expectedHashes)
+  }
+
+  it should "compute the expected hashCode for a String" in {
+    val expectedHash = 1077910243
+    val actualHash = "supercalifragilisticexpialidocious".hashCode
+
+    actualHash should be(expectedHash)
+  }
+
+  it should "compute the expected equivalence hash for a String" in {
+    val expectedHash = 887441175
+    val actualHash = Hash("supercalifragilisticexpialidocious")
+
+    actualHash should be(expectedHash)
+  }
+
+  it should "compute the expected equivalence hash for a DirectedGraph" in {
+    val expectedHash = 1945759943
+    val edge = Edge(0, 1, "relation")
+    val directedGraph = DirectedGraph(List(edge))
+    val actualHash = directedGraph.equivalenceHash
+
+    actualHash should be (expectedHash)
+  }
+}

--- a/main/src/test/scala-2.13/org/clulab/utils/TestHash.scala
+++ b/main/src/test/scala-2.13/org/clulab/utils/TestHash.scala
@@ -1,13 +1,10 @@
-package org.clulab.processors
+package org.clulab.utils
 
-import org.clulab.odin.{CrossSentenceMention, EventMention, ExtractorEngine, Mention, RelationMention, TextBoundMention}
 import org.clulab.odin.serialization.json._
+import org.clulab.odin.{CrossSentenceMention, EventMention, RelationMention, TextBoundMention, _}
 import org.clulab.processors.clu.CluProcessor
 import org.clulab.sequences.LexiconNER
-import org.clulab.utils.FileUtils
-import org.clulab.utils.Test
-
-import java.io.File
+import org.clulab.struct.{DirectedGraph, Edge}
 
 class TestHash extends Test {
   val customLexiconNer = {
@@ -17,14 +14,12 @@ class TestHash extends Test {
     val kbs = kbsAndCaseInsensitiveMatchings.map(_._1)
     val caseInsensitiveMatchings = kbsAndCaseInsensitiveMatchings.map(_._2)
 
-    val result = LexiconNER(kbs, caseInsensitiveMatchings, None)
-    println(result.getLabels)
-    result
+    LexiconNER(kbs, caseInsensitiveMatchings, None)
   }
   val processor = new CluProcessor(optionalNER = Some(customLexiconNer))
   val extractorEngine = {
     val rules = FileUtils.getTextFromResource("/org/clulab/odinstarter/main.yml")
-    println(rules)
+
     ExtractorEngine(rules)
   }
   val document = processor.annotate("John eats cake.")
@@ -39,7 +34,7 @@ class TestHash extends Test {
   behavior of "Hash"
 
   it should "compute the expected equivalence hash for a Document" in {
-    val expectedHash = -1960515414
+    val expectedHash = 1145238653
     val actualHash = document.equivalenceHash
 
     actualHash should be (expectedHash)
@@ -66,14 +61,14 @@ class TestHash extends Test {
   }
 
   it should "compute the expected equivalence hashes for Mentions" in {
-    val expectedHashes = Array(-1163474360, 1678747586, 308621545, 1846645205, -1357918569)
+    val expectedHashes = Array(1317064233, 418554464, 269168883, 1021871359, 1657321605)
     val actualHashes = allMentions.map(getEquivalenceHash)
 
     actualHashes should be (expectedHashes)
   }
 
   it should "compute the expected hashCode for Mentions" in {
-    val expectedHashes = Array(-681771612, -254169462, -1589508928, 823771056, 1600327181)
+    val expectedHashes = Array(1493402696, -1515246319, 205797074, -1416141606, -1294266266)
     val actualHashes = allMentions.map(_.hashCode)
 
     actualHashes should be(expectedHashes)
@@ -84,5 +79,21 @@ class TestHash extends Test {
     val actualHash = "supercalifragilisticexpialidocious".hashCode
 
     actualHash should be(expectedHash)
+  }
+
+  it should "compute the expected equivalence hash for a String" in {
+    val expectedHash = 887441175
+    val actualHash = Hash("supercalifragilisticexpialidocious")
+
+    actualHash should be(expectedHash)
+  }
+
+  it should "compute the expected equivalence hash for a DirectedGraph" in {
+    val expectedHash = 821315811
+    val edge = Edge(0, 1, "relation")
+    val directedGraph = DirectedGraph(List(edge))
+    val actualHash = directedGraph.equivalenceHash
+
+    actualHash should be (expectedHash)
   }
 }

--- a/main/src/test/scala-3/org/clulab/utils/TestHash.scala
+++ b/main/src/test/scala-3/org/clulab/utils/TestHash.scala
@@ -1,0 +1,99 @@
+package org.clulab.utils
+
+import org.clulab.odin.serialization.json._
+import org.clulab.odin.{CrossSentenceMention, EventMention, RelationMention, TextBoundMention, _}
+import org.clulab.processors.clu.CluProcessor
+import org.clulab.sequences.LexiconNER
+import org.clulab.struct.{DirectedGraph, Edge}
+
+class TestHash extends Test {
+  val customLexiconNer = {
+    val kbsAndCaseInsensitiveMatchings: Seq[(String, Boolean)] = Seq(
+      ("org/clulab/odinstarter/FOOD.tsv", true)
+    )
+    val kbs = kbsAndCaseInsensitiveMatchings.map(_._1)
+    val caseInsensitiveMatchings = kbsAndCaseInsensitiveMatchings.map(_._2)
+
+    LexiconNER(kbs, caseInsensitiveMatchings, None)
+  }
+  val processor = new CluProcessor(optionalNER = Some(customLexiconNer))
+  val extractorEngine = {
+    val rules = FileUtils.getTextFromResource("/org/clulab/odinstarter/main.yml")
+
+    ExtractorEngine(rules)
+  }
+  val document = processor.annotate("John eats cake.")
+  val mentions = extractorEngine.extractFrom(document).sortBy(_.arguments.size)
+  val sortedMentions = mentions.sortBy { mention => (mention.startOffset, mention.endOffset) }
+  val eventMention = sortedMentions.find(_.isInstanceOf[EventMention]).get.asInstanceOf[EventMention]
+  val otherMentions = sortedMentions.filterNot(_.eq(eventMention))
+  val relationMention = eventMention.toRelationMention
+  val crossSentenceMention = newCrossSentenceMention(eventMention, otherMentions.head, otherMentions.last)
+  val allMentions = sortedMentions :+ relationMention :+ crossSentenceMention
+
+  behavior of "Hash"
+
+  it should "compute the expected equivalence hash for a Document" in {
+    val expectedHash = 1145238653
+    val actualHash = document.equivalenceHash
+
+    actualHash should be (expectedHash)
+  }
+
+  def getEquivalenceHash(mention: Mention): Int = mention match {
+    case mention: TextBoundMention     => mention.equivalenceHash
+    case mention: EventMention         => mention.equivalenceHash
+    case mention: RelationMention      => mention.equivalenceHash
+    case mention: CrossSentenceMention => mention.equivalenceHash
+  }
+
+  def newCrossSentenceMention(mention: EventMention, anchor: Mention, neighbor: Mention): CrossSentenceMention = {
+    new CrossSentenceMention(
+      mention.labels,
+      anchor,
+      neighbor,
+      mention.arguments,
+      mention.document,
+      mention.keep,
+      mention.foundBy,
+      mention.attachments
+    )
+  }
+
+  it should "compute the expected equivalence hashes for Mentions" in {
+    val expectedHashes = Array(1317064233, 418554464, 269168883, 1021871359, 1657321605)
+    val actualHashes = allMentions.map(getEquivalenceHash)
+
+    actualHashes should be (expectedHashes)
+  }
+
+  it should "compute the expected hashCode for Mentions" in {
+    val expectedHashes = Array(1493402696, -1515246319, 205797074, -1416141606, -1294266266)
+    val actualHashes = allMentions.map(_.hashCode)
+
+    actualHashes should be(expectedHashes)
+  }
+
+  it should "compute the expected hashCode for a String" in {
+    val expectedHash = 1077910243
+    val actualHash = "supercalifragilisticexpialidocious".hashCode
+
+    actualHash should be(expectedHash)
+  }
+
+  it should "compute the expected equivalence hash for a String" in {
+    val expectedHash = 887441175
+    val actualHash = Hash("supercalifragilisticexpialidocious")
+
+    actualHash should be(expectedHash)
+  }
+
+  it should "compute the expected equivalence hash for a DirectedGraph" in {
+    val expectedHash = 821315811
+    val edge = Edge(0, 1, "relation")
+    val directedGraph = DirectedGraph(List(edge))
+    val actualHash = directedGraph.equivalenceHash
+
+    actualHash should be (expectedHash)
+  }
+}

--- a/main/src/test/scala/org/clulab/processors/TestHash.scala
+++ b/main/src/test/scala/org/clulab/processors/TestHash.scala
@@ -1,0 +1,81 @@
+package org.clulab.processors
+
+import org.clulab.odin.{CrossSentenceMention, EventMention, ExtractorEngine, Mention, RelationMention, TextBoundMention}
+import org.clulab.odin.serialization.json._
+import org.clulab.processors.clu.CluProcessor
+import org.clulab.sequences.LexiconNER
+import org.clulab.utils.FileUtils
+import org.clulab.utils.Test
+
+import java.io.File
+
+class TestHash extends Test {
+  val resourceDir: File = new File("./src/main/resources")
+  val customLexiconNer = {
+    val kbsAndCaseInsensitiveMatchings: Seq[(String, Boolean)] = Seq(
+      ("org/clulab/odinstarter/FOOD.tsv", true)
+    )
+    val kbs = kbsAndCaseInsensitiveMatchings.map(_._1)
+    val caseInsensitiveMatchings = kbsAndCaseInsensitiveMatchings.map(_._2)
+
+    LexiconNER(kbs, caseInsensitiveMatchings, Some(resourceDir))
+  }
+  val processor = new CluProcessor(optionalNER = Some(customLexiconNer))
+  val extractorEngine = {
+    val masterResource = "/org/clulab/odinstarter/main.yml"
+    val masterFile = new File(resourceDir, masterResource.drop(1))
+    val rules = FileUtils.getTextFromFile(masterFile)
+    ExtractorEngine(rules, ruleDir = Some(resourceDir))
+  }
+  val document = processor.annotate("John eats cake.")
+  val mentions = extractorEngine.extractFrom(document).sortBy(_.arguments.size)
+  val sortedMentions = mentions.sortBy { mention => (mention.startOffset, mention.endOffset) }
+  val eventMention = sortedMentions.find(_.isInstanceOf[EventMention]).get.asInstanceOf[EventMention]
+  val otherMentions = sortedMentions.filterNot(_.eq(eventMention))
+  val relationMention = eventMention.toRelationMention
+  val crossSentenceMention = newCrossSentenceMention(eventMention, otherMentions.head, otherMentions.last)
+  val allMentions = sortedMentions :+ relationMention :+ crossSentenceMention
+
+  behavior of "Hash"
+
+  it should "compute the expected equivalence hash for a Document" in {
+    val expectedHash = -1960515414
+    val actualHash = document.equivalenceHash
+
+    actualHash should be (expectedHash)
+  }
+
+  def getEquivalenceHash(mention: Mention): Int = mention match {
+    case mention: TextBoundMention     => mention.equivalenceHash
+    case mention: EventMention         => mention.equivalenceHash
+    case mention: RelationMention      => mention.equivalenceHash
+    case mention: CrossSentenceMention => mention.equivalenceHash
+  }
+
+  def newCrossSentenceMention(mention: EventMention, anchor: Mention, neighbor: Mention): CrossSentenceMention = {
+    new CrossSentenceMention(
+      mention.labels,
+      anchor,
+      neighbor,
+      mention.arguments,
+      mention.document,
+      mention.keep,
+      mention.foundBy,
+      mention.attachments
+    )
+  }
+
+  it should "compute the expected equivalence hashes for Mentions" in {
+    val expectedHashes = Array(-1163474360, 1678747586, 308621545, 1846645205, -1357918569)
+    val actualHashes = allMentions.map(getEquivalenceHash)
+
+    actualHashes should be (expectedHashes)
+  }
+
+  it should "compute the expected hashCode for Mentions" in {
+    val expectedHashes = Array(-681771612, -254169462, -1589508928, 823771056, 1600327181)
+    val actualHashes = allMentions.map(_.hashCode)
+
+    actualHashes should be(expectedHashes)
+  }
+}

--- a/main/src/test/scala/org/clulab/processors/TestHash.scala
+++ b/main/src/test/scala/org/clulab/processors/TestHash.scala
@@ -10,7 +10,7 @@ import org.clulab.utils.Test
 import java.io.File
 
 class TestHash extends Test {
-  val resourceDir: File = new File("./src/main/resources")
+  val resourceDir: File = new File("./main/src/main/resources")
   val customLexiconNer = {
     val kbsAndCaseInsensitiveMatchings: Seq[(String, Boolean)] = Seq(
       ("org/clulab/odinstarter/FOOD.tsv", true)

--- a/main/src/test/scala/org/clulab/processors/TestHash.scala
+++ b/main/src/test/scala/org/clulab/processors/TestHash.scala
@@ -10,7 +10,6 @@ import org.clulab.utils.Test
 import java.io.File
 
 class TestHash extends Test {
-  val resourceDir: File = new File("./main/src/main/resources")
   val customLexiconNer = {
     val kbsAndCaseInsensitiveMatchings: Seq[(String, Boolean)] = Seq(
       ("org/clulab/odinstarter/FOOD.tsv", true)
@@ -18,14 +17,15 @@ class TestHash extends Test {
     val kbs = kbsAndCaseInsensitiveMatchings.map(_._1)
     val caseInsensitiveMatchings = kbsAndCaseInsensitiveMatchings.map(_._2)
 
-    LexiconNER(kbs, caseInsensitiveMatchings, Some(resourceDir))
+    val result = LexiconNER(kbs, caseInsensitiveMatchings, None)
+    println(result.getLabels)
+    result
   }
   val processor = new CluProcessor(optionalNER = Some(customLexiconNer))
   val extractorEngine = {
-    val masterResource = "/org/clulab/odinstarter/main.yml"
-    val masterFile = new File(resourceDir, masterResource.drop(1))
-    val rules = FileUtils.getTextFromFile(masterFile)
-    ExtractorEngine(rules, ruleDir = Some(resourceDir))
+    val rules = FileUtils.getTextFromResource("/org/clulab/odinstarter/main.yml")
+    println(rules)
+    ExtractorEngine(rules)
   }
   val document = processor.annotate("John eats cake.")
   val mentions = extractorEngine.extractFrom(document).sortBy(_.arguments.size)

--- a/main/src/test/scala/org/clulab/processors/TestHash.scala
+++ b/main/src/test/scala/org/clulab/processors/TestHash.scala
@@ -78,4 +78,11 @@ class TestHash extends Test {
 
     actualHashes should be(expectedHashes)
   }
+
+  it should "compute the expected hashCode for a String" in {
+    val expectedHash = 1077910243
+    val actualHash = "supercalifragilisticexpialidocious".hashCode
+
+    actualHash should be(expectedHash)
+  }
 }


### PR DESCRIPTION
Let the computer tally the count needed for finalization and transfer intermediate results from one state to the next.  Also show inconsistencies in how hashes are being used.