### PR TITLE
Added "fall" as a season & normalized "week of month" patterns

### DIFF
--- a/main/src/main/resources/org/clulab/numeric/SEASON.tsv
+++ b/main/src/main/resources/org/clulab/numeric/SEASON.tsv
@@ -8,7 +8,7 @@ winter  // XXXX-12-21 -- XXXX-03-20
 spring  // XXXX-03-20 -- XXXX-06-21
 summer  // XXXX-06-21 -- XXXX-09-22
 autumn  // XXXX-09-22 -- XXXX-12-21
-
+fall    // XXXX-09-22 -- XXXX-12-21
 
 
 

--- a/main/src/main/resources/org/clulab/numeric/WEEK.tsv
+++ b/main/src/main/resources/org/clulab/numeric/WEEK.tsv
@@ -1,0 +1,10 @@
+#
+# list of weeks and their date ranges, case insensitive so everything is lower case for simplicity
+# the comments after // are required by WeekNormalizer to get the week date ranges! Do not remove
+# the format for the date ranges must be MM-dd:MM-dd or MM:MM
+# note: multi-word phrases must be tokenized in the same way as our tokenizer. If not sure, try the phrases in ./shell first!
+#
+first week   // XXXX-XX-01 -- XXXX-XX-07
+second week  // XXXX-XX-08 -- XXXX-XX-14
+third week   // XXXX-XX-15 -- XXXX-XX-21
+fourth week  // XXXX-XX-22 -- XXXX-XX-28

--- a/main/src/main/resources/org/clulab/numeric/WEEK.tsv
+++ b/main/src/main/resources/org/clulab/numeric/WEEK.tsv
@@ -4,7 +4,9 @@
 # the format for the date ranges must be MM-dd:MM-dd or MM:MM
 # note: multi-word phrases must be tokenized in the same way as our tokenizer. If not sure, try the phrases in ./shell first!
 #
-first week   // XXXX-XX-01 -- XXXX-XX-07
-second week  // XXXX-XX-08 -- XXXX-XX-14
-third week   // XXXX-XX-15 -- XXXX-XX-21
-fourth week  // XXXX-XX-22 -- XXXX-XX-28
+first week       // XXXX-XX-01 -- XXXX-XX-07
+second week      // XXXX-XX-08 -- XXXX-XX-14
+third week       // XXXX-XX-15 -- XXXX-XX-21
+fourth week      // XXXX-XX-22 -- XXXX-XX-28
+first two weeks  // XXXX-XX-01 -- XXXX-XX-14
+second two weeks // XXXX-XX-15 -- XXXX-XX-28

--- a/main/src/main/resources/org/clulab/numeric/date-ranges.yml
+++ b/main/src/main/resources/org/clulab/numeric/date-ranges.yml
@@ -94,6 +94,15 @@
   pattern: |
     (?<week> /(?i)(first|second|third|fourth|last)/ /(?i)week/) /(?i)of/ @month:PossibleMonth
 
+- name: date-range-10
+  priority: ${rulepriority}
+  label: DateRange
+  type: token
+  example: "First two weeks of May"
+  action: mkDateRangeMentionWithWeek
+  pattern: |
+    (?<week> /(?i)(first|second|last)/ /(?i)two/ /(?i)weeks/) /(?i)of/ @month:PossibleMonth
+
 - name: date-unbound-range-1
   priority: ${rulepriority}
   label: DateRange

--- a/main/src/main/resources/org/clulab/numeric/date-ranges.yml
+++ b/main/src/main/resources/org/clulab/numeric/date-ranges.yml
@@ -85,6 +85,15 @@
   pattern: |
     /(?i)until|through/ @date1:Date
 
+- name: date-range-9
+  priority: ${rulepriority}
+  label: DateRange
+  type: token
+  example: "First week of May"
+  action: mkDateRangeMentionWithWeek
+  pattern: |
+    (?<week> /(?i)(first|second|third|fourth|last)/ /(?i)week/) /(?i)of/ @month:PossibleMonth
+
 - name: date-unbound-range-1
   priority: ${rulepriority}
   label: DateRange

--- a/main/src/main/scala/org/clulab/numeric/NumericEntityRecognizer.scala
+++ b/main/src/main/scala/org/clulab/numeric/NumericEntityRecognizer.scala
@@ -65,6 +65,7 @@ object NumericEntityRecognizer {
   // For the sake of SeasonNormalizer, this does have a leading /.
   val seasonPath = "/org/clulab/numeric/SEASON.tsv"
   val unitNormalizerPath = "/org/clulab/numeric/MEASUREMENT-UNIT.tsv"
+  val weekPath = "/org/clulab/numeric/WEEK.tsv"
 
   // this matches essential dictionaries such as month names
   def mkLexiconNer(seasonsPath: String): LexiconNER = {
@@ -101,11 +102,12 @@ object NumericEntityRecognizer {
     ExtractorEngine(rules, actions, actions.cleanupAction, ruleDir = Some(ruleDir))
   }
 
-  def apply(seasonPath: String = seasonPath, unitNormalizerPath: String = unitNormalizerPath): NumericEntityRecognizer = {
+  def apply(seasonPath: String = seasonPath, unitNormalizerPath: String = unitNormalizerPath, weekPath: String = weekPath): NumericEntityRecognizer = {
     val lexiconNer = mkLexiconNer(seasonPath)
     val seasonNormalizer = new SeasonNormalizer(seasonPath)
     val unitNormalizer = new UnitNormalizer(unitNormalizerPath)
-    val numericActions = new NumericActions(seasonNormalizer, unitNormalizer)
+    val weekNormalizer = new WeekNormalizer(weekPath)
+    val numericActions = new NumericActions(seasonNormalizer, unitNormalizer, weekNormalizer)
     val extractorEngine = mkExtractor(numericActions)
 
     new NumericEntityRecognizer(lexiconNer, numericActions, extractorEngine)

--- a/main/src/main/scala/org/clulab/numeric/TempEvalFormatter.scala
+++ b/main/src/main/scala/org/clulab/numeric/TempEvalFormatter.scala
@@ -51,7 +51,7 @@ object TempEvalFormatter {
     }
   }
 
-  private def convertLiteralMonth(s: String): Int = {
+  def convertLiteralMonth(s: String): Int = {
     val v = s.toLowerCase()
 
     if(v.startsWith("jan")) 1

--- a/main/src/main/scala/org/clulab/numeric/WeekNormalizer.scala
+++ b/main/src/main/scala/org/clulab/numeric/WeekNormalizer.scala
@@ -1,0 +1,62 @@
+package org.clulab.numeric
+
+import java.io.File
+import java.time.{Month, YearMonth}
+
+import org.clulab.sequences.CommentedStandardKbSource
+import org.clulab.utils.Sourcer
+
+import scala.collection.mutable
+import scala.io.Source
+import scala.util.Using
+
+class WeekNormalizer(weekPath: String) {
+  val normMapper = WeekNormalizer.readNormsFromResource(weekPath)
+
+  /** Normalizes seasons */
+  def norm(text: Seq[String]): Option[WeekRange] = {
+    val week = text.mkString(" ").toLowerCase()
+
+    normMapper.get(week)
+  }
+}
+
+object WeekNormalizer {
+
+  def readNormsFromResource(path: String): Map[String, WeekRange] = {
+    val customResourcePath = new File(NumericEntityRecognizer.resourceDir, path)
+
+    if (customResourcePath.exists)
+      Using.resource(Sourcer.sourceFromFile(customResourcePath))(readNormsFromSource)
+    else
+      Using.resource(Sourcer.sourceFromResource(path))(readNormsFromSource)
+  }
+
+  def readNormsFromSource(source: Source): Map[String, WeekRange] = {
+    val norms = new mutable.HashMap[String, WeekRange]()
+
+    CommentedStandardKbSource.read(source) { (week, normOpt, unitClassOpt) =>
+      assert(normOpt.isDefined) // We're insisting on this.
+
+      val norm = normOpt.get.split("--").map(_.trim)
+      val (start, end) = norm match {
+        case Array(start, end) => (start, end)
+        case _ => throw new RuntimeException(s"ERROR: incorrect date range in week file")
+      }
+      val startDay = getDay(start)
+      val endDay = getDay(end)
+      norms += week -> WeekRange(startDay, endDay)
+    }
+    norms.toMap
+  }
+
+  private def getDay(date: String): Option[Seq[String]] = {
+    date.split("-") match {
+      case Array(_, _, day) => Some(Seq(day))
+      case _ => throw new RuntimeException(s"ERROR: incorrect date value in week file: $date")
+    }
+  }
+}
+
+case class WeekRange(startDay: Option[Seq[String]],
+                     endDay: Option[Seq[String]])

--- a/main/src/main/scala/org/clulab/numeric/actions/NumericActions.scala
+++ b/main/src/main/scala/org/clulab/numeric/actions/NumericActions.scala
@@ -1,13 +1,13 @@
 package org.clulab.numeric.actions
 
-import org.clulab.numeric.{SeasonNormalizer, UnitNormalizer}
+import org.clulab.numeric.{SeasonNormalizer, UnitNormalizer, WeekNormalizer}
 import org.clulab.odin.{Actions, Mention, State}
 import org.clulab.numeric.mentions._
 import org.clulab.scala.WrappedArrayBuffer._
 
 import scala.collection.mutable.ArrayBuffer
 
-class NumericActions(seasonNormalizer: SeasonNormalizer, unitNormalizer: UnitNormalizer) extends Actions {
+class NumericActions(seasonNormalizer: SeasonNormalizer, unitNormalizer: UnitNormalizer, weekNormalizer: WeekNormalizer) extends Actions {
   //
   // local actions
   //
@@ -96,6 +96,11 @@ class NumericActions(seasonNormalizer: SeasonNormalizer, unitNormalizer: UnitNor
   /** Constructs a DateRangeMention from a token pattern */
   def mkDateRangeMentionWithUntilRef(mentions: Seq[Mention], state: State): Seq[Mention] = {
     convert(mentions, toDateRangeMentionWithUntilRef, "toDateRangeMentionWithUntilRef")
+  }
+
+  /** Constructs a DateRangeMention from a token pattern */
+  def mkDateRangeMentionWithWeek(mentions: Seq[Mention], state: State): Seq[Mention] = {
+    convert(mentions, toDateRangeMentionWithWeek(weekNormalizer), "toDateRangeMentionWithWeek")
   }
 
   /** Constructs a DateRangeMention from a token pattern */

--- a/main/src/main/scala/org/clulab/numeric/mentions/package.scala
+++ b/main/src/main/scala/org/clulab/numeric/mentions/package.scala
@@ -923,20 +923,30 @@ package object mentions {
 
   private def getWeekRange(weekNormalizer: WeekNormalizer)(argName: String, m:Mention): Option[WeekRange] = {
     val wordsOpt = getArgWords(argName, m)
+    print("this is wordsOpt: " ++ wordsOpt.get.mkString(" "))
 
     if (wordsOpt.isEmpty) None
-    else if (wordsOpt.mkString(" ").toLowerCase().equals("last week")) {
-      getLastWeekRange(m)
-    }
+    else if (wordsOpt.get.mkString(" ").toLowerCase().equals("last week")) {getLastWeekRange(m)}
+    else if (wordsOpt.get.mkString(" ").toLowerCase().equals("last two weeks")) {getLastTwoWeeksRange(m)}
     else weekNormalizer.norm(wordsOpt.get)
   }
 
   private def getLastWeekRange(m:Mention): Option[WeekRange] = {
     val month = getArgWords("month", m)
-    val monthObj = Month.of(month.mkString("").toInt)
+    val modifiedMonth = TempEvalFormatter.convertLiteralMonth(month.get.mkString(""))
+    val monthObj = Month.of(modifiedMonth)
     val lastDay = monthObj.length(false)
 
     Some(WeekRange(startDay = Some(Seq((lastDay - 6).toString)), endDay = Some(Seq(lastDay.toString))))
+  }
+
+  private def getLastTwoWeeksRange(m:Mention): Option[WeekRange] = {
+    val month = getArgWords("month", m)
+    val modifiedMonth = TempEvalFormatter.convertLiteralMonth(month.get.mkString(""))
+    val monthObj = Month.of(modifiedMonth)
+    val lastDay = monthObj.length(false)
+
+    Some(WeekRange(startDay = Some(Seq((lastDay - 13).toString)), endDay = Some(Seq(lastDay.toString))))
   }
 
   private def getHoliday(holiday: Seq[String], year: Option[Seq[String]]): (Option[Seq[String]], Option[Seq[String]]) = {

--- a/main/src/test/scala/org/clulab/numeric/TestSeasonNormalizer.scala
+++ b/main/src/test/scala/org/clulab/numeric/TestSeasonNormalizer.scala
@@ -8,6 +8,11 @@ class TestSeasonNormalizer extends Test {
   val autumnText = "When the leaves changed color in autumn 2017 they were the prettiest ever."
   val seasonText = "When the leaves changed color in rainy season 2017 they were the prettiest ever."
 
+  val trueSeason1 = "you have from fall 2021 or 2022." // originally "you have, um, from, you know, fall 2021 or 2022." but fillers removed to prevent parsing errors
+  val trueSeason2 = "do you do that mainly in the fall or in the spring or do you do a little bit of both?"
+  val falseSeason1 = "Don't like to fall corn with corn here."
+  val falseSeason2 = "He does the spring."
+
   val bDateRange = "B-DATE-RANGE"
   val iDateRange = "I-DATE-RANGE"
 
@@ -57,5 +62,37 @@ class TestSeasonNormalizer extends Test {
     seasonEntities should contain (iDateRange)
     seasonNorms shouldNot contain (fallDateRange)
     seasonNorms should contain (seasonDateRange)
+  }
+
+  behavior of "Default SeasonalCluProcessor"
+
+  it should "find true seasons in trueSeason1" in {
+    val processor = new CluProcessor()
+
+    val (trueEntities1, trueNorms1) = mkEntitiesAndNorms(processor, trueSeason1)
+    trueEntities1 should contain (bDateRange)
+  }
+
+  it should "find true seasons in trueSeason2" in {
+    val processor = new CluProcessor()
+
+    val (trueEntities2, trueNorms2) = mkEntitiesAndNorms(processor, trueSeason2)
+    trueEntities2 should contain (bDateRange)
+  }
+
+  it should "not find false seasons in falseSeason1" in {
+    val processor = new CluProcessor()
+
+    val (falseEntities1, falseNorms1) = mkEntitiesAndNorms(processor, falseSeason1)
+    falseEntities1 shouldNot contain (bDateRange)
+    falseEntities1 shouldNot contain (iDateRange)
+  }
+
+  it should "not find false seasons in falseSeason2" in {
+    val processor = new CluProcessor()
+
+    val (falseEntities2, falseNorms2) = mkEntitiesAndNorms(processor, falseSeason2)
+    falseEntities2 shouldNot contain (bDateRange)
+    falseEntities2 shouldNot contain (iDateRange)
   }
 }

--- a/main/src/test/scala/org/clulab/numeric/TestWeekNormalizer.scala
+++ b/main/src/test/scala/org/clulab/numeric/TestWeekNormalizer.scala
@@ -4,14 +4,18 @@ import org.clulab.processors.clu.CluProcessor
 import org.clulab.utils.Test
 
 class TestWeekNormalizer extends Test {
-  val firstWeek = "We planted corn the first week of April."
-//  val lastWeek = "We planted beans the last week of May."
+  val firstTwoWeeks = "We planted corn the first two weeks of April."
+  val secondWeek = "We planted beans the second week of May."
+  val lastWeek = "We planted beans in the last week of June."
+  val lastTwoWeeks = "We planted beans in the last two weeks of February."
 
   val bDateRange = "B-DATE-RANGE"
   val iDateRange = "I-DATE-RANGE"
 
-  val firstWeekAprilRange = "XXXX-04-01 -- XXXX-04-07"
-//  val lastWeekMayRange = "XXXX-05-25 -- XXXX-05-31"
+  val firstTwoWeeksAprilRange = "XXXX-04-01 -- XXXX-04-14"
+  val secondWeekMayRange = "XXXX-05-08 -- XXXX-05-14"
+  val lastWeekJuneRange = "XXXX-06-24 -- XXXX-06-30"
+  val lastTwoWeeksFebRange = "XXXX-02-15 -- XXXX-02-28"
 
   def mkEntitiesAndNorms(processor: CluProcessor, text: String): (Array[String], Array[String]) = {
     val document = processor.annotate(text)
@@ -23,38 +27,44 @@ class TestWeekNormalizer extends Test {
 
   behavior of "WeekCluProcessor"
 
-  it should "find first week of April" in {
+  it should "find first two weeks of April" in {
     val processor = new CluProcessor()
 
-    val (firstWeekEntities, firstWeekNorms) = mkEntitiesAndNorms(processor, firstWeek)
-    firstWeekEntities should contain (bDateRange)
-    firstWeekEntities should contain (iDateRange)
-    firstWeekNorms should contain (firstWeekAprilRange)
-//    firstWeekNorms shouldNot contain (lastWeekMayRange)
-
-//    val (lastWeekEntities, lastWeekNorms) = mkEntitiesAndNorms(processor, lastWeek)
-//    lastWeekEntities should contain (bDateRange)
-//    lastWeekEntities should contain (iDateRange)
-//    lastWeekNorms should contain (lastWeekMayRange)
-//    lastWeekNorms shouldNot contain (firstWeekAprilRange)
+    val (firstTwoWeeksEntities, firstTwoWeeksNorms) = mkEntitiesAndNorms(processor, firstTwoWeeks)
+    firstTwoWeeksEntities should contain(bDateRange)
+    firstTwoWeeksEntities should contain(iDateRange)
+    firstTwoWeeksNorms should contain(firstTwoWeeksAprilRange)
+    firstTwoWeeksNorms shouldNot contain(secondWeekMayRange)
   }
-//
-//  behavior of "Custom SeasonalCluProcessor"
-//
-//  it should "find rainy season but not autumn" in {
-//    // The file name should remain SEASONS, but it can be put in a different location.
-//    val processor = new CluProcessor(seasonPathOpt = Some("/org/clulab/numeric/custom/SEASON.tsv"))
-//
-//    val (autumnEntities, autumnNorms) = mkEntitiesAndNorms(processor, autumnText)
-//    autumnEntities shouldNot contain (bDateRange)
-//    autumnEntities shouldNot contain (iDateRange)
-//    autumnNorms shouldNot contain (fallDateRange)
-//    autumnNorms shouldNot contain (seasonDateRange)
-//
-//    val (seasonEntities, seasonNorms) = mkEntitiesAndNorms(processor, seasonText)
-//    seasonEntities should contain (bDateRange)
-//    seasonEntities should contain (iDateRange)
-//    seasonNorms shouldNot contain (fallDateRange)
-//    seasonNorms should contain (seasonDateRange)
-//  }
+
+  it should "find second week of May" in {
+    val processor = new CluProcessor()
+
+    val (secondWeekEntities, secondWeekNorms) = mkEntitiesAndNorms(processor, secondWeek)
+    secondWeekEntities should contain (bDateRange)
+    secondWeekEntities should contain (iDateRange)
+    secondWeekNorms should contain (secondWeekMayRange)
+    secondWeekNorms shouldNot contain (firstTwoWeeksAprilRange)
+  }
+
+  it should "find last week of June" in {
+    val processor = new CluProcessor()
+
+    val (lastWeekEntities, lastWeekNorms) = mkEntitiesAndNorms(processor, lastWeek)
+    lastWeekEntities should contain(bDateRange)
+    lastWeekEntities should contain(iDateRange)
+    lastWeekNorms should contain(lastWeekJuneRange)
+    lastWeekNorms shouldNot contain(secondWeekMayRange)
+  }
+
+  it should "find last two weeks of February" in {
+    val processor = new CluProcessor()
+
+    val (lastTwoWeeksEntities, lastTwoWeeksNorms) = mkEntitiesAndNorms(processor, lastTwoWeeks)
+    lastTwoWeeksEntities should contain (bDateRange)
+    lastTwoWeeksEntities should contain (iDateRange)
+    lastTwoWeeksNorms should contain (lastTwoWeeksFebRange)
+    lastTwoWeeksNorms shouldNot contain (firstTwoWeeksAprilRange)
+  }
+
 }

--- a/main/src/test/scala/org/clulab/numeric/TestWeekNormalizer.scala
+++ b/main/src/test/scala/org/clulab/numeric/TestWeekNormalizer.scala
@@ -1,0 +1,60 @@
+package org.clulab.numeric
+
+import org.clulab.processors.clu.CluProcessor
+import org.clulab.utils.Test
+
+class TestWeekNormalizer extends Test {
+  val firstWeek = "We planted corn the first week of April."
+//  val lastWeek = "We planted beans the last week of May."
+
+  val bDateRange = "B-DATE-RANGE"
+  val iDateRange = "I-DATE-RANGE"
+
+  val firstWeekAprilRange = "XXXX-04-01 -- XXXX-04-07"
+//  val lastWeekMayRange = "XXXX-05-25 -- XXXX-05-31"
+
+  def mkEntitiesAndNorms(processor: CluProcessor, text: String): (Array[String], Array[String]) = {
+    val document = processor.annotate(text)
+    val mentions = processor.numericEntityRecognizer.extractFrom(document)
+
+    setLabelsAndNorms(document, mentions)
+    (document.sentences.head.entities.get, document.sentences.head.norms.get)
+  }
+
+  behavior of "WeekCluProcessor"
+
+  it should "find first week of April" in {
+    val processor = new CluProcessor()
+
+    val (firstWeekEntities, firstWeekNorms) = mkEntitiesAndNorms(processor, firstWeek)
+    firstWeekEntities should contain (bDateRange)
+    firstWeekEntities should contain (iDateRange)
+    firstWeekNorms should contain (firstWeekAprilRange)
+//    firstWeekNorms shouldNot contain (lastWeekMayRange)
+
+//    val (lastWeekEntities, lastWeekNorms) = mkEntitiesAndNorms(processor, lastWeek)
+//    lastWeekEntities should contain (bDateRange)
+//    lastWeekEntities should contain (iDateRange)
+//    lastWeekNorms should contain (lastWeekMayRange)
+//    lastWeekNorms shouldNot contain (firstWeekAprilRange)
+  }
+//
+//  behavior of "Custom SeasonalCluProcessor"
+//
+//  it should "find rainy season but not autumn" in {
+//    // The file name should remain SEASONS, but it can be put in a different location.
+//    val processor = new CluProcessor(seasonPathOpt = Some("/org/clulab/numeric/custom/SEASON.tsv"))
+//
+//    val (autumnEntities, autumnNorms) = mkEntitiesAndNorms(processor, autumnText)
+//    autumnEntities shouldNot contain (bDateRange)
+//    autumnEntities shouldNot contain (iDateRange)
+//    autumnNorms shouldNot contain (fallDateRange)
+//    autumnNorms shouldNot contain (seasonDateRange)
+//
+//    val (seasonEntities, seasonNorms) = mkEntitiesAndNorms(processor, seasonText)
+//    seasonEntities should contain (bDateRange)
+//    seasonEntities should contain (iDateRange)
+//    seasonNorms shouldNot contain (fallDateRange)
+//    seasonNorms should contain (seasonDateRange)
+//  }
+}


### PR DESCRIPTION
Added "fall" as a season & normalized "week of month" patterns

1. added fall as a season and added post-processing method for season homonyms (fall/spring)
2. normalized "week of month" patterns into date ranges (e.g., first week of May, last two weeks of June, etc.)