### PR TITLE
Allow subclasses to override tokenizer

### DIFF
--- a/main/src/main/scala/org/clulab/processors/clu/BalaurProcessor.scala
+++ b/main/src/main/scala/org/clulab/processors/clu/BalaurProcessor.scala
@@ -50,13 +50,15 @@ class BalaurProcessor protected (
   override def getConf: Config = config
 
   override def mkDocument(text: String, keepText: Boolean): Document = { 
-    DocumentMaker.mkDocument(wordTokenizer, text, keepText)
+    DocumentMaker.mkDocument(tokenizer, text, keepText)
   }
+
+  def tokenizer: Tokenizer = wordTokenizer
 
   override def mkDocumentFromSentences(sentences: Iterable[String], 
     keepText: Boolean, 
     charactersBetweenSentences: Int): Document = {     
-    DocumentMaker.mkDocumentFromSentences(wordTokenizer, sentences, keepText, charactersBetweenSentences)
+    DocumentMaker.mkDocumentFromSentences(tokenizer, sentences, keepText, charactersBetweenSentences)
   }
 
   override def mkDocumentFromTokens(sentences: Iterable[Iterable[String]], 


### PR DESCRIPTION
The subclass doesn't know what tokenizer the Balaur processor is going to use, so it constructs itself and the superclass, borrows the tokenizer from the superclass, manipulates it, and then overrides the superclass implementation with the modified version.