### PR TITLE
Use aliases to convert CluProcessor to BalaurProcessor

### DIFF
--- a/main/src/main/scala/org/clulab/processors/clu/package.scala
+++ b/main/src/main/scala/org/clulab/processors/clu/package.scala
@@ -1,0 +1,6 @@
+package org.clulab.processors
+
+package object clu {
+  type CluProcessor = BalaurProcessor // This takes care of the class.
+  val CluProcessor = BalaurProcessor  // This takes care of the companion object.
+}

--- a/main/src/test/scala-2.11_2.12/org/clulab/utils/TestHash.scala
+++ b/main/src/test/scala-2.11_2.12/org/clulab/utils/TestHash.scala
@@ -2,7 +2,7 @@ package org.clulab.utils
 
 import org.clulab.odin.serialization.json._
 import org.clulab.odin.{CrossSentenceMention, EventMention, RelationMention, TextBoundMention, _}
-import org.clulab.processors.clu.BalaurProcessor
+import org.clulab.processors.clu.CluProcessor
 import org.clulab.sequences.LexiconNER
 import org.clulab.struct.{DirectedGraph, Edge}
 
@@ -16,7 +16,8 @@ class TestHash extends Test {
 
     LexiconNER(kbs, caseInsensitiveMatchings, None)
   }
-  val processor = new BalaurProcessor(optionalNER = Some(customLexiconNer))
+  val processor = new CluProcessor(optionalNER = Some(customLexiconNer))
+  val outside = CluProcessor.OUTSIDE
   val extractorEngine = {
     val rules = FileUtils.getTextFromResource("/org/clulab/odinstarter/main.yml")
 

--- a/main/src/test/scala-2.13/org/clulab/utils/TestHash.scala
+++ b/main/src/test/scala-2.13/org/clulab/utils/TestHash.scala
@@ -2,7 +2,7 @@ package org.clulab.utils
 
 import org.clulab.odin.serialization.json._
 import org.clulab.odin.{CrossSentenceMention, EventMention, RelationMention, TextBoundMention, _}
-import org.clulab.processors.clu.BalaurProcessor
+import org.clulab.processors.clu.CluProcessor
 import org.clulab.sequences.LexiconNER
 import org.clulab.struct.{DirectedGraph, Edge}
 
@@ -16,7 +16,8 @@ class TestHash extends Test {
 
     LexiconNER(kbs, caseInsensitiveMatchings, None)
   }
-  val processor = new BalaurProcessor(optionalNER = Some(customLexiconNer))
+  val processor = new CluProcessor(optionalNER = Some(customLexiconNer))
+  val outside = CluProcessor.OUTSIDE
   val extractorEngine = {
     val rules = FileUtils.getTextFromResource("/org/clulab/odinstarter/main.yml")
 

--- a/main/src/test/scala-3/org/clulab/utils/TestHash.scala
+++ b/main/src/test/scala-3/org/clulab/utils/TestHash.scala
@@ -2,7 +2,7 @@ package org.clulab.utils
 
 import org.clulab.odin.serialization.json._
 import org.clulab.odin.{CrossSentenceMention, EventMention, RelationMention, TextBoundMention, _}
-import org.clulab.processors.clu.BalaurProcessor
+import org.clulab.processors.clu.CluProcessor
 import org.clulab.sequences.LexiconNER
 import org.clulab.struct.{DirectedGraph, Edge}
 
@@ -16,7 +16,8 @@ class TestHash extends Test {
 
     LexiconNER(kbs, caseInsensitiveMatchings, None)
   }
-  val processor = new BalaurProcessor(optionalNER = Some(customLexiconNer))
+  val processor = new CluProcessor(optionalNER = Some(customLexiconNer))
+  val outside = CluProcessor.OUTSIDE
   val extractorEngine = {
     val rules = FileUtils.getTextFromResource("/org/clulab/odinstarter/main.yml")
 


### PR DESCRIPTION
Show examples in TestHash.  HomeController still had a CluProcessor and it still works unchanged.  Only the package file needs to be used, so this is just a draft.